### PR TITLE
[Add] fix for router files api and example to post query to the api

### DIFF
--- a/src/examples/example_file_upload.py
+++ b/src/examples/example_file_upload.py
@@ -1,0 +1,38 @@
+import argparse
+
+import httpx
+import requests
+
+
+def upload_file(server_url: str, file_path: str):
+    """Uploads a file to the production stack."""
+    try:
+        with open(file_path, "rb") as file:
+            files = {"file": (file_path, file, "application/octet-stream")}
+            data = {"purpose": "unknown"}
+
+            with httpx.Client() as client:
+                response = client.post(server_url, files=files, data=data)
+
+                if response.status_code == 200:
+                    print("File uploaded successfully:", response.json())
+                else:
+                    print("Failed to upload file:", response.text)
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def parse_args():
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(description="Uploads a file to the stack.")
+    parser.add_argument("--path", type=str, help="Path to the file to upload.")
+    parser.add_argument("--url", type=str, help="URL of the stack (router service).")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    endpoint = args.url
+    file_to_upload = args.path
+    upload_file(endpoint, file_to_upload)

--- a/src/vllm_router/router.py
+++ b/src/vllm_router/router.py
@@ -149,12 +149,13 @@ async def route_files(request: Request):
         # Unlike openai, we do not support fine-tuning, so we do not need to
         # check for 'purpose`.`
         purpose = "unknown"
+    else:
+        purpose = form["purpose"]
     if "file" not in form:
         return JSONResponse(
             status_code=400, content={"error": "Missing required parameter 'file'"}
         )
 
-    purpose = form["purpose"]
     file_obj: UploadFile = form["file"]
     file_content = await file_obj.read()
 


### PR DESCRIPTION
This PR fixes a problem that the router will break when the "purpose" does not exist in the query to `/files` endpoint.

It also contains a minimal example to query the `/files` endpoint.