### PR TITLE
chore: update e2e test to use python 3.12 to match setup.py requirements

### DIFF
--- a/.github/workflows/router-e2e-test.yml
+++ b/.github/workflows/router-e2e-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10.13"
+          python-version: "3.12"
           cache: pip
 
       - name: Login to Github Container Registry


### PR DESCRIPTION
The e2e test uses python 3.10. The setup.py script requires 3.12. There is an e2e test failure [here](https://github.com/vllm-project/production-stack/actions/runs/13865700515/job/38804225593?pr=235). This PR is to reconcile the differences.

@Shaoting-Feng @YuhanLiu11 @ApostaC 