### PR TITLE
feat: Add ingress configuration to routerSpec

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.routerSpec.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-ingress-router"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.routerLabels" . | nindent 4 }}
+  {{- with .Values.routerSpec.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.routerSpec.ingress.className }}
+  ingressClassName: {{ .Values.routerSpec.ingress.className }}
+  {{- end }}
+  {{- if .Values.routerSpec.ingress.tls }}
+  tls:
+    {{- range .Values.routerSpec.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.routerSpec.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: "{{ $.Release.Name }}-router-service"
+                port:
+                  number: {{ $.Values.routerSpec.servicePort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -171,6 +171,32 @@ routerSpec:
     environment: "router"
     release: "router"
 
+  ingress:
+    # -- Enable ingress controller resource
+    enabled: false
+
+    # -- IngressClass that will be used to implement the Ingress
+    className: ""
+
+    # -- Additional annotations for the Ingress resource
+    annotations: {}
+      # kubernetes.io/ingress.class: alb
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+
+    # The list of hostnames to be covered with this ingress record.
+    hosts:
+      - host: vllm-router.local
+        paths:
+          - path: /
+            pathType: Prefix
+
+    # --  The tls configuration for hostnames to be covered with this ingress record.
+    tls: []
+    #  - secretName: vllm-router-tls
+    #    hosts:
+    #      - vllm-router.local
+
   # -- TODO: Readiness probe configuration
   #startupProbe:
   #  # -- Number of seconds after the container has started before startup probe is initiated


### PR DESCRIPTION
Adds an ingress configuration to the routerSpec, enabling connections to the router service from outside the cluster. 

Closes https://github.com/vllm-project/production-stack/issues/28