### PR TITLE
Use emptyDir as pvcStorage

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -377,7 +377,10 @@ spec:
       {{- if or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) (hasKey $modelSpec "chatTemplate") (hasKey $modelSpec "extraVolumes") (hasKey $.Values "sharedPvcStorage") }}
       volumes:
       {{- end}}
-        {{- if hasKey $modelSpec "pvcStorage" }}
+        {{- if eq (toString $modelSpec.pvcStorage) "emptyDir" }}
+        - name: {{ .Release.Name }}-storage
+          emptyDir: {}
+        {{- else if hasKey $modelSpec "pvcStorage" }}
         - name: {{ .Release.Name }}-storage
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-{{$modelSpec.name}}-storage-claim"

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -3,6 +3,7 @@
 {{- range $modelSpec := .Values.servingEngineSpec.modelSpec }}
 {{- with $ -}}
 {{- if and (hasKey $modelSpec "pvcStorage") (not (empty $modelSpec.pvcStorage)) }}
+{{- if ne (toString $modelSpec.pvcStorage) "emptyDir" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -26,6 +27,7 @@ spec:
     matchLabels:
       {{- toYaml $modelSpec.pvcMatchLabels | nindent 8 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 ---


### PR DESCRIPTION


I am using the vLLM stack to deploy engine servers.
I am hosted on a cloud provider that does not support the RunAI streamer to load LLM models from S3 object storage.

My goal is to temporarily bypass the S3 issue by adding an initContainer AWS CLI that download the model from S3 (faster than hugging face) and use the RunAI streamer to load the model from the local POD storage.
