### PR TITLE
:bug: add namespace to router chart

### DIFF
--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -26,6 +26,8 @@ spec:
           - "{{ .Values.routerSpec.containerPort }}"
           - "--service-discovery"
           - "k8s"
+          - "--k8s-namespace"
+          - "{{ .Release.Namespace }}"
           - "--k8s-label-selector"
           - {{ include "labels.toCommaSeparatedList" .Values.servingEngineSpec.labels }}
           - "--routing-logic"


### PR DESCRIPTION
Fixes #6 

This adds the missing `--k8s-namespace` arg to the router chart, which is required for the router to watch the namespace it was installed in. If unset, the router will try to watch the `default` namespace only.