### PR TITLE
[Bugfix] Allow single-label hostnames in URL validation

### DIFF
--- a/src/vllm_router/utils.py
+++ b/src/vllm_router/utils.py
@@ -157,7 +157,7 @@ def validate_url(url: str) -> bool:
     regex = re.compile(
         r"^(http|https)://"  # Protocol
         r"(([a-zA-Z0-9_-]+\.)+[a-zA-Z]{2,}|"  # Domain name
-        r"(?!-)[a-zA-Z0-9_-]+(?<!-)|" # single-label
+        r"(?!-)[a-zA-Z0-9_-]+(?<!-)|"  # single-label
         r"localhost|"  # Or localhost
         r"\d{1,3}(\.\d{1,3}){3})"  # Or IPv4 address
         r"(:\d+)?"  # Optional port


### PR DESCRIPTION
Fix validate_url to accept URLs with single-label hosts like http://oss-20b:8000, which are common in Docker and internal networking setups.