### PR TITLE
feat: Add Github workflows to lint and release Helm chart

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,26 @@
+name: Lint vLLM Stack Helm Charts
+
+on:
+  pull_request:
+    paths:
+      - "helm/**"
+  push:
+    paths:
+      - "helm/**"
+
+jobs:
+  lint-chart:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint open-webui Helm Chart
+        run: |
+          helm lint ./helm
+

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,57 @@
+name: Release vLLM Production Stack Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "helm/**"
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # Could add Prometheus as a dependent chart here if desired    
+      # - name: Add Dependency Repos
+      #   run: |
+      #     helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          skip_existing: false
+          packages_with_index: true
+          charts_dir: "."
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Login to GitHub Container Registry
+        run: |
+          echo "${GHCR_REGISTRY_PASSWORD}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+        env:
+          GHCR_REGISTRY_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push Charts to ghcr.io
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              echo "No charts to release"
+              break
+            fi
+            REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+            helm push "${pkg}" oci://ghcr.io/$REPO
+          done
+


### PR DESCRIPTION
This PR adds Github Actions workflows that can run `helm lint` on the Helm charts, and release Helm charts to Github using Github Pages as a publishing source. 

**Action Required - Set Up `gh-pages` Branch** 
Before the Helm release workflow will work correctly, there is setup required by a maintainer. The steps can be found in the [Helm docs](https://helm.sh/docs/topics/chart_repository/#github-pages-example), and should only take about 5 minutes. 

A successful test run of this workflow can be seen in my fork here: https://github.com/0xThresh/vllm-production-stack/actions/runs/12979140685/job/36194506180 

And you can see the charts that I successfully published on my repo here: https://0xthresh.github.io/vllm-production-stack/index.yaml

While I hope this is a helpful PR, I also understand if there are other plans for chart publishing. If that is the case, I hope the Lint workflow is still helpful, and can update my PR to only include that. Thank you! 