### PR TITLE
[Router][Feat] Enhance K8s service discovery to support all models per engine pod

### DIFF
--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -18,7 +18,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from kubernetes import client, config, watch
@@ -113,7 +113,7 @@ class K8sServiceDiscovery(ServiceDiscovery):
         """
         self.namespace = namespace
         self.port = port
-        self.available_engines: Dict[str, EndpointInfo] = {}
+        self.available_engines: Dict[Tuple[str, str], EndpointInfo] = {}
         self.available_engines_lock = threading.Lock()
         self.label_selector = label_selector
 
@@ -142,31 +142,60 @@ class K8sServiceDiscovery(ServiceDiscovery):
         ready_count = sum(1 for status in container_statuses if status.ready)
         return ready_count == len(container_statuses)
 
-    def _get_model_name(self, pod_ip) -> Optional[str]:
+    def _get_model_names(self, pod_ip) -> Optional[List[str]]:
         """
-        Get the model name of the serving engine pod by querying the pod's
-        '/v1/models' endpoint.
+        Get the model names of the serving engine pod by querying the pod's
+        '/v1/models' endpoint. A pod can serve multiple models (e.g., base + LoRAs).
 
         Args:
             pod_ip: the IP address of the pod
 
         Returns:
-            the model name of the serving engine
+            A list of model names served by the engine, or None if an error occurs or no models found.
         """
         url = f"http://{pod_ip}:{self.port}/v1/models"
+        model_names_list: List[str] = []
         try:
             headers = None
             if VLLM_API_KEY := os.getenv("VLLM_API_KEY"):
-                logger.info(f"Using vllm server authentication")
+                logger.info(f"Using vllm server authentication for {url}")
                 headers = {"Authorization": f"Bearer {VLLM_API_KEY}"}
-            response = requests.get(url, headers=headers)
+            # Consider making timeout configurable if necessary
+            response = requests.get(url, headers=headers, timeout=10)
             response.raise_for_status()
-            model_name = response.json()["data"][0]["id"]
-        except Exception as e:
-            logger.error(f"Failed to get model name from {url}: {e}")
-            return None
+            data = response.json().get("data")
 
-        return model_name
+            if isinstance(data, list):
+                for model_entry in data:
+                    if isinstance(model_entry, dict) and "id" in model_entry and model_entry["id"]:
+                        model_names_list.append(model_entry["id"])
+            
+            if not model_names_list: # This means data was not a list, was empty, or contained no valid model_entries
+                logger.warning(f"No model IDs found or 'data' was not a list/empty in response from {url}. Response status: {response.status_code}")
+                # If the API successfully returns an empty list of models, we should return an empty list.
+                # If there was an issue with the 'data' field itself not being a list, or structure is wrong, then None is more appropriate.
+                # For now, if data is a list but empty, it results in an empty model_names_list, which is fine.
+                # If 'data' is not a list, model_names_list remains empty, leading to this warning and returning None.
+                # Let's refine this: if data is a list (even empty), return model_names_list. If data is None or not a list, then it's an issue.
+                if data is None or not isinstance(data, list):
+                     logger.error(f"Field 'data' missing or not a list in response from {url}")
+                     return None # Indicates an issue with the response structure beyond just an empty list of models
+                # If data is an empty list, model_names_list will be empty, and that's what will be returned.
+
+        except requests.exceptions.Timeout:
+            logger.error(f"Timeout when getting model names from {url}")
+            return None
+        except requests.exceptions.RequestException as e: # Covers ConnectionError, HTTPError, etc.
+            logger.error(f"Request failed to get model names from {url}: {e}")
+            return None
+        except (ValueError, KeyError) as e: # Handles JSON parsing errors or missing keys like "data" or "id"
+            logger.error(f"Failed to parse model names from response of {url}: {e}")
+            return None
+        except Exception as e: # Catch-all for other unexpected errors
+            logger.error(f"Unexpected error when getting model names from {url}: {e}")
+            return None
+        
+        return model_names_list
 
     def _watch_engines(self):
         # TODO (ApostaC): remove the hard-coded timeouts
@@ -177,80 +206,141 @@ class K8sServiceDiscovery(ServiceDiscovery):
                     self.k8s_api.list_namespaced_pod,
                     namespace=self.namespace,
                     label_selector=self.label_selector,
-                    timeout_seconds=30,
+                    timeout_seconds=30, # This is watcher stream timeout, not request timeout
                 ):
                     pod = event["object"]
                     event_type = event["type"]
                     pod_name = pod.metadata.name
-                    pod_ip = pod.status.pod_ip
+                    pod_ip = pod.status.pod_ip # pod_ip can be None if pod is not fully up
+                    
                     is_pod_ready = self._check_pod_ready(pod.status.container_statuses)
-                    if is_pod_ready:
-                        model_name = self._get_model_name(pod_ip)
-                    else:
-                        model_name = None
+                    
+                    model_names_reported: Optional[List[str]] = None
+                    if is_pod_ready and pod_ip: # Only try to get models if pod is ready and has an IP
+                        model_names_reported = self._get_model_names(pod_ip)
+                    # If model_names_reported is None here, it means _get_model_names failed.
+                    # If it's an empty list, it means the endpoint returned no models.
+                    
                     self._on_engine_update(
-                        pod_name, pod_ip, event_type, is_pod_ready, model_name
+                        pod_name, pod_ip, event_type, is_pod_ready, model_names_reported
                     )
+            except client.exceptions.ApiException as e:
+                if e.status == 410: # Resource version too old (Gone)
+                    logger.warning(f"K8s watcher stream returned HTTP 410 (Gone): {e}. Restarting watch.")
+                else:
+                    logger.error(f"K8s watcher ApiException: {e}. Status: {e.status}, Reason: {e.reason}")
+                time.sleep(1) # Brief pause before restarting loop/watch
             except Exception as e:
                 logger.error(f"K8s watcher error: {e}")
-                time.sleep(0.5)
+                time.sleep(1) # Brief pause
 
     def _add_engine(self, engine_name: str, engine_ip: str, model_name: str):
+        # engine_name is pod_name
+        endpoint_key = (engine_name, model_name)
         logger.info(
-            f"Discovered new serving engine {engine_name} at "
+            f"Adding/Updating serving endpoint for pod {engine_name} at "
             f"{engine_ip}, running model: {model_name}"
         )
         with self.available_engines_lock:
-            self.available_engines[engine_name] = EndpointInfo(
+            self.available_engines[endpoint_key] = EndpointInfo(
                 url=f"http://{engine_ip}:{self.port}",
                 model_name=model_name,
                 added_timestamp=int(time.time()),
             )
 
     def _delete_engine(self, engine_name: str):
-        logger.info(f"Serving engine {engine_name} is deleted")
+        # engine_name is pod_name. This function removes all models associated with this pod.
+        logger.info(f"Serving engine pod {engine_name} is being removed or is unhealthy. Removing all its associated model endpoints.")
+        models_removed_count = 0
         with self.available_engines_lock:
-            del self.available_engines[engine_name]
+            keys_to_delete = [
+                key for key in self.available_engines if key[0] == engine_name
+            ]
+            if not keys_to_delete:
+                 logger.info(f"No model endpoints were registered for pod {engine_name} to remove.")
+                 return
+
+            for key in keys_to_delete:
+                # Check if key still exists, as another thread might have modified it, though less likely with this design.
+                if key in self.available_engines:
+                    del self.available_engines[key]
+                    models_removed_count += 1
+                    logger.debug(f"Deleted endpoint for model {key[1]} from pod {engine_name}")
+        if models_removed_count > 0:
+            logger.info(f"Removed {models_removed_count} model endpoint(s) associated with pod {engine_name}.")
+        
 
     def _on_engine_update(
         self,
-        engine_name: str,
+        engine_name: str, # This is pod_name
         engine_ip: Optional[str],
         event: str,
         is_pod_ready: bool,
-        model_name: Optional[str],
+        model_names_reported: Optional[List[str]], # List of model names, or None if _get_model_names failed
     ) -> None:
         if event == "ADDED":
-            if engine_ip is None:
-                return
-
-            if not is_pod_ready:
-                return
-
-            if model_name is None:
-                return
-
-            self._add_engine(engine_name, engine_ip, model_name)
+            if engine_ip and is_pod_ready:
+                if model_names_reported is not None: # Check if _get_model_names succeeded
+                    if model_names_reported: # Ensure there are actual models
+                        for mn in model_names_reported:
+                            self._add_engine(engine_name, engine_ip, mn)
+                    else: # _get_model_names succeeded but returned an empty list
+                        logger.info(f"Pod {engine_name} (ADDED) is ready and reported zero models.")
+                else: # _get_model_names failed (returned None)
+                    logger.warning(f"Pod {engine_name} (ADDED) is ready but failed to retrieve model names.")
+            # else: Pod not ready, no IP - do nothing for ADDED until it's ready and reports models.
 
         elif event == "DELETED":
-            if engine_name not in self.available_engines:
-                return
-
-            self._delete_engine(engine_name)
+            self._delete_engine(engine_name) # Removes all models for this pod_name
 
         elif event == "MODIFIED":
-            if engine_ip is None:
-                return
-
-            if is_pod_ready and model_name is not None:
-                self._add_engine(engine_name, engine_ip, model_name)
-                return
-
-            if (
-                not is_pod_ready or model_name is None
-            ) and engine_name in self.available_engines:
+            if not engine_ip: # If IP is gone on MODIFIED, pod is likely unusable.
+                logger.info(f"Pod {engine_name} (MODIFIED) has no IP. Removing associated model endpoints.")
                 self._delete_engine(engine_name)
                 return
+
+            if is_pod_ready:
+                # Pod is ready. model_names_reported could be:
+                # - a list of model names (possibly empty if pod serves no models)
+                # - None (if _get_model_names failed)
+                
+                with self.available_engines_lock:
+                    current_registered_model_keys_for_pod = {
+                        key for key in self.available_engines if key[0] == engine_name
+                    }
+                    current_registered_model_names_for_pod = {key[1] for key in current_registered_model_keys_for_pod}
+                    
+                    if model_names_reported is not None: # _get_model_names succeeded
+                        newly_reported_models_set = set(model_names_reported)
+
+                        # Add/update models that are newly reported
+                        for mn_new in newly_reported_models_set:
+                            # _add_engine will update if (engine_name, mn_new) already exists, or add if new.
+                            self._add_engine(engine_name, engine_ip, mn_new)
+                        
+                        # Remove models that were registered but are no longer reported
+                        models_to_remove = current_registered_model_names_for_pod - newly_reported_models_set
+                        for mn_to_remove in models_to_remove:
+                            endpoint_key_to_remove = (engine_name, mn_to_remove)
+                            if endpoint_key_to_remove in self.available_engines: # Should always be true
+                                del self.available_engines[endpoint_key_to_remove]
+                                logger.info(f"Removed model '{mn_to_remove}' from pod {engine_name} as it's no longer reported after MODIFIED event.")
+                        
+                        if not newly_reported_models_set and current_registered_model_names_for_pod:
+                            logger.info(f"Pod {engine_name} (MODIFIED) is ready but now reports zero models. All its previous models were removed.")
+                        elif not newly_reported_models_set:
+                             logger.info(f"Pod {engine_name} (MODIFIED) is ready and reported zero models (no changes to registration if it had none).")
+
+                    else: # _get_model_names failed (returned None)
+                        # Pod is ready, but we couldn't get its models.
+                        # This is a tricky state. We should probably remove existing models for this pod,
+                        # as we can't confirm they are still valid.
+                        logger.warning(f"Pod {engine_name} (MODIFIED) is ready, but failed to retrieve model list. Removing all previously registered models for this pod.")
+                        self._delete_engine(engine_name) # Treat as if it's unhealthy from a model reporting perspective
+
+            else: # Pod modified to be not ready
+                logger.info(f"Pod {engine_name} (MODIFIED) is not ready. Removing all its associated model endpoints.")
+                self._delete_engine(engine_name)
 
     def get_endpoint_info(self) -> List[EndpointInfo]:
         """


