### PR TITLE
[Bugfix] Update logger handler to handle stdout/stderr prorperly

### DIFF
--- a/src/vllm_router/log.py
+++ b/src/vllm_router/log.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from logging import Logger
 
 
@@ -31,13 +32,29 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+class MaxLevelFilter(logging.Filter):
+    def __init__(self, max_level: int):
+        super().__init__()
+        self.max_level = max_level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno <= self.max_level
+
+
 def init_logger(name: str, log_level=logging.DEBUG) -> Logger:
     logger = logging.getLogger(name)
+    logger.setLevel(log_level)
 
-    ch = logging.StreamHandler()
-    ch.setLevel(log_level)
-    ch.setFormatter(CustomFormatter())
-    logger.addHandler(ch)
-    logger.setLevel(logging.DEBUG)
+    stdout_stream = logging.StreamHandler(sys.stdout)
+    stdout_stream.setLevel(log_level)
+    stdout_stream.setFormatter(CustomFormatter())
+    stdout_stream.addFilter(MaxLevelFilter(logging.INFO))
+    logger.addHandler(stdout_stream)
+
+    error_stream = logging.StreamHandler()
+    error_stream.setLevel(logging.WARNING)
+    error_stream.setFormatter(CustomFormatter())
+    logger.addHandler(error_stream)
+    logger.propagate = False
 
     return logger


### PR DESCRIPTION
* [logging.StreamHandler](https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler) emits the log as stderr by default.
* It will be the issue at the production logging system where stderr as the system error.
* In our production, the logging detect system recognizes it as the error status since it emits stderr even if the log level is info.
* To fix it properly, there should be two logging.StreamHandler. One is for stdout the other is for the stderr.
* In this change.
    - logging.StreamHandler for stdout only emit until the log level is INFO.
    - If the log level is greater than WARN, then the logger will emit the log as stderr.
* And the other fix is propagate, if the propagate is set as True, in real logging system, it detects duplicated log from unicorn. So to prevent propagation to unicorn log, propagate should be set as False.