### PR TITLE
feat: OpenAI batch API part 1

### DIFF
--- a/examples/batch.jsonl
+++ b/examples/batch.jsonl
@@ -1,0 +1,2 @@
+{"custom_id": "request-2", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "facebook/opt-125m", "messages": [{"role": "system", "content": "You are an unhelpful assistant."},{"role": "user", "content": "Hello world!"}],"max_completion_tokens": 1000}}
+{"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "facebook/opt-125m", "messages": [{"role": "system", "content": "You are an unhelpful assistant."},{"role": "user", "content": "Hello world!"}],"max_completion_tokens": 1000}}

--- a/examples/batch.py
+++ b/examples/batch.py
@@ -1,0 +1,42 @@
+"""
+This script uploads JSONL files to the server, which can be used to run
+batch inference on the VLLM model.
+"""
+
+from pathlib import Path
+
+import rich
+from openai import OpenAI
+
+# get the current directory
+current_dir = Path(__file__).parent
+# generate this file using `./generate_file.sh`
+filepath = current_dir / "batch.jsonl"
+
+# Modify OpenAI's API key and API base to use vLLM's API server.
+openai_api_key = "EMPTY"
+openai_api_base = "http://localhost:8000/v1"
+
+client = OpenAI(
+    api_key=openai_api_key,
+    base_url=openai_api_base,
+)
+
+
+def from_in_memory() -> None:
+    file = client.files.create(
+        file=filepath.read_bytes(),
+        purpose="batch",
+    )
+    return file
+
+
+if __name__ == "__main__":
+    file = from_in_memory()
+
+    # get the file according to the file id
+    retrieved = client.files.retrieve(file.id)
+    rich.print(retrieved)
+
+    file_content = client.files.retrieve_content(file.id)
+    rich.print(file_content.encode("utf-8"))

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
         "kubernetes",
         "prometheus_client",
         "uhashring",
+        "aiofiles",
+        "python-multipart",
     ],
     entry_points={
         "console_scripts": [

--- a/src/vllm_router/files/__init__.py
+++ b/src/vllm_router/files/__init__.py
@@ -1,0 +1,10 @@
+from vllm_router.files.file_storage import FileStorage
+from vllm_router.files.files import OpenAIFile
+from vllm_router.files.storage import Storage, initialize_storage
+
+__all__ = [
+    "OpenAIFile",
+    "Storage",
+    "FileStorage",
+    "initialize_storage",
+]

--- a/src/vllm_router/files/file_storage.py
+++ b/src/vllm_router/files/file_storage.py
@@ -1,0 +1,123 @@
+import os
+import uuid
+from typing import List
+
+import aiofiles
+
+from vllm_router.files.files import OpenAIFile
+from vllm_router.files.storage import Storage
+from vllm_router.log import init_logger
+
+logger = init_logger(__name__)
+
+
+class FileStorage(Storage):
+    """
+    File storage implementation using the local filesystem.
+
+    Files are stored in the following directory structure:
+    /tmp/vllm_files/<user_id>/<file_id>
+
+    user_id is not
+    """
+
+    def __init__(self, base_path: str = "/tmp/vllm_files"):
+        self.base_path = base_path
+        logger.info(f"Using local file storage at {base_path}")
+        os.makedirs(base_path, exist_ok=True)
+
+    def _get_user_path(self, user_id: str) -> str:
+        """Get user-specific directory path"""
+        user_path = os.path.join(self.base_path, user_id)
+        os.makedirs(user_path, exist_ok=True)
+        return user_path
+
+    async def save_file(
+        self,
+        file_id: str = None,
+        user_id: str = Storage.DEFAULT_USER_ID,
+        file_name: str = None,
+        content: bytes = None,
+        purpose: str = Storage.DEFAULT_PURPOSE,
+    ) -> OpenAIFile:
+        """Save file content to disk"""
+        if content is None:
+            raise ValueError("Content cannot be None")
+        if file_id is None:
+            file_id = f"file-{uuid.uuid4().hex[:6]}"
+
+        # Save file to disk. File name is the same as file_id.
+        user_path = self._get_user_path(user_id)
+        file_path = os.path.join(user_path, file_id)
+        async with aiofiles.open(file_path, "wb") as f:
+            await f.write(content)
+
+        # Create OpenAIFile object.
+        file_size = len(content)
+        created_at = int(os.path.getctime(file_path))
+        return OpenAIFile(
+            id=file_id,
+            object="file",
+            bytes=file_size,
+            created_at=created_at,
+            filename=file_name or file_id,
+            purpose=purpose,
+        )
+
+    async def save_file_chunk(
+        self,
+        file_id: str,
+        user_id: str = Storage.DEFAULT_USER_ID,
+        chunk: bytes = None,
+        purpose: str = Storage.DEFAULT_PURPOSE,
+        offset: int = 0,
+    ) -> None:
+        """Save file chunk to disk at specified offset"""
+        user_path = self._get_user_path(user_id)
+        file_path = os.path.join(user_path, file_id)
+        async with aiofiles.open(file_path, "r+b") as f:
+            await f.seek(offset)
+            await f.write(chunk)
+
+    async def get_file(
+        self, file_id: str, user_id: str = Storage.DEFAULT_USER_ID
+    ) -> OpenAIFile:
+        """Retrieve file metadata from disk"""
+        user_path = self._get_user_path(user_id)
+        file_path = os.path.join(user_path, file_id)
+        if not os.path.exists(file_path):
+            logger.error(f"File {file_id} not found, returning empty file")
+            raise FileNotFoundError(f"File {file_id} not found")
+        file_size = os.path.getsize(file_path)
+        created_at = int(os.path.getctime(file_path))
+        return OpenAIFile(
+            id=file_id,
+            object="file",
+            bytes=file_size,
+            created_at=created_at,
+            filename=file_id,
+            purpose=Storage.DEFAULT_PURPOSE,
+        )
+
+    async def get_file_content(
+        self, file_id: str, user_id: str = Storage.DEFAULT_USER_ID
+    ) -> bytes:
+        """Retrieve file content from disk"""
+        user_path = self._get_user_path(user_id)
+        file_path = os.path.join(user_path, file_id)
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File {file_id} not found")
+        async with aiofiles.open(file_path, "rb") as f:
+            return await f.read()
+
+    async def list_files(self, user_id: str = Storage.DEFAULT_USER_ID) -> List[str]:
+        """List all files in storage"""
+        user_path = self._get_user_path(user_id)
+        return os.listdir(user_path)
+
+    async def delete_file(self, file_id: str, user_id: str = Storage.DEFAULT_USER_ID):
+        """Delete file from disk"""
+        user_path = self._get_user_path(user_id)
+        file_path = os.path.join(user_path, file_id)
+        if os.path.exists(file_path):
+            os.remove(file_path)

--- a/src/vllm_router/files/file_storage.py
+++ b/src/vllm_router/files/file_storage.py
@@ -18,7 +18,7 @@ class FileStorage(Storage):
     Files are stored in the following directory structure:
     /tmp/vllm_files/<user_id>/<file_id>
 
-    user_id is not
+    user_id is not used in the current implementation. It is reserved for future use.
     """
 
     def __init__(self, base_path: str = "/tmp/vllm_files"):

--- a/src/vllm_router/files/files.py
+++ b/src/vllm_router/files/files.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class OpenAIFile:
+    """
+    Represents a file object
+
+    https://platform.openai.com/docs/api-reference/files/object
+    """
+
+    id: str
+    object: Literal["file"]
+    bytes: int
+    created_at: int
+    filename: str
+    purpose: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OpenAIFile":
+        return cls(
+            id=data["id"],
+            object=data["object"],
+            bytes=data["bytes"],
+            created_at=data["created_at"],
+            filename=data["filename"],
+            purpose=data["purpose"],
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "object": self.object,
+            "bytes": self.bytes,
+            "created_at": self.created_at,
+            "filename": self.filename,
+            "purpose": self.purpose,
+        }
+
+    def metadata(self) -> dict:
+        return {
+            "id": self.id,
+            "bytes": self.bytes,
+            "created_at": self.created_at,
+            "filename": self.filename,
+            "purpose": self.purpose,
+        }

--- a/src/vllm_router/files/storage.py
+++ b/src/vllm_router/files/storage.py
@@ -24,6 +24,22 @@ class Storage(ABC):
         content: bytes = None,
         purpose: str = DEFAULT_PURPOSE,
     ) -> OpenAIFile:
+        """
+        Save a file with the given parameters and returns an OpenAIFile object.
+
+        Args:
+            file_id (str, optional): Unique identifier for the file. Defaults to None.
+            user_id (str, optional): ID of the user uploading the file. Defaults to DEFAULT_USER_ID.
+            file_name (str, optional): Name of the file. Defaults to None.
+            content (bytes, optional): Binary content of the file. Defaults to None.
+            purpose (str, optional): Purpose of the file upload. Defaults to DEFAULT_PURPOSE.
+
+        Returns:
+            OpenAIFile: Object containing the saved file information.
+
+        Notes:
+            This is an abstract method that must be implemented by subclasses.
+        """
         pass
 
     @abstractmethod
@@ -35,29 +51,104 @@ class Storage(ABC):
         purpose: str = DEFAULT_PURPOSE,
         offset: int = 0,
     ) -> None:
+        """
+        Save a chunk of a file in a streaming upload process.
+
+        This abstract method is designed for handling streamed file uploads, allowing
+        chunks of data to be saved incrementally.
+
+        Args:
+            file_id (str): The unique identifier for the file being uploaded.
+            user_id (str, optional): The ID of the user uploading the file. 
+                Defaults to DEFAULT_USER_ID.
+            chunk (bytes, optional): The binary data chunk to be saved. 
+                Defaults to None.
+            purpose (str, optional): The intended use of the file. 
+                Defaults to DEFAULT_PURPOSE.
+            offset (int, optional): The position in the file where this chunk should be written.
+                Defaults to 0.
+
+        Returns:
+            None
+
+        Notes:
+            This method is specifically designed for streaming uploads where a file is sent
+            in multiple chunks rather than as a single upload. Each chunk is saved at the
+            specified offset position.
+        """
         pass
 
+    @abstractmethod
     async def get_file(
         self, file_id: str, user_id: str = DEFAULT_USER_ID
     ) -> OpenAIFile:
+        """
+        Retrieve file metadata from the storage.
+
+        Args:
+            file_id (str): The unique identifier for the file.
+            user_id (str, optional): The ID of the user who owns the file. 
+                Defaults to DEFAULT_USER_ID.
+        
+        Returns:
+            OpenAIFile: An OpenAIFile object containing the file metadata.
+        """
         pass
 
     @abstractmethod
     async def get_file_content(
         self, file_id: str, user_id: str = DEFAULT_USER_ID
     ) -> bytes:
+        """
+        Retrieve the content of a file from the storage.
+
+        Args:
+            file_id (str): The unique identifier for the file.
+            user_id (str, optional): The ID of the user who owns the file. 
+                Defaults to DEFAULT_USER_ID.
+        
+        Returns:
+            bytes: The binary content of the file.
+        """
         pass
 
     @abstractmethod
     async def list_files(self, user_id: str = DEFAULT_USER_ID) -> List[str]:
+        """
+        List all files stored for a given user.
+
+        Args:
+            user_id (str, optional): The ID of the user whose files should be listed. 
+                Defaults to DEFAULT_USER_ID.
+        
+        Returns:
+            List[str]: A list of file IDs for the user.
+        """
         pass
 
     @abstractmethod
     async def delete_file(self, file_id: str, user_id: str = DEFAULT_USER_ID):
+        """
+        Delete a file from the storage.
+
+        Args:
+            file_id (str): The unique identifier for the file to be deleted.
+            user_id (str, optional): The ID of the user who owns the file. 
+                Defaults to DEFAULT_USER_ID.
+        """
         pass
 
 
 def initialize_storage(storage_type: str, base_path: str = None) -> Storage:
+    """
+    Initialize a file storage object based on the specified storage type.
+
+    It is the factory method for creating the appropriate storage object based on the
+    configuration provided.
+
+    TODO(gaocegege): Make storage_type an enum, and the storage related variables
+    like base_path should be in a config object.
+    """
     if storage_type == "local_file":
         from vllm_router.files.file_storage import FileStorage
 

--- a/src/vllm_router/files/storage.py
+++ b/src/vllm_router/files/storage.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from vllm_router.files.files import OpenAIFile
+
+
+class Storage(ABC):
+    DEFAULT_USER_ID = "uid_default"
+    DEFAULT_PURPOSE = "batch"
+
+    @abstractmethod
+    async def save_file(
+        self,
+        file_id: str = None,
+        user_id: str = DEFAULT_USER_ID,
+        file_name: str = None,
+        content: bytes = None,
+        purpose: str = DEFAULT_PURPOSE,
+    ) -> OpenAIFile:
+        pass
+
+    @abstractmethod
+    async def save_file_chunk(
+        self,
+        file_id: str,
+        user_id: str = DEFAULT_USER_ID,
+        chunk: bytes = None,
+        purpose: str = DEFAULT_PURPOSE,
+        offset: int = 0,
+    ) -> None:
+        pass
+
+    async def get_file(
+        self, file_id: str, user_id: str = DEFAULT_USER_ID
+    ) -> OpenAIFile:
+        pass
+
+    @abstractmethod
+    async def get_file_content(
+        self, file_id: str, user_id: str = DEFAULT_USER_ID
+    ) -> bytes:
+        pass
+
+    @abstractmethod
+    async def list_files(self, user_id: str = DEFAULT_USER_ID) -> List[str]:
+        pass
+
+    @abstractmethod
+    async def delete_file(self, file_id: str, user_id: str = DEFAULT_USER_ID):
+        pass
+
+
+def initialize_storage(storage_type: str, base_path: str = None) -> Storage:
+    if storage_type == "local_file":
+        from vllm_router.files.file_storage import FileStorage
+
+        return FileStorage(base_path)
+    else:
+        raise ValueError(f"Unsupported storage type: {storage_type}")

--- a/src/vllm_router/files/storage.py
+++ b/src/vllm_router/files/storage.py
@@ -59,11 +59,11 @@ class Storage(ABC):
 
         Args:
             file_id (str): The unique identifier for the file being uploaded.
-            user_id (str, optional): The ID of the user uploading the file. 
+            user_id (str, optional): The ID of the user uploading the file.
                 Defaults to DEFAULT_USER_ID.
-            chunk (bytes, optional): The binary data chunk to be saved. 
+            chunk (bytes, optional): The binary data chunk to be saved.
                 Defaults to None.
-            purpose (str, optional): The intended use of the file. 
+            purpose (str, optional): The intended use of the file.
                 Defaults to DEFAULT_PURPOSE.
             offset (int, optional): The position in the file where this chunk should be written.
                 Defaults to 0.
@@ -87,7 +87,7 @@ class Storage(ABC):
 
         Args:
             file_id (str): The unique identifier for the file.
-            user_id (str, optional): The ID of the user who owns the file. 
+            user_id (str, optional): The ID of the user who owns the file.
                 Defaults to DEFAULT_USER_ID.
 
         Returns:
@@ -104,7 +104,7 @@ class Storage(ABC):
 
         Args:
             file_id (str): The unique identifier for the file.
-            user_id (str, optional): The ID of the user who owns the file. 
+            user_id (str, optional): The ID of the user who owns the file.
                 Defaults to DEFAULT_USER_ID.
 
         Returns:
@@ -118,7 +118,7 @@ class Storage(ABC):
         List all files stored for a given user.
 
         Args:
-            user_id (str, optional): The ID of the user whose files should be listed. 
+            user_id (str, optional): The ID of the user whose files should be listed.
                 Defaults to DEFAULT_USER_ID.
 
         Returns:
@@ -133,7 +133,7 @@ class Storage(ABC):
 
         Args:
             file_id (str): The unique identifier for the file to be deleted.
-            user_id (str, optional): The ID of the user who owns the file. 
+            user_id (str, optional): The ID of the user who owns the file.
                 Defaults to DEFAULT_USER_ID.
         """
         pass

--- a/src/vllm_router/files/storage.py
+++ b/src/vllm_router/files/storage.py
@@ -89,7 +89,7 @@ class Storage(ABC):
             file_id (str): The unique identifier for the file.
             user_id (str, optional): The ID of the user who owns the file. 
                 Defaults to DEFAULT_USER_ID.
-        
+
         Returns:
             OpenAIFile: An OpenAIFile object containing the file metadata.
         """
@@ -106,7 +106,7 @@ class Storage(ABC):
             file_id (str): The unique identifier for the file.
             user_id (str, optional): The ID of the user who owns the file. 
                 Defaults to DEFAULT_USER_ID.
-        
+
         Returns:
             bytes: The binary content of the file.
         """
@@ -120,7 +120,7 @@ class Storage(ABC):
         Args:
             user_id (str, optional): The ID of the user whose files should be listed. 
                 Defaults to DEFAULT_USER_ID.
-        
+
         Returns:
             List[str]: A list of file IDs for the user.
         """

--- a/src/vllm_router/files/storage.py
+++ b/src/vllm_router/files/storage.py
@@ -5,6 +5,13 @@ from vllm_router.files.files import OpenAIFile
 
 
 class Storage(ABC):
+    """
+    Abstract class for file storage.
+
+    The storage should be able to save, retrieve, and delete files.
+    It is used to support file uploads and downloads for batch inference.
+    """
+
     DEFAULT_USER_ID = "uid_default"
     DEFAULT_PURPOSE = "batch"
 

--- a/src/vllm_router/router.py
+++ b/src/vllm_router/router.py
@@ -139,7 +139,7 @@ async def route_general_request(request: Request, endpoint: str):
     )
 
 
-@app.post("/v1/files")
+@app.post("/files")
 async def route_files(request: Request):
     """Handle file upload requests that include a purpose and file data."""
     form = await request.form()
@@ -169,7 +169,7 @@ async def route_files(request: Request):
         )
 
 
-@app.get("/v1/files/{file_id}")
+@app.get("/files/{file_id}")
 async def route_get_file(file_id: str):
     try:
         file = await FILE_STORAGE.get_file(file_id)
@@ -180,7 +180,7 @@ async def route_get_file(file_id: str):
         )
 
 
-@app.get("/v1/files/{file_id}/content")
+@app.get("/files/{file_id}/content")
 async def route_get_file_content(file_id: str):
     try:
         # TODO(gaocegege): Stream the file content with chunks to support

--- a/src/vllm_router/router.py
+++ b/src/vllm_router/router.py
@@ -4,12 +4,12 @@ import threading
 import time
 from contextlib import asynccontextmanager
 
-import httpx
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request, UploadFile
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from vllm_router.engine_stats import GetEngineStatsScraper, InitializeEngineStatsScraper
+from vllm_router.files import initialize_storage
 from vllm_router.httpx_client import HTTPXClientWrapper
 from vllm_router.protocols import ModelCard, ModelList
 from vllm_router.request_stats import (
@@ -137,6 +137,60 @@ async def route_general_request(request: Request, endpoint: str):
         status_code=status_code,
         headers={key: value for key, value in headers.items()},
     )
+
+
+@app.post("/v1/files")
+async def route_files(request: Request):
+    """Handle file upload requests that include a purpose and file data."""
+    form = await request.form()
+
+    # Validate required fields
+    if "purpose" not in form:
+        # Unlike openai, we do not support fine-tuning, so we do not need to
+        # check for 'purpose`.`
+        purpose = "unknown"
+    if "file" not in form:
+        return JSONResponse(
+            status_code=400, content={"error": "Missing required parameter 'file'"}
+        )
+
+    purpose = form["purpose"]
+    file_obj: UploadFile = form["file"]
+    file_content = await file_obj.read()
+
+    try:
+        file_info = await FILE_STORAGE.save_file(
+            file_name=file_obj.filename, content=file_content, purpose=purpose
+        )
+        return JSONResponse(content=file_info.metadata())
+    except Exception as e:
+        return JSONResponse(
+            status_code=500, content={"error": f"Failed to save file: {str(e)}"}
+        )
+
+
+@app.get("/v1/files/{file_id}")
+async def route_get_file(file_id: str):
+    try:
+        file = await FILE_STORAGE.get_file(file_id)
+        return JSONResponse(content=file.metadata())
+    except FileNotFoundError:
+        return JSONResponse(
+            status_code=404, content={"error": f"File {file_id} not found"}
+        )
+
+
+@app.get("/v1/files/{file_id}/content")
+async def route_get_file_content(file_id: str):
+    try:
+        # TODO(gaocegege): Stream the file content with chunks to support
+        # openai uploads interface.
+        file_content = await FILE_STORAGE.get_file_content(file_id)
+        return Response(content=file_content)
+    except FileNotFoundError:
+        return JSONResponse(
+            status_code=404, content={"error": f"File {file_id} not found"}
+        )
 
 
 @app.post("/chat/completions")
@@ -287,6 +341,22 @@ def parse_args():
         help="The key (in the header) to identify a session.",
     )
 
+    # Batch API
+    # TODO(gaocegege): Make these batch api related arguments to a separate config.
+    parser.add_argument(
+        "--file-storage-class",
+        type=str,
+        default="local_file",
+        choices=["local_file"],
+        help="The file storage class to use.",
+    )
+    parser.add_argument(
+        "--file-storage-path",
+        type=str,
+        default="/tmp/vllm_files",
+        help="The path to store files.",
+    )
+
     # Monitoring
     parser.add_argument(
         "--engine-stats-interval",
@@ -311,7 +381,6 @@ def parse_args():
         type=int,
         default=10,
         help="The interval in seconds to log statistics.",
-        hidden=True,
     )
     args = parser.parse_args()
     validate_args(args)
@@ -354,6 +423,12 @@ def InitializeAll(args):
     InitializeEngineStatsScraper(args.engine_stats_interval)
     InitializeRequestStatsMonitor(args.request_stats_window)
 
+    # TODO(gaocegege): Try adopting a more general way to initialize the
+    # storage, and global router. Maybe singleton?
+    global FILE_STORAGE
+    FILE_STORAGE = initialize_storage(args.file_storage_class, args.file_storage_path)
+
+    # TODO(gaocegege): Wrap it to a factory function.
     global GLOBAL_ROUTER
     if args.routing_logic == "roundrobin":
         GLOBAL_ROUTER = InitializeRoutingLogic(RoutingLogic.ROUND_ROBIN)


### PR DESCRIPTION
This is the part 1 of #47 

file.Storage has been introduced to abstract file operations, to support both OpenAI files and the uploads API. The user-id in the interface is defaulted to uid-default, which is kept for future extensibility.

I believe OpenAI uses a database, such as PostgreSQL, to store file metadata. For now, we are using simple file operations to handle this.

I’ve raised this PR to discuss whether this approach aligns with our requirements. Then will implement the batch API in part 2.