### PR TITLE
fix: set Deployment strategy as Recreate instead of RollingUpdates

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -120,6 +120,9 @@ spec:
         {{-   toYaml . | nindent 8 }}
       {{-   end }}
       {{- end }}
+      
+      strategy:
+        type: Recreate
 
       {{- if .Values.servingEngineSpec.runtimeClassName }}
       runtimeClassName: {{ .Values.servingEngineSpec.runtimeClassName }}


### PR DESCRIPTION
RollingUpdates can't be used if replica count is set to 1. It would wait indefinitely to re-deploy the pods. Need to use Recreate or make it configurable in the chart. 
