### PR TITLE
[Feat] Add nodeSelectorTerms for router & cacher servers

### DIFF
--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -16,6 +16,15 @@ spec:
       labels:
       {{- include "chart.cacheserverLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.cacheserverSpec.nodeSelectorTerms}}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            {{- with .Values.cacheserverSpec.nodeSelectorTerms }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- end }}
       containers:
         - name: "lmcache-server"
           image: "{{ required "Required value 'cacheserverSpec.repository' must be defined !" .Values.cacheserverSpec.repository }}:{{ required "Required value 'cacheserverSpec.tag' must be defined !" .Values.cacheserverSpec.tag }}"
@@ -40,7 +49,6 @@ spec:
             - name: "caserver-cport"
               containerPort: {{ .Values.cacheserverSpec.containerPort }}
           imagePullPolicy: IfNotPresent
-
         # TODO(Jiayi): add health check for lmcache server
         # livenessProbe:
         #   initialDelaySeconds: 30

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -18,6 +18,15 @@ spec:
       {{- include "chart.routerLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-router-service-account
+      {{- if .Values.routerSpec.nodeSelectorTerms }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            {{- with .Values.routerSpec.nodeSelectorTerms }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- end }}
       containers:
       - name: router-container
         image: "{{ .Values.routerSpec.repository | default "lmcache/lmstack-router" }}:{{ .Values.routerSpec.tag | default "latest" }}"
@@ -90,7 +99,6 @@ spec:
         ports:
           - name: "router-cport"
             containerPort: {{ .Values.routerSpec.containerPort }}
-
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 5

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -302,6 +302,9 @@ routerSpec:
     #    hosts:
     #      - vllm-router.local
 
+  # The node selector terms to match the nodes
+  nodeSelectorTerms: []
+
   # -- TODO: Readiness probe configuration
   #startupProbe:
   #  # -- Number of seconds after the container has started before startup probe is initiated

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -303,6 +303,13 @@ routerSpec:
     #      - vllm-router.local
 
   # The node selector terms to match the nodes
+  # Example:
+  #   nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: nvidia.com/gpu.product
+  #         operator: "In"
+  #         values:
+  #         - "NVIDIA-RTX-A6000"
   nodeSelectorTerms: []
 
   # -- TODO: Readiness probe configuration


### PR DESCRIPTION
Add nodeSelectorTerms to router and cache servers to select on which nodes these deployments should be put on. Right now only the "model"/GPU deployment has this possibility.

---

- [X] Make sure the code changes pass the [pre-commit](../CONTRIBUTING.md) checks.
- [X] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [X] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

