### PR TITLE
[vllm-router] fall back to remote tokenizer

### DIFF
--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -22,6 +22,7 @@ import uuid
 from typing import Dict, List
 
 from fastapi import Request
+import requests
 
 try:
     from transformers import AutoTokenizer
@@ -285,11 +286,24 @@ class KvawareRouter(RoutingInterface):
             request_json (Dict): The request body (needed for finding the
             longest prefix match)
         """
-        if self.tokenizer is None:
-            self.tokenizer = AutoTokenizer.from_pretrained(endpoints[0].model_names[0])
-        url = endpoints[0].url + "/tokenize"
+        token_ids = None
+        # Local-first tokenization, fall back to remote "/tokenize" API on failure
         # TODO (Yuhan): Handle chat completions
-        token_ids = self.tokenizer.encode(request_json["prompt"])
+        try:
+            if self.tokenizer is None:
+                self.tokenizer = AutoTokenizer.from_pretrained(endpoints[0].model_names[0])
+            token_ids = self.tokenizer.encode(request_json["prompt"])
+        except Exception:
+            # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
+            remote_url = endpoints[0].url + "/tokenize"
+            headers = {"Content-Type": "application/json"}
+            data = {
+                "model": endpoints[0].model_names[0],
+                "prompt": request_json.get("prompt", ""),
+            }
+            body = requests.post(remote_url, headers=headers, json=data, timeout=10).json()
+            token_ids = body["tokens"]
+
         event_id = "Lookup" + str(uuid.uuid4())
         logger.debug(f"Lookup event id: {event_id}")
         msg = LookupMsg(tokens=token_ids, event_id=event_id)
@@ -306,13 +320,10 @@ class KvawareRouter(RoutingInterface):
             or len(instance_id.layout_info) == 0
             or matched_tokens < max(len(token_ids) - self.threshold, 0)
         ):
-
             session_id = request.headers.get(self.session_key, None)
             logger.debug(f"Got session id: {session_id}")
-
             # Update the hash ring with the current list of endpoints
             self._update_hash_ring(endpoints)
-
             if session_id is None:
                 # Route based on QPS if no session ID is present
                 url = self._qps_routing(endpoints, request_stats)


### PR DESCRIPTION
FIX NA


I was trying to just delete an unused line `url = endpoints[0].url + "/tokenize"`
But my another thought told me to create this PR, remote as an backup :-)

because : we cannot guarantee that the proxy has `transformers` installed or model's tokenizer downloaded.



@YuhanLiu11 