### PR TITLE
[Feat]: Add extraVolumeMount for initContainer

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -146,6 +146,15 @@ limits:
 {{- end }}
 
 {{/*
+  Define Annotations for serving engine and its service
+*/}}
+{{- define "chart.engineAnnotations" -}}
+{{-   with .Values.servingEngineSpec.podAnnotations -}}
+{{      toYaml . }}
+{{-   end }}
+{{- end }}
+
+{{/*
   Define helper function to convert labels to a comma separated list
 */}}
 {{- define "labels.toCommaSeparatedList" -}}

--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
       {{- include "chart.cacheserverLabels" . | nindent 8 }}
+      {{- with .Values.cacheserverSpec.podAnnotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.cacheserverSpec.nodeSelectorTerms}}
       affinity:

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
       {{- include "chart.routerLabels" . | nindent 8 }}
+      {{- with .Values.routerSpec.podAnnotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-router-service-account
       {{- if .Values.routerSpec.nodeSelectorTerms }}

--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -33,6 +33,8 @@ spec:
         model: {{ $modelSpec.name }}
         helm-release-name: {{ .Release.Name }}
       {{- include "chart.engineLabels" . | nindent 8 }}
+      annotations:
+      {{- include "chart.engineAnnotations" . | nindent 8 }}
     spec:
       {{- if hasKey $modelSpec "initContainer" }}
       {{- $container := $modelSpec.initContainer }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -313,6 +313,9 @@ routerSpec:
     environment: "router"
     release: "router"
 
+  # -- Pod Annotations the router deployment
+  podAnnotations: {}
+
   ingress:
     # -- Enable ingress controller resource
     enabled: false


### PR DESCRIPTION

This PR adds extraVolumeMount to the initContainer to facilitate the download of models or metadata to specific volume mounts. 

This PR also includes changes to allow a list of imagePullSecrets. The reason behind this is that the initContainer and the main container may come from different repositories.

