### PR TITLE
[Router] Adding Request TTFT Tracking RouterTime tracking router

### DIFF
--- a/docs/time_tracking_routing.md
+++ b/docs/time_tracking_routing.md
@@ -5,7 +5,7 @@
 
 ---
 
-## 🚀 Features
+## Features
 
 - Tracks per-endpoint **mean** and **standard deviation** of completion times.
 - Considers **current load** to avoid overloading busy endpoints.
@@ -14,7 +14,7 @@
 
 ---
 
-## ⚙️ Parameters
+## Parameters
 
 You can customize the importance of each routing factor using:
 
@@ -30,7 +30,7 @@ TimeTrackingRouter(alpha=1.0, beta=1.0, gamma=0.5)
 
 ---
 
-## 📦 Classes
+## Classes
 
 ### `TimeTrackingRouter(RoutingInterface)`
 
@@ -67,7 +67,7 @@ class EndpointInfo:
 
 ---
 
-## 📈 Routing Algorithm
+## Routing Algorithm
 
 The score for each endpoint is computed as:
 
@@ -81,7 +81,7 @@ If an endpoint lacks data, it defaults to a score of zero for missing metrics (f
 
 ---
 
-## 🧪 Example Usage
+## Example Usage
 
 ```python
 router = TimeTrackingRouter(alpha=1.0, beta=2.0, gamma=0.3)
@@ -91,14 +91,14 @@ router.record_completion(endpoint, duration=1.25)
 
 ---
 
-## 📋 Notes
+## Notes
 
 - Uses a fixed-size rolling window (`maxlen=100`) for tracking completion time history.
 - Designed to plug into systems implementing `RoutingInterface`.
 
 ---
 
-## 🔧 Future Enhancements
+## Future Enhancements
 
 - Add support for exponential decay or recency bias in stats.
 - Consider request priority or user-level QoE history.

--- a/docs/time_tracking_routing.md
+++ b/docs/time_tracking_routing.md
@@ -71,7 +71,7 @@ class EndpointInfo:
 
 The score for each endpoint is computed as:
 
-```
+```python
 score = (alpha * mean_completion_time) + (beta * current_load) + (gamma * std_completion_time)
 ```
 

--- a/docs/time_tracking_routing.md
+++ b/docs/time_tracking_routing.md
@@ -1,0 +1,105 @@
+
+# TimeTrackingRouter
+
+`TimeTrackingRouter` is a customizable routing strategy that selects the best endpoint for a request based on historical performance data. It balances **mean completion time**, **load**, and **latency variability** (standard deviation), helping optimize for quality of experience (QoE) in systems serving LLM or similar model endpoints.
+
+---
+
+## 🚀 Features
+
+- Tracks per-endpoint **mean** and **standard deviation** of completion times.
+- Considers **current load** to avoid overloading busy endpoints.
+- Assigns a **scoring function** to choose the optimal endpoint.
+- Automatically updates endpoint stats based on request outcomes.
+
+---
+
+## ⚙️ Parameters
+
+You can customize the importance of each routing factor using:
+
+- `alpha`: Weight for **mean completion time**.
+- `beta`: Weight for **current load**.
+- `gamma`: Weight for **completion time standard deviation**.
+
+### Default Configuration
+
+```python
+TimeTrackingRouter(alpha=1.0, beta=1.0, gamma=0.5)
+```
+
+---
+
+## 📦 Classes
+
+### `TimeTrackingRouter(RoutingInterface)`
+
+Implements the routing logic:
+
+- `route_request(...)`: Chooses the endpoint with the lowest score.
+- `register_endpoint(endpoint)`: Initializes tracking for new endpoints.
+- `update_stats(endpoint)`: Updates endpoint with latest performance stats.
+- `record_completion(endpoint, duration)`: Records completion time after a request finishes.
+
+### `EndpointStats`
+
+Maintains historical performance for a single endpoint:
+
+- `add_completion_time(time)`: Adds a new completion time.
+- `mean()`: Returns mean of recorded times.
+- `stdev()`: Returns standard deviation (returns `0.0` if insufficient data).
+
+### `EndpointInfo`
+
+Metadata for each endpoint:
+
+```python
+@dataclass
+class EndpointInfo:
+    url: str
+    model_name: str
+    added_timestamp: float
+    model_label: str
+    mean_completion_time: Optional[float]
+    std_completion_time: Optional[float]
+    current_load: Optional[int]
+```
+
+---
+
+## 📈 Routing Algorithm
+
+The score for each endpoint is computed as:
+
+```
+score = (alpha * mean_completion_time) + (beta * current_load) + (gamma * std_completion_time)
+```
+
+The endpoint with the **lowest score** is selected.
+
+If an endpoint lacks data, it defaults to a score of zero for missing metrics (favoring exploration).
+
+---
+
+## 🧪 Example Usage
+
+```python
+router = TimeTrackingRouter(alpha=1.0, beta=2.0, gamma=0.3)
+chosen_url = await router.route_request(endpoints, engine_stats, request_stats, request, request_json)
+router.record_completion(endpoint, duration=1.25)
+```
+
+---
+
+## 📋 Notes
+
+- Uses a fixed-size rolling window (`maxlen=100`) for tracking completion time history.
+- Designed to plug into systems implementing `RoutingInterface`.
+
+---
+
+## 🔧 Future Enhancements
+
+- Add support for exponential decay or recency bias in stats.
+- Consider request priority or user-level QoE history.
+- Track token-level latency (e.g. TTFT, ITL).

--- a/proposals/time_tracking_router_proposal.md
+++ b/proposals/time_tracking_router_proposal.md
@@ -1,0 +1,93 @@
+# Add TimeTrackingRouter: QoE-driven endpoint routing balancing latency
+
+## Table of Contents
+
+* [Summary](#summary)
+* [Motivation](#motivation)
+* [Goals](#goals)
+* [Non-Goals](#non-goals)
+* [Proposal](#proposal)
+
+  * [Proposed Changes](#proposed-changes)
+  * [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
+  * [Test Plans](#test-plans)
+* [Drawbacks](#drawbacks)
+* [Alternatives](#alternatives)
+* [Implementation Timeline / Phases](#implementation-timeline--phases)
+* [References](#references)
+
+---
+
+## Summary
+
+This PR introduces `TimeTrackingRouter`, a routing strategy that selects the optimal endpoint for requests by scoring them based on mean completion time and variability. This approach improves quality of experience (QoE) in serving LLM or similar model endpoints by balancing speed and reliability.
+
+---
+
+## Motivation
+
+Current routing approaches may overload endpoints or ignore latency variability, leading to inconsistent user experiences. This feature addresses the need for a smarter, performance-aware router that makes routing decisions based on endpoint statistics, reducing response time variability and improving overall system efficiency.
+
+---
+
+## Goals
+
+* Track per-endpoint mean and standard deviation of completion times
+* Use a configurable weighted scoring function to rank endpoints.
+
+---
+
+## Non-Goals
+
+* Token-level latency tracking (TTFT, ITL) is not implemented in this PR.
+* Does not handle user-level QoE or request priority at this stage.
+
+---
+
+## Proposal
+
+### Proposed Changes
+
+* Implement `TimeTrackingRouter` class with routing logic based on scoring function:
+  `score = alpha * mean_completion + beta * current_load + gamma * std_completion`
+* Add `EndpointStats` for stats tracking.
+* Update routing and stats APIs to support dynamic updates and routing decisions.
+
+### Implementation Details/Notes/Constraints
+
+* Uses a fixed window of 100 most recent completion times per endpoint.
+* Scores endpoints with missing stats as zero to favor exploration.
+* Alpha, beta, gamma weights are configurable with sensible defaults.
+* Minimal performance overhead expected; only simple arithmetic and in-memory stats tracking.
+
+### Test Plans
+
+* Unit tests covering stats calculations, scoring, and endpoint selection logic.
+* Integration/E2E tests verifying correct routing behavior under varying load and latency scenarios.
+* Negative tests verifying fallback behavior when data is incomplete or missing.
+
+---
+
+## Drawbacks
+
+* Adds complexity to routing logic and state management per endpoint.
+* Requires maintaining additional metrics which might increase memory usage slightly.
+* Fixed window size may not adapt well to all workloads — future work needed for adaptive windowing.
+* Load ignored, can cause overload and inconsistent experience
+
+---
+
+## Alternatives
+
+* Use simple round-robin or random routing — simpler but less QoE-optimized.
+* Implement full token-level latency aware routing — deferred for future enhancement due to complexity.
+
+---
+
+## Implementation Timeline / Phases
+
+* **Phase 1 (This PR):** Core router implementation and unit tests.
+* **Phase 2:** Integration testing and performance tuning.
+* **Phase 3:** Future enhancements like user-level priority support, checking KV cache, balancing load.
+
+---

--- a/proposals/time_tracking_router_proposal.md
+++ b/proposals/time_tracking_router_proposal.md
@@ -14,7 +14,6 @@
 * [Drawbacks](#drawbacks)
 * [Alternatives](#alternatives)
 * [Implementation Timeline / Phases](#implementation-timeline--phases)
-* [References](#references)
 
 ---
 

--- a/src/tests/test_time_tracking_router.py
+++ b/src/tests/test_time_tracking_router.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import Mock
+from typing import Dict, List
+
+from vllm_router.routers.routing_logic import TimeTrackingRouter
+from vllm_router.service_discovery import EndpointInfo, EndpointStats
+from vllm_router.stats.engine_stats import EngineStats
+from vllm_router.stats.request_stats import RequestStats
+
+# Mock definitions
+class EndpointStats:
+    def __init__(self):
+        self.times = []
+
+    def add_completion_time(self, duration: float):
+        self.times.append(duration)
+
+    def mean(self):
+        return sum(self.times) / len(self.times) if self.times else 0.0
+
+    def stdev(self):
+        if len(self.times) < 2:
+            return 0.0
+        mean = self.mean()
+        return (sum((x - mean) ** 2 for x in self.times) / (len(self.times) - 1)) ** 0.5
+
+class EndpointInfo:
+    def __init__(self, url: str, current_load: int = 0):
+        self.url = url
+        self.current_load = current_load
+        self.mean_completion_time = None
+        self.std_completion_time = None
+
+class Request:
+    pass  # can be expanded as needed
+
+# Import the router class here if defined externally
+# from my_router_module import TimeTrackingRouter
+
+@pytest.mark.asyncio
+async def test_time_tracking_router_prefers_fastest_endpoint():
+    router = TimeTrackingRouter(alpha=1.0, beta=1.0, gamma=1.0)
+
+    endpoint_a = EndpointInfo("http://endpoint-a", current_load=2)
+    endpoint_b = EndpointInfo("http://endpoint-b", current_load=1)
+
+    router.register_endpoint(endpoint_a)
+    router.register_endpoint(endpoint_b)
+
+    # Simulate completion history
+    router.record_completion(endpoint_a, 2.0)  # mean = 2.0
+    router.record_completion(endpoint_a, 2.5)
+    router.record_completion(endpoint_b, 1.0)  # mean = 1.0
+    router.record_completion(endpoint_b, 1.2)
+
+    endpoints = [endpoint_a, endpoint_b]
+    engine_stats: Dict[str, any] = {}
+    request_stats: Dict[str, any] = {}
+    request = Request()
+    request_json = {}
+
+    selected = await router.route_request(endpoints, engine_stats, request_stats, request, request_json)
+
+    assert selected == "http://endpoint-b", "Router should prefer the faster and less loaded endpoint"

--- a/src/tests/test_time_tracking_router.py
+++ b/src/tests/test_time_tracking_router.py
@@ -1,11 +1,13 @@
-import pytest
-from unittest.mock import Mock
 from typing import Dict, List
+from unittest.mock import Mock
+
+import pytest
 
 from vllm_router.routers.routing_logic import TimeTrackingRouter
 from vllm_router.service_discovery import EndpointInfo, EndpointStats
 from vllm_router.stats.engine_stats import EngineStats
 from vllm_router.stats.request_stats import RequestStats
+
 
 # Mock definitions
 class EndpointStats:
@@ -24,6 +26,7 @@ class EndpointStats:
         mean = self.mean()
         return (sum((x - mean) ** 2 for x in self.times) / (len(self.times) - 1)) ** 0.5
 
+
 class EndpointInfo:
     def __init__(self, url: str, current_load: int = 0):
         self.url = url
@@ -31,11 +34,14 @@ class EndpointInfo:
         self.mean_completion_time = None
         self.std_completion_time = None
 
+
 class Request:
     pass  # can be expanded as needed
 
+
 # Import the router class here if defined externally
 # from my_router_module import TimeTrackingRouter
+
 
 @pytest.mark.asyncio
 async def test_time_tracking_router_prefers_fastest_endpoint():
@@ -59,6 +65,10 @@ async def test_time_tracking_router_prefers_fastest_endpoint():
     request = Request()
     request_json = {}
 
-    selected = await router.route_request(endpoints, engine_stats, request_stats, request, request_json)
+    selected = await router.route_request(
+        endpoints, engine_stats, request_stats, request, request_json
+    )
 
-    assert selected == "http://endpoint-b", "Router should prefer the faster and less loaded endpoint"
+    assert (
+        selected == "http://endpoint-b"
+    ), "Router should prefer the faster and less loaded endpoint"

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -15,14 +15,13 @@
 import abc
 import asyncio
 import enum
+import math
 import random
 import socket
 import threading
 from typing import Dict, List
 
 import requests
-import math
-
 from fastapi import Request
 
 try:
@@ -389,21 +388,21 @@ class DisaggregatedPrefillRouter(RoutingInterface):
 
 class TimeTrackingRouter(RoutingInterface):
     def __init__(self, alpha=1.0, beta=1.0, gamma=0.5):
-        self.alpha = alpha # weight for mean time
-        self.beta = beta # weight for load
-        self.gamma = gamma # weight for std deviation
+        self.alpha = alpha  # weight for mean time
+        self.beta = beta  # weight for load
+        self.gamma = gamma  # weight for std deviation
 
         self.endpoint_stats: Dict[str, EndpointStats] = {}
 
     def register_endpoint(self, endpoint: EndpointInfo):
         if endpoint.url not in self.endpoint_stats:
             self.endpoint_stats[endpoint.url] = EndpointStats()
-    
+
     def update_stats(self, endpoint: EndpointInfo):
         stats = self.endpoint_stats[endpoint.url]
         endpoint.mean_completion_time = stats.mean()
         endpoint.std_completion_time = stats.stdev()
-    
+
     async def route_request(
         self,
         endpoints: List[EndpointInfo],
@@ -431,9 +430,9 @@ class TimeTrackingRouter(RoutingInterface):
             if score < best_score:
                 best_score = score
                 best_endpoint = endpoint
-        
+
         return best_endpoint.url
-    
+
     def record_completion(self, endpoint: EndpointInfo, duration: float):
         self.endpoint_stats[endpoint.url].add_completion_time(duration)
 
@@ -463,7 +462,7 @@ def initialize_routing_logic(
         )
     elif routing_logic == RoutingLogic.TIME_TRACKING:
         logger.info("Initializing endpoint load balancing routing logic")
-        return TimeTrackingRouter() #TODO
+        return TimeTrackingRouter()  # TODO
     else:
         raise ValueError(f"Invalid routing logic {routing_logic}")
 
@@ -477,7 +476,7 @@ def reconfigure_routing_logic(
         RoundRobinRouter,
         KvawareRouter,
         DisaggregatedPrefillRouter,
-        TimeTrackingRouter
+        TimeTrackingRouter,
     ):
         if cls in SingletonABCMeta._instances:
             del SingletonABCMeta._instances[cls]
@@ -492,7 +491,7 @@ def get_routing_logic() -> RoutingInterface:
         KvawareRouter,
         PrefixAwareRouter,
         DisaggregatedPrefillRouter,
-        TimeTrackingRouter
+        TimeTrackingRouter,
     ):
         if cls in SingletonABCMeta._instances:
             return cls()

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -424,8 +424,10 @@ class TimeTrackingRouter(RoutingInterface):
             std = endpoint.std_completion_time or 0.0
             load = endpoint.current_load or 0
 
+            # assign endpoint score based on mean & std of completion time
             score = (self.alpha * mean) + (self.beta * load) + (self.gamma * std)
 
+            # choose the lowest score
             if score < best_score:
                 best_score = score
                 best_endpoint = endpoint

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -21,6 +21,8 @@ import threading
 from typing import Dict, List
 
 import requests
+import math
+
 from fastapi import Request
 
 try:
@@ -35,7 +37,7 @@ except ImportError:
 from uhashring import HashRing
 
 from vllm_router.log import init_logger
-from vllm_router.service_discovery import EndpointInfo
+from vllm_router.service_discovery import EndpointInfo, EndpointStats
 from vllm_router.stats.engine_stats import EngineStats
 from vllm_router.stats.request_stats import RequestStats
 from vllm_router.utils import SingletonABCMeta
@@ -49,6 +51,7 @@ class RoutingLogic(str, enum.Enum):
     KVAWARE = "kvaware"
     PREFIXAWARE = "prefixaware"
     DISAGGREGATED_PREFILL = "disaggregated_prefill"
+    TIME_TRACKING = "timetracking"
 
 
 class RoutingInterface(metaclass=SingletonABCMeta):
@@ -384,6 +387,55 @@ class DisaggregatedPrefillRouter(RoutingInterface):
             return decoder_endpoints[0].url
 
 
+class TimeTrackingRouter(RoutingInterface):
+    def __init__(self, alpha=1.0, beta=1.0, gamma=0.5):
+        self.alpha = alpha # weight for mean time
+        self.beta = beta # weight for load
+        self.gamma = gamma # weight for std deviation
+
+        self.endpoint_stats: Dict[str, EndpointStats] = {}
+
+    def register_endpoint(self, endpoint: EndpointInfo):
+        if endpoint.url not in self.endpoint_stats:
+            self.endpoint_stats[endpoint.url] = EndpointStats()
+    
+    def update_stats(self, endpoint: EndpointInfo):
+        stats = self.endpoint_stats[endpoint.url]
+        endpoint.mean_completion_time = stats.mean()
+        endpoint.std_completion_time = stats.stdev()
+    
+    async def route_request(
+        self,
+        endpoints: List[EndpointInfo],
+        engine_stats: Dict[str, EngineStats],
+        request_stats: Dict[str, RequestStats],
+        request: Request,
+        request_json: Dict,
+    ) -> str:
+        best_score = math.inf
+        best_endpoint = None
+
+        for endpoint in endpoints:
+            self.register_endpoint(endpoint)
+            self.update_stats(endpoint)
+
+            # if no data yet, treat it as best
+            mean = endpoint.mean_completion_time or 0.0
+            std = endpoint.std_completion_time or 0.0
+            load = endpoint.current_load or 0
+
+            score = (self.alpha * mean) + (self.beta * load) + (self.gamma * std)
+
+            if score < best_score:
+                best_score = score
+                best_endpoint = endpoint
+        
+        return best_endpoint.url
+    
+    def record_completion(self, endpoint: EndpointInfo, duration: float):
+        self.endpoint_stats[endpoint.url].add_completion_time(duration)
+
+
 # Instead of managing a global _global_router, we can define the initialization functions as:
 def initialize_routing_logic(
     routing_logic: RoutingLogic, *args, **kwargs
@@ -407,6 +459,9 @@ def initialize_routing_logic(
         return DisaggregatedPrefillRouter(
             kwargs.get("prefill_model_labels"), kwargs.get("decode_model_labels")
         )
+    elif routing_logic == RoutingLogic.TIME_TRACKING:
+        logger.info("Initializing endpoint load balancing routing logic")
+        return TimeTrackingRouter() #TODO
     else:
         raise ValueError(f"Invalid routing logic {routing_logic}")
 
@@ -420,6 +475,7 @@ def reconfigure_routing_logic(
         RoundRobinRouter,
         KvawareRouter,
         DisaggregatedPrefillRouter,
+        TimeTrackingRouter
     ):
         if cls in SingletonABCMeta._instances:
             del SingletonABCMeta._instances[cls]
@@ -434,6 +490,7 @@ def get_routing_logic() -> RoutingInterface:
         KvawareRouter,
         PrefixAwareRouter,
         DisaggregatedPrefillRouter,
+        TimeTrackingRouter
     ):
         if cls in SingletonABCMeta._instances:
             return cls()

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -15,9 +15,9 @@
 import abc
 import enum
 import os
+import statistics
 import threading
 import time
-import statistics
 from collections import deque
 from dataclasses import dataclass
 from typing import Dict, List, Optional
@@ -54,13 +54,14 @@ class EndpointInfo:
     # endpoint's mean request completion time
     mean_completion_time: Optional[float]
 
-    #standard deviation of request completion time
+    # standard deviation of request completion time
     std_completion_time: Optional[float]
 
-    #current number of requests routed to an endpoint
+    # current number of requests routed to an endpoint
     current_load: Optional[int]
 
-class EndpointStats():
+
+class EndpointStats:
     def __init__(self, maxlen=100):
         self.completion_times = deque(maxlen=maxlen)
 
@@ -76,7 +77,8 @@ class EndpointStats():
         if len(self.completion_times) < 2:
             return 0.0
         return statistics.stdev(self.completion_times)
-    
+
+
 class ServiceDiscovery(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_endpoint_info(self) -> List[EndpointInfo]:

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -17,6 +17,8 @@ import enum
 import os
 import threading
 import time
+import statistics
+from collections import deque
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -49,7 +51,32 @@ class EndpointInfo:
     # Model label
     model_label: str
 
+    # endpoint's mean request completion time
+    mean_completion_time: Optional[float]
 
+    #standard deviation of request completion time
+    std_completion_time: Optional[float]
+
+    #current number of requests routed to an endpoint
+    current_load: Optional[int]
+
+class EndpointStats():
+    def __init__(self, maxlen=100):
+        self.completion_times = deque(maxlen=maxlen)
+
+    def add_completion_time(self, completion_time: float):
+        self.completion_times.append(completion_time)
+
+    def mean(self):
+        if not self.completion_times:
+            return None
+        return statistics.mean(self.completion_times)
+
+    def stdev(self):
+        if len(self.completion_times) < 2:
+            return 0.0
+        return statistics.stdev(self.completion_times)
+    
 class ServiceDiscovery(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_endpoint_info(self) -> List[EndpointInfo]:

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -26,7 +26,7 @@ from vllm_router.routers.routing_logic import (
     DisaggregatedPrefillRouter,
     KvawareRouter,
     PrefixAwareRouter,
-    TimeTrackingRouter
+    TimeTrackingRouter,
 )
 from vllm_router.service_discovery import get_service_discovery
 from vllm_router.services.request_service.rewriter import (
@@ -138,8 +138,9 @@ async def process_request(
     )
 
     if isinstance(request.app.state.router, TimeTrackingRouter):
-        request.app.state.router.record_completion(endpoint, completion_time-start_time)
-        
+        request.app.state.router.record_completion(
+            endpoint, completion_time - start_time
+        )
 
     # if debug_request:
     #    logger.debug(f"Finished the request with request id: {debug_request.headers.get('x-request-id', None)} at {time.time()}")


### PR DESCRIPTION
### **Overview of Key Changes**
This pull request adds the TimeTrackingRouter, a routing strategy designed to optimize Quality of Experience (QoE) by selecting endpoints based on historical request performance. It balances mean completion time and latency variability to  distribute requests across endpoints.

### **Implementation Details**

- New Class: `TimeTrackingRouter`

- Implements a scoring function to select the best endpoint:

`score = alpha * mean + beta * load + gamma * std_dev
`
- Chooses the endpoint with the lowest score.

- Default Weights

`alpha = 1.0, beta = 1.0, gamma = 0.5
`
- Rolling window size: 100 entries.

**Supporting Classes**

- EndpointStats: Maintains a rolling history of completion times and computes mean and standard deviation.

- EndpointInfo: Added metadata to each endpoint about observed performance.



