### PR TITLE
[Feat] allow service discovery by service names

### DIFF
--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -146,6 +146,7 @@ def initialize_all(app: FastAPI, args):
     elif args.service_discovery == "k8s":
         initialize_service_discovery(
             ServiceDiscoveryType.K8S,
+            k8s_service_discovery_type=args.k8s_service_discovery_type,
             app=app,
             namespace=args.k8s_namespace,
             port=args.k8s_port,

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -108,6 +108,12 @@ def parse_args():
         help="The service discovery type.",
     )
     parser.add_argument(
+        "--k8s-service-discovery-type",
+        type=str,
+        choices=["pod-ip", "service-name"],
+        help="The k8s service discovery type implementation only applies if service-discovery is specified as k8s.",
+    )
+    parser.add_argument(
         "--static-backends",
         type=str,
         default=None,


### PR DESCRIPTION
allow service discovery by service names

FIX #https://github.com/vllm-project/production-stack/issues/471

```bash
python3 -m  vllm_router.app --port=8000 --k8s-port=80 --service-discovery=k8s --k8s-service-discovery-type=service-name --k8s-label-selector=release=test\  --k8s-namespace=lzj --routing-logic=session --session-key=x-user-id --engine-stats-interval=10 --log-stats 
/root/code/production-stack/src/vllm_router/parsers/parser.py:20: RuntimeWarning: Failed to read commit hash:
No module named 'vllm_router._version'
  from vllm_router.version import __version__
[2025-07-18 02:15:20,301] INFO: Scraping metrics from 0 serving engine(s) (engine_stats.py:146:vllm_router.stats.engine_stats)
[2025-07-18 02:15:20,302] INFO: Initializing session-based routing logic with kwargs: {'session_key': 'x-user-id', 'lmcache_controller_port': 9000, 'prefill_model_labels': None, 'decode_model_labels': None, 'kv_aware_threshold': 2000} (routing_logic.py:462:vllm_router.routers.routing_logic)
INFO:     Started server process [109250]
INFO:     Waiting for application startup.
[2025-07-18 02:15:20,374] INFO: Found models on service vllm-opt125m-engine-service: ['facebook/opt-125m'] (service_discovery.py:877:vllm_router.service_discovery)
[2025-07-18 02:15:20,375] INFO: Discovered new serving engine vllm-opt125m-engine-service at running models: ['facebook/opt-125m'] (service_discovery.py:962:vllm_router.service_discovery)
[2025-07-18 02:15:20,400] INFO: httpx AsyncClient instantiated. Id 140710513065712 (httpx_client.py:31:vllm_router.httpx_client)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
[2025-07-18 02:15:30,303] INFO: Scraping metrics from 1 serving engine(s) (engine_stats.py:146:vllm_router.stats.engine_stats)
[2025-07-18 02:15:30,304] INFO: 
==================================================
Server: http://vllm-opt125m-engine-service:80
Models:
  - facebook/opt-125m
 Engine Stats: No stats available
 Request Stats: No stats available
--------------------------------------------------
==================================================
 (log_stats.py:115:vllm_router.stats.log_stats)
INFO:     127.0.0.1:48508 - "GET /v1/models HTTP/1.1" 200 OK
[2025-07-18 02:15:40,305] INFO: 
==================================================
```


```bash
# curl http://0.0.0.0:8000/v1/models|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   135  100   135    0     0  39393      0 --:--:-- --:--:-- --:--:-- 45000
{
  "object": "list",
  "data": [
    {
      "id": "facebook/opt-125m",
      "object": "model",
      "created": 1752805040,
      "owned_by": "vllm",
      "root": null,
      "parent": null
    }
  ]
}
````


**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

Feat

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
