### PR TITLE
Fix the problem of 1k prompts.

### DIFF
--- a/src/vllm_router/httpx_client.py
+++ b/src/vllm_router/httpx_client.py
@@ -14,7 +14,10 @@ class HTTPXClientWrapper:
 
     def start(self):
         """Instantiate the client. Call from the FastAPI startup hook."""
-        self.async_client = httpx.AsyncClient()
+        # To fully leverage the router's concurrency capabilities,
+        # we set the maximum number of connections to be unlimited.
+        limits = httpx.Limits(max_connections=None)
+        self.async_client = httpx.AsyncClient(limits=limits)
         logger.info(f"httpx AsyncClient instantiated. Id {id(self.async_client)}")
 
     async def stop(self):

--- a/src/vllm_router/router.py
+++ b/src/vllm_router/router.py
@@ -57,13 +57,10 @@ async def process_request(
     GetRequestStatsMonitor().on_new_request(backend_url, request_id, start_time)
 
     client = httpx_client_wrapper()
-    header_dict = dict(header)
-    # Overwrite the host if the backend server is behind a reverse proxy that routes requests based on the host.
-    header_dict["host"] = urlparse(backend_url).netloc
     async with client.stream(
         method=method,
         url=backend_url + endpoint,
-        headers=header_dict,
+        headers=dict(header),
         content=body,
         timeout=None,
     ) as backend_response:

--- a/src/vllm_router/utils.py
+++ b/src/vllm_router/utils.py
@@ -1,4 +1,5 @@
 import re
+import resource
 
 
 def validate_url(url: str) -> bool:
@@ -20,3 +21,22 @@ def validate_url(url: str) -> bool:
         r"(/.*)?$"  # Optional path
     )
     return bool(regex.match(url))
+
+
+# Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L630 # noqa: E501
+def set_ulimit(target_soft_limit=65535):
+    resource_type = resource.RLIMIT_NOFILE
+    current_soft, current_hard = resource.getrlimit(resource_type)
+
+    if current_soft < target_soft_limit:
+        try:
+            resource.setrlimit(resource_type, (target_soft_limit, current_hard))
+        except ValueError as e:
+            logger.warning(
+                "Found ulimit of %s and failed to automatically increase"
+                "with error %s. This can cause fd limit errors like"
+                "`OSError: [Errno 24] Too many open files`. Consider "
+                "increasing with ulimit -n",
+                current_soft,
+                e,
+            )


### PR DESCRIPTION
httpx client has a default max_connections(100) which will block the requests if the concurrency is over 100.

This commit enhances the router's concurrency capabilities. Key changes:
1. Set `httpx.AsyncClient` max connections to unlimited to unblock the requests.
2. In `process_request`, overwrite host header for proxies routing by host.
3. Call `set_ulimit` in `main` to prevent uvicorn from dropping requests due to high FD count.