### PR DESCRIPTION
### Summary

This PR enhances the Kubernetes service discovery mechanism within the `vllm_router` to correctly identify and register all models served by each vLLM engine pod. This includes the base model and any loaded LoRA adapters that are reported via the pod's `/v1/models` endpoint.

Previously, the `K8sServiceDiscovery` in `src/vllm_router/service_discovery.py` would only process the first model ID returned by a pod's `/v1/models` endpoint. This limited the router's visibility, as subsequent models or LoRA adapters served by the same pod were not recognized or made available for routing.

### Changes Made

The primary changes were made to the `K8sServiceDiscovery` class in `src/vllm_router/service_discovery.py`:

1.  **`_get_model_names` (formerly `_get_model_name`)**:
    *   This method now parses the entire `"data"` list from the JSON response of a pod's `/v1/models` endpoint.
    *   It collects all model `"id"` fields, allowing for the discovery of multiple models (base + LoRAs) from a single pod.
    *   Error handling and timeout configurations for the HTTP request have been improved.

2.  **Internal Storage (`self.available_engines`)**:
    *   The dictionary now uses a `Tuple[str, str]` (specifically `(pod_name, model_name)`) as its key. This allows multiple `EndpointInfo` objects (each representing a unique model) to be associated with the same pod.

3.  **Event Handling (`_add_engine`, `_delete_engine`, `_on_engine_update`)**:
    *   `_add_engine`: Updated to use the new composite key.
    *   `_delete_engine`: Now correctly removes all model endpoints associated with a given `pod_name` when that pod is deleted or becomes unhealthy.
    *   `_on_engine_update`: Logic has been significantly revised to handle lists of model names:
        *   For `ADDED` events, it iterates through all reported models from a new ready pod and adds each one.
        *   For `MODIFIED` events, it intelligently compares the newly reported list of models with the currently registered ones for that pod, adding new ones and removing those no longer reported. It also handles cases where a pod becomes ready but fails to report models, or becomes unready.

### Impact

*   The vLLM router can now discover and make available *all* models (including LoRA adapters) that are served by individual vLLM engine pods in a Kubernetes deployment, provided they are listed in the pod's `/v1/models` output.
*   This enables more granular routing to specific LoRA adapters and ensures that the router's own `/v1/models` endpoint accurately reflects all available model variations.
*   Users can now reliably target specific LoRA adapters through the router.

### How to Test (Suggested)

1.  Deploy vLLM engine pods in a Kubernetes environment. Configure at least one pod to serve a base model and one or more LoRA adapters.
2.  Ensure the `/v1/models` endpoint on such a pod correctly lists the base model and all loaded LoRA adapters.
3.  Configure and deploy the `vllm-router` with `service_discovery: k8s`, pointing to the namespace and label selector for your engine pods.
4.  Query the router's `/v1/models` endpoint. It should now list all unique model IDs from all discovered pods, including the base models and all their LoRA adapters.
5.  Attempt to send inference requests through the router, specifically targeting one of the LoRA adapters by its ID in the request.


FIX #xxxx (*link existing issues this PR will resolve, or remove if not applicable*)

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [ ] Make sure the code changes pass the [pre-commit](../CONTRIBUTING.md) checks.
- [ ] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [ ] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.