### PR TITLE
[Misc] fix values.schema.json so it does not contradict to examples from tutorials/assets/*.yaml

### DIFF
--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "servingEngineSpec": {
@@ -71,7 +71,7 @@
                 "type": "string"
               },
               "requestGPU": {
-                "type": "integer"
+                "type": "number"
               },
               "requestGPUType": {
                 "type": "string"
@@ -214,11 +214,24 @@
                     },
                     "value": {
                       "type": "string"
+                    },
+                    "valueFrom": {
+                      "type": "object"
                     }
                   },
-                  "required": [
-                    "name",
-                    "value"
+                  "anyOf": [
+                    {
+                      "required": [
+                        "name",
+                        "value"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "name",
+                        "valueFrom"
+                      ]
+                    }
                   ]
                 }
               },
@@ -267,8 +280,7 @@
               "replicaCount",
               "requestCPU",
               "requestMemory",
-              "requestGPU",
-              "pvcStorage"
+              "requestGPU"
             ]
           }
         },
@@ -405,19 +417,19 @@
           "type": "integer"
         },
         "vllmApiKey": {
-           "type": "object",
-            "properties": {
-              "secretName": {
-                "type": "string"
-              },
-              "secretKey": {
-                "type": "string"
-              }
+          "type": "object",
+          "properties": {
+            "secretName": {
+              "type": "string"
             },
-            "required": [
-              "secretName",
-              "secretKey"
-            ]
+            "secretKey": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "secretName",
+            "secretKey"
+          ]
         },
         "labels": {
           "type": "object",


### PR DESCRIPTION
While working on the unification of the configuration process by using [cue](https://cuelang.org/), I had a few errors. 
This PR fixes them.

You can convert `values.schema.json` to cue format first by running
```
cue import helm/values.schema.json
```
and then verify existing configs
```
cue vet -i helm/values.schema.cue tutorials/assets/*.yaml
```

It also includes https://github.com/vllm-project/production-stack/pull/423.