### PR TITLE
[Feat] Production Stack Router: Add OpenTelemetry tracing support with W3C context propagation

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -201,6 +201,14 @@ This table documents all available configuration values for the Production Stack
 | `routerSpec.readinessProbe.failureThreshold` | integer |`3`| Failure threshold for router's readiness probe |
 | `routerSpec.readinessProbe.httpGet.path` | string |`"/health"`| Endpoint that the router's readiness probe will be testing |
 
+#### Router OpenTelemetry Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `routerSpec.otel.endpoint` | string | `""` | OTLP endpoint for tracing (e.g., "otel-collector:4317"). Tracing is enabled when this is set. |
+| `routerSpec.otel.serviceName` | string | `"vllm-router"` | Service name for OpenTelemetry traces |
+| `routerSpec.otel.secure` | boolean | `false` | Use secure (TLS) connection for OTLP exporter |
+
 #### Router Ingress Configuration
 
 | Field | Type | Default | Description |

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -136,6 +136,15 @@ spec:
           - "--lmcache-controller-port"
           - "{{ .Values.routerSpec.lmcacheControllerPort }}"
           {{- end }}
+          {{- if .Values.routerSpec.otel.endpoint }}
+          - "--otel-endpoint"
+          - "{{ .Values.routerSpec.otel.endpoint }}"
+          - "--otel-service-name"
+          - "{{ .Values.routerSpec.otel.serviceName | default "vllm-router" }}"
+          {{- if .Values.routerSpec.otel.secure }}
+          - "--otel-secure"
+          {{- end }}
+          {{- end }}
         {{- if .Values.routerSpec.resources }}
         resources:
           {{- if .Values.routerSpec.resources.requests }}

--- a/helm/tests/routerOtel_test.yaml
+++ b/helm/tests/routerOtel_test.yaml
@@ -1,0 +1,77 @@
+suite: test router OpenTelemetry configuration
+templates:
+  - deployment-router.yaml
+tests:
+  - it: should not include otel args when endpoint is not set
+    set:
+      routerSpec:
+        enableRouter: true
+        otel:
+          endpoint: ""
+    asserts:
+      - template: deployment-router.yaml
+        notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--otel-endpoint"
+
+  - it: should include otel args when endpoint is set
+    set:
+      routerSpec:
+        enableRouter: true
+        otel:
+          endpoint: "otel-collector:4317"
+          serviceName: "vllm-router"
+          secure: false
+    asserts:
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--otel-endpoint"
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "otel-collector:4317"
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--otel-service-name"
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "vllm-router"
+      - template: deployment-router.yaml
+        notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--otel-secure"
+
+  - it: should use custom service name when specified
+    set:
+      routerSpec:
+        enableRouter: true
+        otel:
+          endpoint: "jaeger:4317"
+          serviceName: "my-custom-router"
+          secure: false
+    asserts:
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "my-custom-router"
+
+  - it: should include otel-secure flag when secure is true
+    set:
+      routerSpec:
+        enableRouter: true
+        otel:
+          endpoint: "otel-collector:4317"
+          serviceName: "vllm-router"
+          secure: true
+    asserts:
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--otel-endpoint"
+      - template: deployment-router.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--otel-secure"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -580,6 +580,26 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "otel": {
+          "type": "object",
+          "description": "OpenTelemetry tracing configuration for the router",
+          "properties": {
+            "endpoint": {
+              "type": "string",
+              "description": "OTLP endpoint for tracing (e.g., 'otel-collector:4317'). Tracing is enabled when this is set."
+            },
+            "serviceName": {
+              "type": "string",
+              "description": "Service name for OpenTelemetry traces",
+              "default": "vllm-router"
+            },
+            "secure": {
+              "type": "boolean",
+              "description": "Use secure (TLS) connection for OTLP exporter",
+              "default": false
+            }
+          }
         }
       }
     }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -377,6 +377,16 @@ routerSpec:
   # -- Window size in seconds to calculate the request statistics
   requestStatsWindow: 60
 
