### PR TITLE
fix: Update example to use new hf_token instead of old ENV value

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -68,9 +68,7 @@ servingEngineSpec:
   #     enabled: true
   #     cpuOffloadingBufferSize: "30"
   #
-  #   env:
-  #     - name: HF_TOKEN
-  #       value: <HUGGING_FACE_TOKEN>
+  #   hf_token: <HUGGING_FACE_TOKEN>
   #
   #   nodeSelectorTerms:
   #     - matchExpressions:


### PR DESCRIPTION
https://github.com/vllm-project/production-stack/pull/22 updated the schema to use `hf_token` instead of an environment variable config in `Values.yaml`, but the commented out example was not updated to reflect this. This PR corrects the example to use the new `hf_token` value.