### PR TITLE
[Bugfix] added model name to deployment selector

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -14,6 +14,7 @@ spec:
   {{- include "chart.engineStrategy" . | nindent 2 }}
   selector:
     matchLabels:
+      model: {{ $modelSpec.name }}
     {{- include "chart.engineLabels" . | nindent 6 }}
   progressDeadlineSeconds: 1200
   template:


### PR DESCRIPTION
Added model label to deployment selector.

In order to ensure the deployments for each model select only the pods associated with their model, I added the model label to the selector.