### PR TITLE
[Doc] fixed chart-name related misalignments in tutorial docs

### DIFF
--- a/tutorials/02-basic-vllm-config.md
+++ b/tutorials/02-basic-vllm-config.md
@@ -84,8 +84,8 @@ Expected output:
 You should see output indicating the successful deployment of the Helm chart:
 
 ```plaintext
-Release "llmstack" has been deployed. Happy Helming!
-NAME: llmstack
+Release "vllm" has been deployed. Happy Helming!
+NAME: vllm
 LAST DEPLOYED: <timestamp>
 NAMESPACE: default
 STATUS: deployed
@@ -106,12 +106,12 @@ REVISION: 1
 
    ```plaintext
    NAME                                             READY   STATUS    RESTARTS   AGE
-   pod/llmstack-deployment-router-xxxx-xxxx         1/1     Running   0          3m23s
-   llmstack-llama3-deployment-vllm-xxxx-xxxx        1/1     Running   0          3m23s
+   pod/vllm-deployment-router-xxxx-xxxx         1/1     Running   0          3m23s
+   vllm-llama3-deployment-vllm-xxxx-xxxx        1/1     Running   0          3m23s
    ```
 
-   - The `llmstack-deployment-router` pod acts as the router, managing requests and routing them to the appropriate model-serving pod.
-   - The `llmstack-llama3-deployment-vllm` pod serves the actual model for inference.
+   - The `vllm-deployment-router` pod acts as the router, managing requests and routing them to the appropriate model-serving pod.
+   - The `vllm-llama3-deployment-vllm` pod serves the actual model for inference.
 
 2. Verify the service is exposed correctly:
 
@@ -125,12 +125,12 @@ REVISION: 1
 
    ```plaintext
    NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
-   llmstack-engine-service   ClusterIP   10.103.98.170    <none>        80/TCP    4m
-   llmstack-router-service   ClusterIP   10.103.110.107   <none>        80/TCP    4m
+   vllm-engine-service   ClusterIP   10.103.98.170    <none>        80/TCP    4m
+   vllm-router-service   ClusterIP   10.103.110.107   <none>        80/TCP    4m
    ```
 
-   - The `llmstack-engine-service` exposes the serving engine.
-   - The `llmstack-router-service` handles routing and load balancing across model-serving pods.
+   - The `vllm-engine-service` exposes the serving engine.
+   - The `vllm-router-service` handles routing and load balancing across model-serving pods.
 
 3. Test the health endpoint:
 

--- a/tutorials/03-load-model-from-pv.md
+++ b/tutorials/03-load-model-from-pv.md
@@ -97,7 +97,7 @@ In this tutorial, you will learn how to load a model from a Persistent Volume (P
 2. Deploy the Helm chart:
 
    ```bash
-   helm install vllm vllm/production-stack -f tutorials/assets/values-03-match-pv.yaml
+   helm install vllm vllm/vllm-stack -f tutorials/assets/values-03-match-pv.yaml
    ```
 
 3. Verify the deployment:
@@ -110,8 +110,8 @@ In this tutorial, you will learn how to load a model from a Persistent Volume (P
 
    ```plaintext
    NAME                                             READY   STATUS    RESTARTS   AGE
-   llmstack-deployment-router-xxxx-xxxx             1/1     Running   0          1m
-   llmstack-llama3-deployment-vllm-xxxx-xxxx        1/1     Running   0          1m
+   vllm-deployment-router-xxxx-xxxx             1/1     Running   0          1m
+   vllm-llama3-deployment-vllm-xxxx-xxxx        1/1     Running   0          1m
    ```
 
 ## Step 3: Verifying the Deployment
@@ -142,9 +142,9 @@ In this tutorial, you will learn how to load a model from a Persistent Volume (P
 2. Uninstall and reinstall the deployment to observe faster startup:
 
    ```bash
-   sudo helm uninstall llmstack
+   sudo helm uninstall vllm
    sudo kubectl delete -f tutorials/assets/pv-03.yaml && sudo kubectl apply -f tutorials/assets/pv-03.yaml
-   helm install vllm vllm/production-stack -f tutorials/assets/values-03-match-pv.yaml
+   helm install vllm vllm/vllm-stack -f tutorials/assets/values-03-match-pv.yaml
    ```
 
 ### Explanation

--- a/tutorials/04-launch-multiple-model.md
+++ b/tutorials/04-launch-multiple-model.md
@@ -62,7 +62,7 @@ servingEngineSpec:
 Deploy the Helm chart using the customized values file:
 
 ```bash
-helm install vllm vllm/production-stack -f tutorials/assets/values-04-multiple-models.yaml
+helm install vllm vllm/vllm-stack -f tutorials/assets/values-04-multiple-models.yaml
 ```
 
 ## Step 3: Verifying the Deployment
@@ -77,9 +77,9 @@ helm install vllm vllm/production-stack -f tutorials/assets/values-04-multiple-m
 
    ```plaintext
    NAME                                           READY   STATUS    RESTARTS   AGE
-   llmstack-deployment-router-xxxxx-xxxxx         1/1     Running   0          90s
-   llmstack-llama3-deployment-vllm-xxxxx-xxxxx    1/1     Running   0          90s
-   llmstack-mistral-deployment-vllm-xxxxx-xxxxx   1/1     Running   0          90s
+   vllm-deployment-router-xxxxx-xxxxx         1/1     Running   0          90s
+   vllm-llama3-deployment-vllm-xxxxx-xxxxx    1/1     Running   0          90s
+   vllm-mistral-deployment-vllm-xxxxx-xxxxx   1/1     Running   0          90s
    ```
 
    > **Note:** It may take some time for the models to be downloaded before the READY changes to "1/1".
@@ -87,7 +87,7 @@ helm install vllm vllm/production-stack -f tutorials/assets/values-04-multiple-m
 2. Forward the router service port to access it locally:
 
    ```bash
-   sudo kubectl port-forward svc/llmstack-router-service 30080:80
+   sudo kubectl port-forward svc/vllm-router-service 30080:80
    ```
 
    > **Explanation:** We are forwarding the port from the router service, which has a global view of all the vLLM engines running different models.

--- a/tutorials/05-offload-kv-cache.md
+++ b/tutorials/05-offload-kv-cache.md
@@ -69,7 +69,7 @@ helm install vllm vllm/vllm-stack -f tutorials/assets/values-05-cpu-offloading.y
    sudo kubectl get pods
    ```
 
-   Identify the pod name for the vLLM deployment (e.g., `llmstack-mistral-deployment-vllm-xxxx-xxxx`). Then run:
+   Identify the pod name for the vLLM deployment (e.g., `vllm-mistral-deployment-vllm-xxxx-xxxx`). Then run:
 
    ```bash
    sudo kubectl logs -f <pod-name>
@@ -85,7 +85,7 @@ helm install vllm vllm/vllm-stack -f tutorials/assets/values-05-cpu-offloading.y
 2. Forward the router service port to access the stack locally:
 
    ```bash
-   sudo kubectl port-forward svc/llmstack-router-service 30080:80
+   sudo kubectl port-forward svc/vllm-router-service 30080:80
    ```
 
 3. Send a request to the stack and observe the logs:


### PR DESCRIPTION
Aligned tutorial docs with chart:
- Changed instances of `production-stack` to `vllm-stack` (chart-name)
- Changed instances of `llmstack` to `vllm` (release-name)