### PR TITLE
Add coverage tracking to E2E test workflow

### DIFF
--- a/.github/workflows/router-e2e-test.yml
+++ b/.github/workflows/router-e2e-test.yml
@@ -1,12 +1,21 @@
 name: Router E2E tests
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/vllm_router/**'
+      - 'docker/**'
+      - 'pyproject.toml'
+      - '.github/**'
   pull_request:
     types: [ready_for_review]
     paths:
       - 'src/vllm_router/**'
       - 'docker/**'
       - 'pyproject.toml'
+      - '.github/**'
   workflow_dispatch:
 
 jobs:
@@ -85,15 +94,24 @@ jobs:
           # Run with Python debug option
           python3 -v request_generator.py --qps 10 --num-workers 32 --duration 300 2>&1 | tee logs/request_generator.log
 
-      - name: Run E2E Tests
+      - name: Run E2E Tests with Coverage
         run: |
-          pytest src/tests/test_*.py
+          pip install coverage
+          coverage run --source=src/vllm_router -m pytest src/tests/test_*.py
+          coverage report -m > coverage.txt
 
       - name: Cleanup Test Environment
         if: always()
         working-directory: src/tests/perftest
         run: |
           bash clean-up.sh
+
+      - name: Upload Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.txt
 
       - name: Upload Test logs
         if: always()


### PR DESCRIPTION
- Use `coverage run` to track test coverage for src/vllm_router
- Upload coverage.txt
- Trigger workflow on push to main and changes in .github/**