### PR TITLE
[Router] add sentry sdk and cli args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "numpy==1.26.4",
     "prometheus-client==0.21.1",
     "python-multipart==0.0.20",
+    "sentry-sdk[fastapi,httpx]==2.27.0",
     "uhashring==2.3",
     "uvicorn==0.34.0",
 ]

--- a/src/vllm_router/README.md
+++ b/src/vllm_router/README.md
@@ -48,6 +48,10 @@ The router can be configured using command-line arguments. Below are the availab
 
 - `--dynamic-config-json`: The path to the json file containing the dynamic configuration.
 
+### Sentry Options
+
+- `--sentry-dsn`: The Sentry Data Source Name to use for error reporting.
+
 ## Build docker image
 
 ```bash

--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -2,6 +2,7 @@ import logging
 import threading
 from contextlib import asynccontextmanager
 
+import sentry_sdk
 import uvicorn
 from fastapi import FastAPI
 
@@ -55,7 +56,6 @@ from vllm_router.services.batch_service import initialize_batch_processor
 from vllm_router.services.files_service import initialize_storage
 from vllm_router.services.request_service.rewriter import (
     get_request_rewriter,
-    initialize_request_rewriter,
 )
 from vllm_router.stats.engine_stats import (
     get_engine_stats_scraper,
@@ -106,6 +106,9 @@ def initialize_all(app: FastAPI, args):
     Raises:
         ValueError: if the service discovery type is invalid
     """
+    if sentry_dsn := args.sentry_dsn:
+        sentry_sdk.init(dsn=sentry_dsn, send_default_pii=True)
+
     if args.service_discovery == "static":
         initialize_service_discovery(
             ServiceDiscoveryType.STATIC,

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -210,6 +210,12 @@ def parse_args():
         help="Log level for uvicorn. Default is 'info'.",
     )
 
+    parser.add_argument(
+        "--sentry-dsn",
+        type=str,
+        help="Enables Sentry Error Reporting to the specified Data Source Name",
+    )
+
     args = parser.parse_args()
     validate_args(args)
     return args

--- a/src/vllm_router/requirements.txt
+++ b/src/vllm_router/requirements.txt
@@ -5,5 +5,6 @@ kubernetes==32.0.0
 numpy==1.26.4
 prometheus_client==0.21.1
 python-multipart==0.0.20
+sentry-sdk[fastapi,httpx]==2.27.0
 uhashring==2.3
 uvicorn==0.34.0

--- a/uv.lock
+++ b/uv.lock
@@ -990,6 +990,27 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/b6/a92ae6fa6d7e6e536bc586776b1669b84fb724dfe21b8ff08297f2d7c969/sentry_sdk-2.27.0.tar.gz", hash = "sha256:90f4f883f9eff294aff59af3d58c2d1b64e3927b28d5ada2b9b41f5aeda47daf", size = 323556 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/8b/fb496a45854e37930b57564a20fb8e90dd0f8b6add0491527c00f2163b00/sentry_sdk-2.27.0-py2.py3-none-any.whl", hash = "sha256:c58935bfff8af6a0856d37e8adebdbc7b3281c2b632ec823ef03cd108d216ff0", size = 340786 },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+httpx = [
+    { name = "httpx" },
+]
+
+[[package]]
 name = "setuptools"
 version = "75.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1241,6 +1262,7 @@ dependencies = [
     { name = "numpy" },
     { name = "prometheus-client" },
     { name = "python-multipart" },
+    { name = "sentry-sdk", extra = ["fastapi", "httpx"] },
     { name = "uhashring" },
     { name = "uvicorn" },
 ]
@@ -1273,6 +1295,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = "==0.21.1" },
     { name = "python-multipart", specifier = "==0.0.20" },
     { name = "sentence-transformers", marker = "extra == 'semantic-cache'", specifier = "==2.2.2" },
+    { name = "sentry-sdk", extras = ["fastapi", "httpx"], specifier = "==2.27.0" },
     { name = "uhashring", specifier = "==2.3" },
     { name = "uvicorn", specifier = "==0.34.0" },
 ]


### PR DESCRIPTION
We want to deploy the router part of production stack in our own environment. We make use of [Sentry](https://sentry.io) for error reporting. This PR adds the `sentry-sdk` package along with the required extras to make use of Sentry's integration with FastAPI and HTTPX. The setup will only be done in cases where the new `--sentry-dsn` flag has been set at startup. Otherwise, the router will start without any changes.

I tried my best to assume the configuration of the `pyproject.toml` and `requirements.txt` dependencies. Please let me know if I should change anything regarding the setup. Other than that, the Sentry SDK doesn't require much setup other than the call to `sentry_sdk.setup()` which monkey-patches some functions.