### PR TITLE
resolve problem dynamic config

### DIFF
--- a/src/vllm_router/dynamic_config.py
+++ b/src/vllm_router/dynamic_config.py
@@ -139,6 +139,7 @@ class DynamicConfigWatcher(metaclass=SingletonMeta):
                 ServiceDiscoveryType.STATIC,
                 urls=parse_static_urls(config.static_backends),
                 models=parse_comma_separated_args(config.static_models),
+                app=self.app
             )
         elif config.service_discovery == "k8s":
             reconfigure_service_discovery(

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -206,12 +206,12 @@ class StaticServiceDiscovery(ServiceDiscovery):
         app,
         urls: List[str],
         models: List[str],
-        aliases: List[str] | None,
-        model_labels: List[str] | None,
-        model_types: List[str] | None,
-        static_backend_health_checks: bool,
-        prefill_model_labels: List[str] | None,
-        decode_model_labels: List[str] | None,
+        aliases: List[str] | None=None,
+        model_labels: List[str] | None=None,
+        model_types: List[str] | None=None,
+        static_backend_health_checks: bool=False,
+        prefill_model_labels: List[str] | None=None,
+        decode_model_labels: List[str] | None=None,
     ):
         self.app = app
         assert len(urls) == len(models), "URLs and models should have the same length"


### PR DESCRIPTION
[Router/Bugfix] Fix dynamic config in vllm router

Fixed dynamic config functionality in vllm router to allow config changes without container downtime. The changes include:

- Used app inside dynamic config
- Added default None values for:
  - aliases
  - model_labels
  - model_types
  - static_backend_health_checks
  - prefill_model_labels
  - decode_model_labels

Testing:
- Manually verified config changes work without container restart

Signed-off-by: [Ali Khabazian] <[Khabaziana@gmail.com]>