### PR TITLE
feat(helm): make imagePullPolicy configurable & fix router service an…

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -188,7 +188,7 @@ spec:
           - "--chat-template"
           - "/templates/{{ $modelSpec.chatTemplate }}"
           {{- end }}
-          imagePullPolicy: Always
+          imagePullPolicy: "{{ .Values.servingEngineSpec.imagePullPolicy | default "Always" }}"
           env:
           - name: HF_HOME
             {{- if hasKey $modelSpec "pvcStorage" }}

--- a/helm/templates/service-router.yaml
+++ b/helm/templates/service-router.yaml
@@ -4,6 +4,9 @@ kind: Service
 metadata:
   name: "{{ .Release.Name }}-router-service"
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.routerSpec.serviceAnnotations }}
+  annotations: {{- toYaml .Values.routerSpec.serviceAnnotations | nindent 4 }}
+  {{- end }}
   labels:
   {{- include "chart.routerLabels" . | nindent 4 }}
 spec:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -99,6 +99,7 @@ servingEngineSpec:
   #   tag: "latest"
   #   modelURL: "mistralai/Mistral-7B-Instruct-v0.2"
   #   replicaCount: 1
+  #   imagePullPolicy: "Always" # or "IfNotPresent"
   #
   #   requestCPU: 10
   #   requestMemory: "64Gi"
@@ -270,6 +271,8 @@ routerSpec:
 
   # -- Service type
   serviceType: ClusterIP
+  # -- Service annotations if you use a LoadBalancer or NodePort service type
+  serviceAnnotations: {}
 
   # -- Service port
   servicePort: 80


### PR DESCRIPTION
## What this PR does

This PR introduces two improvements to the Helm chart in `production-stack`:

---

### 1. Improve deployment flexibility for testing scenarios

- **Added**: `servingEngineSpec.modelSpec.imagePullPolicy` in `values.yaml`
- **Updated**: `deployment-vllm-multi.yaml` template to make `imagePullPolicy` configurable.
- **Why**: In test environments, it's inefficient to always re-pull images. Making this configurable enables developers to use `IfNotPresent` for faster iteration.

```yaml
imagePullPolicy: "{{ .Values.servingEngineSpec.imagePullPolicy | default "Always" }}"
```

---

### 2. Fix missing annotations for LoadBalancer services

- **Added**: `routerSpec.serviceAnnotations` in `values.yaml`
- **Updated**: `service-router.yaml` template to apply annotations to the router service.
- **Why**: When using `serviceType: LoadBalancer`, missing annotations (e.g., for specific cloud LB classes) may cause the router service to stay in `Pending` state indefinitely.

```yaml
annotations:
  {{- toYaml .Values.routerSpec.serviceAnnotations | nindent 4 }}
```

---

## Testing

Both changes have been tested with Helm `install` and `template` on Kubernetes (v1.28), using containerd. Verified:

- imagePullPolicy setting behaves correctly
- router service receives annotations and correctly provisions external IPs via LoadBalancer.

---

## Notes

- These changes are **backward-compatible**
- Default values and behaviors remain unchanged unless overridden

---

Let me know if you'd like me to contribute additional improvements or chart documentation.
