### PR TITLE
[Feat] OpenTelemetry Support Example

### DIFF
--- a/tutorials/12-distributed-tracing.md
+++ b/tutorials/12-distributed-tracing.md
@@ -1,0 +1,149 @@
+# Tutorial: Basic tracing/metrics/logs Collection using OpenTelemetry
+
+## Introduction
+
+This tutorial guides you through the basic configurations required to collect
+traces, metrics, and logs from a vLLM serving engine in a Kubernetes environment
+with GPU support. You will learn how to use OpenTelemetry tooling along with
+the Jaeger distributed tracing observability platform to monitor running vLLM
+instances. You will learn how to specify the tracing configuration with
+necessary environment variables (like `OTEL_SERVICE_NAME`,
+`OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_RESOURCE_ATTRIBUTES`).
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Step 1: Preparing the Jaeger Configuration File](#step-1-preparing-the-jaeger-configuration-file)
+3. [Step 2: Preparing the OpenTelemetry Collector File](#step-2-preparing-the-opentelemetry-collector-file)
+4. [Step 3: Configuring Model and Monitoring](#step-3-configuring-model-and-monitoring)
+
+## Prerequisites
+
+- A Kubernetes environment with GPU support, as set up in the
+  [00-install-kubernetes-env tutorial](00-install-kubernetes-env.md).
+- Helm installed on your system.
+- Access to a HuggingFace token (`HF_TOKEN`).
+- A self-defined api key or an existing secret (`VLLM_API_KEY`).
+
+## Step 1: Preparing the Jaeger Configuration File
+
+1. Locate the example configuration files
+   `tutorials/assets/otel-example/{jaeger, jaeger-query, jaeger-collector}.yaml`.
+2. Open the files and examine the following fields:
+   - Specify your desired ports for `jaeger-collector` and `jaeger-query`
+   services for trace storage and retrieval, respectively.
+   - Verify that `COLLECTOR_OTLP_ENABLED` is set to `true`; this enables
+   Jaeger's native support for OpenTelemetry
+
+### Explanation of Key Items in Jaeger Files
+
+- **`ports`**: The ports through which Jaeger performs its operations
+(collection and querying in this case).
+- **`name`**: The unique identifier for your Jaeger deployment.
+- **`image`**: The single Docker image that runs all Jaeger's backend parts as
+well as its UI in a container.
+- **`type`**: The ClusterIP type ensures the query service is only reachable
+from within the cluster.
+
+## Step 2: Preparing the OpenTelemetry Collector File
+
+1. Locate the example collector files
+   `tutorials/assets/otel-example/{otel-collector, otel-collector-config}.yaml`.
+2. Open the file and examine the following fields:
+   - Specify the `receivers`, `processors`, and `exporters` of the collector
+   - The OpenTelemetry collection is an intermediary step of collecting traces
+   from the vLLM service and then providing these to Jaeger for its UI.
+   - The `resources` specify the compute resources available to the container
+   running the OpenTelemetry collector.
+
+## Step 3: Configuring Model and Monitoring
+
+1. Feel free to inspect the `values-12-otel-vllm.yaml` file. Note that the
+   `OTEL_EXPORTER_OTLP_ENDPOINT` specification enables metrics, traces, and
+   logs to be collected. Further configurations can be explored
+   [here](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/).
+
+   Run the following from the `tutorials/assets` directory:
+
+   ```bash
+   sudo kubectl apply -f otel-example/jaeger.yaml
+   sudo kubectl apply -f otel-example/jaeger-collector.yaml
+   sudo kubectl apply -f otel-example/jaeger-query.yaml
+   sudo kubectl apply -f otel-example/otel-collector-config.yaml
+   sudo kubectl apply -f otel-example/otel-collector.yaml
+   sudo helm install vllm ../../helm/ -f values-12-otel-vllm.yaml
+   ```
+
+   ```bash
+   sudo kubectl get pods
+   ```
+
+   Expected output:
+
+   You should see pods such as the following:
+
+   ```plaintext
+    NAME                                               READY   STATUS    RESTARTS   AGE
+    jaeger-744484b5bc-rdrgn                            1/1     Running   0          13m
+    otel-collector-859db69dd4-kj8x6                    1/1     Running   0          12m
+    vllm-deployment-router-6888598c6-m6gl9             1/1     Running   0          12m
+    vllm-opt125m-deployment-vllm-b489dfd8b-95gb5       1/1     Running   0          12m
+   ```
+
+   - The `vllm-deployment-router` pod acts as the router, managing requests and
+    routing them to the appropriate model-serving pod.
+   - The `vllm-opt125m-deployment-vllm` pod serves the actual model for
+    inference.
+
+2. Check service usage:
+
+   ```bash
+   sudo kubectl get services
+   ```
+
+   Expected output:
+
+   Ensure there are services for the serving engine, router, jaeger-collector,
+   and jaeger-query. Note that the OpenTelemetry deployment does not require
+   its own service:
+
+   ```plaintext
+   NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
+    jaeger-collector          ClusterIP   10.99.125.245   <none>        4317/TCP,4318/TCP   86m
+    jaeger-query              ClusterIP   10.97.59.30     <none>        16686/TCP           86m
+    vllm-engine-service   ClusterIP   10.102.6.58     <none>        80/TCP              86m
+    vllm-router-service   ClusterIP   10.103.127.48   <none>        80/TCP              86m
+   ```
+
+   - The `vllm-engine-service` exposes the serving engine.
+   - The `vllm-router-service` handles routing and load balancing across
+     model-serving pods.
+   - The `jaeger-collector` service handles collection of trace data from
+   OpenTelemetry.
+   - The `jaeger-query` service pulls data from the jaeger collector to use in
+   the UI.
+
+3. Expose the model and the Jaeger UI:
+
+   ```bash
+   sudo kubectl port-forward svc/vllm-router-service 30080:80
+   sudo kubectl port-forward svc/jaeger-query 16686:16686
+   ```
+
+   Note that 30080:80 can be replaced with any TCP/UDP port and that port
+   16686 is not used if a different `jaeger-query` port is chosen instead.
+
+Please refer to Step 3 in the
+[01-minimal-helm-installation](01-minimal-helm-installation.md) tutorial for
+querying the deployed vLLM service. You can monitor all queries by navigating
+to localhost:16686 or wherever your jaeger-query port is specified, select
+`jaeger-all-in-one` from the Service dropdown menu on the Jaeger UI and click
+"Find Traces" to yield the traces.
+
+## Conclusion
+
+In this tutorial, you configured and deployed a vLLM serving engine in a
+Kubernetes environment, processed and exported resulting traces to Jaeger
+using an OpenTelemetry collector, and viewed the traces in the Jaeger UI. For
+further customization, please look at the various data sources available for
+monitoring [here](https://opentelemetry.io/docs/collector/configuration/).

--- a/tutorials/assets/otel-example/jaeger-collector.yaml
+++ b/tutorials/assets/otel-example/jaeger-collector.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-collector
+  namespace: default
+spec:
+  ports:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+  selector:
+    app: jaeger

--- a/tutorials/assets/otel-example/jaeger-query.yaml
+++ b/tutorials/assets/otel-example/jaeger-query.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-query
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - name: query
+    port: 16686
+    targetPort: 16686
+  selector:
+    app: jaeger

--- a/tutorials/assets/otel-example/jaeger.yaml
+++ b/tutorials/assets/otel-example/jaeger.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+      - name: jaeger
+        image: jaegertracing/all-in-one:latest
+        ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4318
+          name: otlp-http
+        - containerPort: 16686
+          name: query
+        env:
+        - name: COLLECTOR_OTLP_ENABLED
+          value: "true"

--- a/tutorials/assets/otel-example/otel-collector-config.yaml
+++ b/tutorials/assets/otel-example/otel-collector-config.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap # defines configs through receivers, processors, exporters, and service pipelines
+metadata: # define name for use in other files
+  name: otel-collector-conf
+  namespace: default
+data: # how we want to collect tracing data is specified here
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 1s
+        send_batch_size: 1024
+
+    exporters:
+      logging:
+        verbosity: detailed
+      otlp:
+        endpoint: jaeger-collector.default.svc.cluster.local:4317
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [logging, otlp]

--- a/tutorials/assets/otel-example/otel-collector.yaml
+++ b/tutorials/assets/otel-example/otel-collector.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+      - name: collector
+        image: otel/opentelemetry-collector-contrib:0.86.0
+        args:
+        - "--config=/conf/collector.yaml"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4318
+          name: otlp-http
+        volumeMounts:
+        - name: config
+          mountPath: /conf
+      volumes:
+      - name: config
+        configMap:
+          name: otel-collector-conf


### PR DESCRIPTION
Addresses #77

<h3>Added OpenTelemetry Collector Example w/ Jaeger UI</h3>
<p>This PR adds the following files to a <code>otel-example</code> folder under <code>helm</code>: </p>
<ul>
    <li><code>jaeger.yaml</code> configures jaeger deployment and exposes ports 4317 (gRPC) and 4318 (HTTP) for data collection.</li>
    <li><code>otel-collector.yaml</code> specifies otel collection (receives trace data via OTLP), processes traces in batches, and exports to jaeger collector.</li>
    <li><code>sample-otel-values.yaml</code> is the same as <code>values.yaml</code> except that we specify OTEL service name, port, and attributes to be injected into the Kubernetes manifest.</li>
</ul>

<h3>Usage</h3>

<p>First deploy jaeger, otel-collection, and the vllm model from the <code>otel-example</code> directory. </p>
<ul>
<li><code>sudo kubectl apply -f otel-collector.yaml</code></li>
<li><code>sudo kubectl apply -f jaeger.yaml</code></li>
</ul>
<p>Add the production-stack repository to helm and install the sample values yaml file</p>
<ul>
<li> <code>sudo helm repo add vllm https://vllm-project.github.io/production-stack</code>
<li> <code>sudo helm install vllm vllm/vllm-stack -f sample-otel-values.yaml</code>
</ul>
<p>Expose the router service to query the opt model and expose the jaeger UI</p>
<ul>
<li> <code>sudo kubectl port-forward svc/vllm-router-service 30080:80</code>
<li> <code>sudo kubectl port-forward svc/jaeger-query 16686:16686</code>
</ul>
<p>Now you can query the model with</p>
<code>curl -X POST http://localhost:30080/v1/completions   -H "Content-Type: application/json"   -d '{
    "model": "facebook/opt-125m",
    "prompt": "Once upon a time,",
    "max_tokens": 10
  }'</code>
<p>and monitor the traces via the jaeger UI.</p>

![Jaeger UI Example](https://github.com/user-attachments/assets/3f26cf85-0e2d-4111-aa71-f2efa8b81bdb)