+  # -- OpenTelemetry tracing configuration
+  # When otelEndpoint is set, tracing is automatically enabled
+  otel:
+    # -- OTLP endpoint for tracing (e.g., "localhost:4317" or "otel-collector:4317")
+    endpoint: ""
+    # -- Service name for traces (default: "vllm-router")
+    serviceName: "vllm-router"
+    # -- Use secure (TLS) connection for OTLP exporter (default: false, i.e., insecure)
+    secure: false
+
   # -- deployment strategy
   strategy: {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "xxhash==3.5.0",
     "psutil==7.0.0",
     "pyyaml>=6.0.2",
+    "opentelemetry-api>=1.28.0",
+    "opentelemetry-sdk>=1.28.0",
+    "opentelemetry-exporter-otlp>=1.28.0",
 ]
 
 [project.scripts]

--- a/src/tests/test_otel_tracing.py
+++ b/src/tests/test_otel_tracing.py
@@ -1,0 +1,81 @@
+import pytest
+from opentelemetry.trace import SpanKind
+
+import vllm_router.experimental.otel.tracing as tracing_module
+from vllm_router.experimental.otel.tracing import (
+    end_span,
+    extract_context,
+    initialize_tracing,
+    inject_context,
+    is_tracing_enabled,
+    shutdown_tracing,
+    start_span,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_state():
+    """Reset global tracing state before each test."""
+    tracing_module._tracer = None
+    tracing_module._provider = None
+    tracing_module._tracing_enabled = False
+    yield
+    # Cleanup after test
+    if tracing_module._tracing_enabled:
+        shutdown_tracing()
+
+
+class TestTracingIntegration:
+    def test_full_request_flow(self):
+        """Test a complete request tracing flow."""
+        initialize_tracing(service_name="vllm-router", otlp_endpoint="localhost:4317")
+
+        # Simulate incoming request with trace context
+        incoming_headers = {
+            "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        }
+        incoming_context = extract_context(incoming_headers)
+
+        # Create parent span (router)
+        parent_span, parent_context = start_span(
+            name="router /v1/chat/completions",
+            parent_context=incoming_context,
+            kind=SpanKind.SERVER,
+            attributes={
+                "http.method": "POST",
+                "vllm.model": "Qwen/Qwen2.5-7B-Instruct",
+            },
+        )
+
+        # Create child span (backend request)
+        child_span, child_context = start_span(
+            name="backend_request",
+            parent_context=parent_context,
+            kind=SpanKind.CLIENT,
+            attributes={
+                "http.url": "http://backend:8000/v1/chat/completions",
+            },
+        )
+
+        # Inject context into outgoing headers
+        outgoing_headers = {}
+        inject_context(outgoing_headers, child_context)
+
+        assert "traceparent" in outgoing_headers
+
+        # End spans in reverse order
+        end_span(child_span, status_code=200)
+        end_span(parent_span, status_code=200)
+
+    def test_tracing_disabled_flow(self):
+        """Test that operations handle disabled tracing gracefully."""
+        assert is_tracing_enabled() is False
+
+        # These should not raise even when tracing is disabled
+        headers = {}
+        inject_context(headers)
+        end_span(None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -79,6 +79,18 @@ try:
 except ImportError:
     semantic_cache_available = False
 
+try:
+    # OpenTelemetry tracing integration
+    from vllm_router.experimental.otel import (
+        initialize_tracing,
+        is_tracing_enabled,
+        shutdown_tracing,
+    )
+
+    otel_available = True
+except ImportError:
+    otel_available = False
+
 logger = logging.getLogger("uvicorn")
 
 
@@ -121,6 +133,11 @@ async def lifespan(app: FastAPI):
     logger.info("Closing routing logic instances")
     cleanup_routing_logic()
 
+    # Shutdown OpenTelemetry tracing if enabled
+    if otel_available and app.state.otel_enabled:
+        logger.info("Shutting down OpenTelemetry tracing")
+        shutdown_tracing()
+
 
 def initialize_all(app: FastAPI, args):
     """
@@ -140,6 +157,23 @@ def initialize_all(app: FastAPI, args):
             profile_lifecycle="trace",
             traces_sample_rate=args.sentry_traces_sample_rate,
             profile_session_sample_rate=args.sentry_profile_session_sample_rate,
+        )
+
+    if otel_available and args.otel_endpoint:
+        initialize_tracing(
+            service_name=args.otel_service_name,
+            otlp_endpoint=args.otel_endpoint,
+            insecure=not args.otel_secure,
+        )
+        app.state.otel_enabled = is_tracing_enabled()
+        if app.state.otel_enabled:
+            logger.info(
+                f"OpenTelemetry tracing enabled, exporting to {args.otel_endpoint}"
+            )
+    elif args.otel_endpoint and not otel_available:
+        logger.warning(
+            "OpenTelemetry endpoint specified but OpenTelemetry packages not installed. "
+            "Install with: pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp"
         )
 
     if args.service_discovery == "static":
@@ -292,6 +326,7 @@ app.include_router(batches_router)
 app.include_router(metrics_router)
 app.state.aiohttp_client_wrapper = AiohttpClientWrapper()
 app.state.semantic_cache_available = semantic_cache_available
+app.state.otel_enabled = False
 
 
 def main():

--- a/src/vllm_router/experimental/otel/__init__.py
+++ b/src/vllm_router/experimental/otel/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2024-2025 The vLLM Production Stack Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry tracing module for vLLM Router."""
+
+from vllm_router.experimental.otel.tracing import (
+    end_span,
+    extract_context,
+    get_tracer,
+    initialize_tracing,
+    inject_context,
+    is_tracing_enabled,
+    shutdown_tracing,
+    start_span,
+)
+
+__all__ = [
+    "initialize_tracing",
+    "shutdown_tracing",
+    "get_tracer",
+    "is_tracing_enabled",
+    "extract_context",
+    "inject_context",
+    "start_span",
+    "end_span",
+]

--- a/src/vllm_router/experimental/otel/tracing.py
+++ b/src/vllm_router/experimental/otel/tracing.py
@@ -1,0 +1,199 @@
+# Copyright 2024-2025 The vLLM Production Stack Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry tracing utilities for vLLM Router.
+
+This module provides distributed tracing support using OpenTelemetry.
+It handles:
+- Trace context extraction from incoming requests (W3C Trace Context)
+- Span creation for router operations
+- Trace context injection into outgoing requests to backends
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.propagate import extract, inject
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+# Global state for tracing
+_tracer: Optional[trace.Tracer] = None
+_provider: Optional[TracerProvider] = None
+_tracing_enabled: bool = False
+
+
+def initialize_tracing(
+    service_name: str = "vllm-router",
+    otlp_endpoint: str = "localhost:4317",
+    insecure: bool = True,
+) -> None:
+    """Initialize OpenTelemetry tracing with OTLP exporter.
+
+    Args:
+        service_name: The service name to use for traces.
+        otlp_endpoint: The OTLP collector endpoint (e.g., "localhost:4317").
+        insecure: Whether to use insecure connection (no TLS).
+    """
+    global _tracer, _provider, _tracing_enabled
+
+    if _tracing_enabled:
+        logger.warning("Tracing already initialized, skipping re-initialization")
+        return
+
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.version": "1.0.0",
+        }
+    )
+    exporter = OTLPSpanExporter(
+        endpoint=otlp_endpoint,
+        insecure=insecure,
+    )
+    _provider = TracerProvider(resource=resource)
+    _provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(_provider)
+    _tracer = trace.get_tracer("vllm-router")
+    _tracing_enabled = True
+
+    logger.info(
+        f"OpenTelemetry tracing initialized: service={service_name}, "
+        f"endpoint={otlp_endpoint}, insecure={insecure}"
+    )
+
+
+def shutdown_tracing() -> None:
+    """Shutdown the tracer provider and flush pending spans."""
+    global _provider, _tracing_enabled
+
+    if _provider is not None:
+        _provider.shutdown()
+        logger.info("OpenTelemetry tracing shutdown complete")
+
+    _tracing_enabled = False
+
+
+def get_tracer() -> trace.Tracer:
+    """Get the tracer instance.
+
+    Returns:
+        The tracer instance.
+
+    Raises:
+        RuntimeError: If tracing has not been initialized.
+    """
+    if _tracer is None:
+        raise RuntimeError("Tracing not initialized. Call initialize_tracing() first.")
+    return _tracer
+
+
+def is_tracing_enabled() -> bool:
+    """Check if tracing is enabled.
+
+    Returns:
+        True if tracing is initialized and enabled.
+    """
+    return _tracing_enabled
+
+
+def extract_context(headers: Dict[str, Any]) -> Context:
+    """Extract trace context from incoming request headers.
+
+    This extracts W3C Trace Context (traceparent, tracestate) from headers.
+
+    Args:
+        headers: Dictionary of request headers.
+
+    Returns:
+        OpenTelemetry Context with extracted trace information.
+    """
+    return extract(carrier=headers)
+
+
+def inject_context(
+    headers: Dict[str, str], context: Optional[Context] = None
+) -> Dict[str, str]:
+    """Inject trace context into outgoing request headers.
+
+    This injects W3C Trace Context (traceparent, tracestate) into headers.
+
+    Args:
+        headers: Dictionary of request headers to inject into.
+        context: Optional context to inject. If None, uses current context.
+
+    Returns:
+        The headers dictionary with trace context added.
+    """
+    inject(carrier=headers, context=context)
+    return headers
+
+
+def start_span(
+    name: str,
+    parent_context: Optional[Context] = None,
+    kind: trace.SpanKind = trace.SpanKind.SERVER,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> tuple[trace.Span, Context]:
+    """Start a new span and return both the span and its context.
+
+    Args:
+        name: Name of the span.
+        parent_context: Parent context to create span under. If None, extracts from current context.
+        kind: The span kind (SERVER, CLIENT, etc.).
+        attributes: Optional dict of attributes to set on the span.
+
+    Returns:
+        Tuple of (span, span_context) where span_context can be used as parent for child spans.
+    """
+    tracer = get_tracer()
+    span = tracer.start_span(name, context=parent_context, kind=kind)
+
+    if attributes:
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+
+    span_context = trace.set_span_in_context(span, parent_context)
+    return span, span_context
+
+
+def end_span(
+    span: Optional[trace.Span],
+    error: Optional[Exception] = None,
+    status_code: Optional[int] = None,
+) -> None:
+    """End a span, optionally recording error information.
+
+    Args:
+        span: The span to end. If None, does nothing.
+        error: Optional exception to record on the span.
+        status_code: Optional HTTP status code to set on the span.
+    """
+    if span is None:
+        return
+
+    if status_code is not None:
+        span.set_attribute("http.status_code", status_code)
+
+    if error is not None:
+        span.record_exception(error)
+        span.set_status(trace.StatusCode.ERROR, str(error))
+
+    span.end()

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -358,6 +358,26 @@ def parse_args():
         help="The sample rate for Sentry profiling sessions. Default is 1.0 (100%)",
     )
 
+    # OpenTelemetry tracing arguments
+    parser.add_argument(
+        "--otel-endpoint",
+        type=str,
+        default=None,
+        help="OTLP endpoint for tracing (e.g., localhost:4317). Enables tracing when set.",
+    )
+    parser.add_argument(
+        "--otel-service-name",
+        type=str,
+        default="vllm-router",
+        help="Service name for OpenTelemetry tracing. Default is 'vllm-router'.",
+    )
+    parser.add_argument(
+        "--otel-secure",
+        action="store_true",
+        default=False,
+        help="Use secure (TLS) connection for OTLP exporter. Default is insecure.",
+    )
+
     parser.add_argument(
         "--prefill-model-labels",
         type=str,

--- a/src/vllm_router/requirements.txt
+++ b/src/vllm_router/requirements.txt
@@ -3,6 +3,11 @@ aiohttp[speedups]==3.13.0
 fastapi==0.115.8
 kubernetes==32.0.0
 numpy==1.26.4
+
+# OpenTelemetry tracing (optional)
+opentelemetry-api==1.28.0
+opentelemetry-exporter-otlp==1.28.0
+opentelemetry-sdk==1.28.0
 prometheus_client==0.21.1
 psutil==7.0.0
 python-multipart==0.0.20

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -48,6 +48,21 @@ try:
 except ImportError:
     semantic_cache_available = False
 
+try:
+    # OpenTelemetry tracing integration
+    from opentelemetry import trace
+
+    from vllm_router.experimental.otel import (
+        end_span,
+        extract_context,
+        inject_context,
+        start_span,
+    )
+
+    otel_available = True
+except ImportError:
+    otel_available = False
+
 from vllm_router.services.metrics_service import num_incoming_requests_total
 
 logger = init_logger(__name__)
@@ -74,6 +89,7 @@ async def process_request(
     endpoint,
     background_tasks: BackgroundTasks,
     debug_request=None,
+    parent_span_context=None,
 ):
     """
     Process a request by sending it to the chosen backend.
@@ -86,6 +102,7 @@ async def process_request(
         endpoint: The endpoint to send the request to on the backend.
         debug_request: The original request object from the client, used for
             optional debug logging.
+        parent_span_context: OpenTelemetry context from parent span for trace propagation.
 
     Yields:
         The response headers and status code, followed by the response content.
@@ -93,6 +110,26 @@ async def process_request(
     Raises:
         HTTPError: If the backend returns a 4xx or 5xx status code.
     """
+    # OpenTelemetry tracing: create child span at function entry
+    span, span_context = None, None
+    tracing_active = (
+        otel_available
+        and request.app.state.otel_enabled
+        and parent_span_context is not None
+    )
+    if tracing_active:
+        span, span_context = start_span(
+            "process_request",
+            parent_context=parent_span_context,
+            kind=trace.SpanKind.CLIENT,
+            attributes={
+                "http.method": request.method,
+                "http.url": backend_url + endpoint,
+                "vllm.backend_url": backend_url,
+                "vllm.request_id": request_id,
+            },
+        )
+
     first_token = False
     total_len = 0
     start_time = time.time()
@@ -107,53 +144,69 @@ async def process_request(
         # If we can't parse the body as JSON, assume it's not streaming
         raise HTTPException(status=400, detail="Request body is not JSON parsable.")
 
-    # sanitize the request headers
+    # Add streaming info to span after parsing
+    if span is not None:
+        span.set_attribute("vllm.is_streaming", is_streaming)
+
+    # Sanitize the request headers
     headers = {
         k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS
     }
 
+    # Inject trace context into outgoing headers
+    if tracing_active:
+        inject_context(headers, span_context)
+
     # For non-streaming requests, collect the full response to cache it properly
     full_response = bytearray()
 
-    async with request.app.state.aiohttp_client_wrapper().request(
-        method=request.method,
-        url=backend_url + endpoint,
-        headers=headers,
-        data=body,
-        timeout=aiohttp.ClientTimeout(total=None),
-    ) as backend_response:
-        # Yield headers and status code first.
-        yield backend_response.headers, backend_response.status
-        # Stream response content.
-        async for chunk in backend_response.content.iter_any():
-            total_len += len(chunk)
-            if not first_token:
-                first_token = True
-                request.app.state.request_stats_monitor.on_request_response(
-                    backend_url, request_id, time.time()
-                )
-            # For non-streaming requests, collect the full response
-            if full_response is not None:
-                full_response.extend(chunk)
-            yield chunk
+    try:
+        async with request.app.state.aiohttp_client_wrapper().request(
+            method=request.method,
+            url=backend_url + endpoint,
+            headers=headers,
+            data=body,
+            timeout=aiohttp.ClientTimeout(total=None),
+        ) as backend_response:
+            # Set response status on span if tracing
+            if span is not None:
+                span.set_attribute("http.status_code", backend_response.status)
 
-    request.app.state.request_stats_monitor.on_request_complete(
-        backend_url, request_id, time.time()
-    )
+            # Yield headers and status code first.
+            yield backend_response.headers, backend_response.status
+            # Stream response content.
+            async for chunk in backend_response.content.iter_any():
+                total_len += len(chunk)
+                if not first_token:
+                    first_token = True
+                    request.app.state.request_stats_monitor.on_request_response(
+                        backend_url, request_id, time.time()
+                    )
+                # For non-streaming requests, collect the full response
+                if full_response is not None:
+                    full_response.extend(chunk)
+                yield chunk
 
-    # if debug_request:
-    #    logger.debug(f"Finished the request with request id: {debug_request.headers.get('x-request-id', None)} at {time.time()}")
-    # Store in semantic cache if applicable
-    # Use the full response for non-streaming requests, or the last chunk for streaming
-    if request.app.state.semantic_cache_available:
-        cache_chunk = bytes(full_response) if not is_streaming else chunk
-        await store_in_semantic_cache(
-            endpoint=endpoint, method=request.method, body=body, chunk=cache_chunk
+        request.app.state.request_stats_monitor.on_request_complete(
+            backend_url, request_id, time.time()
         )
-    if background_tasks and getattr(request.app.state, "callbacks", None):
-        background_tasks.add_task(
-            request.app.state.callbacks.post_request, request, full_response
-        )
+
+        # Store in semantic cache if applicable
+        # Use the full response for non-streaming requests, or the last chunk for streaming
+        if request.app.state.semantic_cache_available:
+            cache_chunk = bytes(full_response) if not is_streaming else chunk
+            await store_in_semantic_cache(
+                endpoint=endpoint, method=request.method, body=body, chunk=cache_chunk
+            )
+        if background_tasks and getattr(request.app.state, "callbacks", None):
+            background_tasks.add_task(
+                request.app.state.callbacks.post_request, request, full_response
+            )
+    except Exception as e:
+        end_span(span, error=e) if tracing_active else None
+        raise
+    finally:
+        end_span(span) if tracing_active else None
 
 
 async def route_general_request(
@@ -185,6 +238,23 @@ async def route_general_request(
     request_body = await request.body()
     request_json = json.loads(request_body) if request_body else {}
 
+    # OpenTelemetry tracing: extract incoming context and create parent span
+    span, span_context = None, None
+    tracing_active = otel_available and request.app.state.otel_enabled
+    if tracing_active:
+        incoming_context = extract_context(dict(request.headers))
+        span, span_context = start_span(
+            f"router {endpoint}",
+            parent_context=incoming_context,
+            kind=trace.SpanKind.SERVER,
+            attributes={
+                "http.method": request.method,
+                "http.url": str(request.url),
+                "http.target": endpoint,
+                "vllm.request_id": request_id,
+            },
+        )
+
     if request.query_params:
         request_endpoint = request.query_params.get("id")
     else:
@@ -200,11 +270,16 @@ async def route_general_request(
 
     requested_model = request_json.get("model", None)
     if requested_model is None:
+        end_span(span, status_code=400) if tracing_active else None
         return JSONResponse(
             status_code=400,
             content={"error": "Invalid request: missing 'model' in request body."},
             headers={"X-Request-Id": request_id},
         )
+
+    # Add model info to parent span
+    if span is not None:
+        span.set_attribute("vllm.model", requested_model)
 
     # Apply request rewriting if enabled
     if is_request_rewriter_initialized():
@@ -263,6 +338,7 @@ async def route_general_request(
 
     if not endpoints:
         if not model_ever_existed:
+            end_span(span, status_code=404) if tracing_active else None
             return JSONResponse(
                 status_code=404,
                 content={
@@ -272,6 +348,7 @@ async def route_general_request(
             )
         else:
             # Model existed before but is now scaled to zero
+            end_span(span, status_code=503) if tracing_active else None
             return JSONResponse(
                 status_code=503,
                 content={
@@ -315,6 +392,14 @@ async def route_general_request(
     logger.info(
         f"Routing request {request_id} with session id {session_id_display} to {server_url} at {curr_time}, process time = {curr_time - in_router_time:.4f}"
     )
+
+    # Add backend URL to parent span
+    if span is not None:
+        span.set_attribute("vllm.backend_url", server_url)
+        span.set_attribute(
+            "vllm.routing_logic", type(request.app.state.router).__name__
+        )
+
     stream_generator = process_request(
         request,
         request_body,
@@ -322,12 +407,24 @@ async def route_general_request(
         request_id,
         endpoint,
         background_tasks,
+        parent_span_context=span_context,
     )
     headers, status = await anext(stream_generator)
     headers_dict = {key: value for key, value in headers.items()}
     headers_dict["X-Request-Id"] = request_id
+
+    # Wrap the generator to end parent span when streaming completes
+    async def traced_stream():
+        try:
+            async for chunk in stream_generator:
+                yield chunk
+            end_span(span, status_code=status) if tracing_active else None
+        except Exception as e:
+            end_span(span, error=e, status_code=500) if tracing_active else None
+            raise
+
     return StreamingResponse(
-        stream_generator,
+        traced_stream(),
         status_code=status,
         headers=headers_dict,
         media_type="text/event-stream",

--- a/tutorials/assets/values-12-otel-vllm.yaml
+++ b/tutorials/assets/values-12-otel-vllm.yaml
@@ -12,11 +12,18 @@ servingEngineSpec:
     requestMemory: "8Gi"
     requestGPU: 1
 
-  # environment variables for OpenTelemetry (using gRPC)
-  env:
-    - name: OTEL_SERVICE_NAME
-      value: "vllm-router"
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: "http://otel-collector:4317"
-    - name: OTEL_RESOURCE_ATTRIBUTES
-      value: "service.name=vllm-router,deployment.environment=test"
+    # OpenTelemetry tracing configuration for the engine
+    env:
+      - name: OTEL_SERVICE_NAME
+        value: "vllm-engine"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "http://otel-collector:4317"
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        value: "service.name=vllm-engine,deployment.environment=test"
+
+routerSpec:
+  # OpenTelemetry tracing configuration for the router
+  otel:
+    endpoint: "otel-collector:4317"
+    serviceName: "vllm-router"
+    secure: false


### PR DESCRIPTION
This PR adds OpenTelemetry tracing support to the vLLM production stack router, enabling end-to-end distributed tracing across the inference pipeline. When enabled via `--otel-endpoint` (or Helm's `routerSpec.otel.endpoint`), the router extracts incoming W3C Trace Context headers (`traceparent, tracestate`), creates spans for routing operations, and propagates trace context to backend vLLM engines. This allows operators to visualize the complete request flow from client through router to engine in observability platforms like Jaeger.

The implementation includes a new `experimental/otel` module with helper functions for span management, CLI arguments for configuration, Helm chart integration with schema validation, unit tests for both Python and Helm templates, and updated documentation in the distributed tracing tutorial. Tracing auto-enables when an OTLP endpoint is provided, requiring no additional feature flags.

An example command of launching vLLM Router with Otel enabled:
```
vllm-router --port 8001 --service-discovery static --static-backends "http://localhost:8000" \
--static-models "Qwen/Qwen2.5-7B-Instruct" --routing-logic roundrobin \
--otel-endpoint localhost:4317
```







FIX #773 

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

### Testing
I use my local machine for testing with following setup (Semantic Router + Production Stack integration)

```
  Envoy (8080)
      ↓
  Semantic Router (50051 gRPC / 8080 HTTP)
      ↓
  vLLM Production Stack Router (8001)  ← NEW
      ↓
  vLLM Engine (8000)

```

Without the vLLM Router enabling the Otel (you need this change of Semantic Router side https://github.com/vllm-project/semantic-router/pull/852):


<img width="3297" height="250" alt="image" src="https://github.com/user-attachments/assets/dd4c6196-6531-447f-89d7-8f1ee0e10d81" />

With vLLM Router enabling the Otel:

<img width="3297" height="286" alt="image" src="https://github.com/user-attachments/assets/317a943e-f669-44b8-b6a5-328a110b415b" />

Note: Right now only the following endpoints have this tracing gap filled

  | Endpoint             | Description          |
  |----------------------|----------------------|
  | /v1/chat/completions | Chat completions API |
  | /v1/completions      | Text completions API |
  | /v1/embeddings       | Embeddings API       |
  | /tokenize            | Tokenization         |
  | /detokenize          | Detokenization       |
  | /v1/rerank           | Reranking API (v1)   |
  | /rerank              | Reranking API        |
  | /v1/score            | Scoring API (v1)     |
  | /score               | Scoring API          |
  | /v1/responses        | Responses API        |

  Endpoints without tracing:
  - `/v1/audio/transcriptions` - uses `route_transcription_request()`
  - Disaggregated prefill requests - uses `route_disaggregated_prefill_request()`
  - Health/metrics endpoints (`/health`, `/v1/models`, etc.)







<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
