### PR TITLE
[BugFix][Feat]: fix serviceEngineSpec probe field and improve probe management in helm template

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -84,24 +84,154 @@ Define additional router ports
 Define startup, liveness and readiness probes
 */}}
 {{- define "chart.probes" -}}
-{{-   if .Values.servingEngineSpec.startupProbe  }}
+{{- if .Values.servingEngineSpec.startupProbe }}
 startupProbe:
-{{-     with .Values.servingEngineSpec.startupProbe }}
-{{-       toYaml . | nindent 2 }}
-{{-     end }}
-{{-   end }}
-{{-   if .Values.servingEngineSpec.livenessProbe  }}
+  {{- with .Values.servingEngineSpec.startupProbe }}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 15 }}
+  periodSeconds: {{ .periodSeconds | default 10 }}
+  failureThreshold: {{ .failureThreshold | default 3 }}
+  {{- if .timeoutSeconds }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  {{- end }}
+  {{- if .successThreshold }}
+  successThreshold: {{ .successThreshold }}
+  {{- end }}
+  {{- if .tcpSocket }}
+  tcpSocket:
+    {{- if .tcpSocket.host }}
+    host: {{ .tcpSocket.host }}
+    {{- end }}
+    port: {{ .tcpSocket.port }}
+  {{- end }}
+  {{- if .grpc }}
+  grpc:
+    {{- if .grpc.service }}
+    service: {{ .grpc.service }}
+    {{- end }}
+    port: {{ .grpc.port }}
+  {{- end }}
+  {{- if .exec }}
+  exec:
+    command: {{- range .exec.command }}
+      - {{.}} {{- end}}
+  {{- else }}
+  httpGet:
+    path:  {{ .httpGet.path | default "/health" }}
+    port: {{ .httpGet.port | default 8000 }}
+    {{- if .httpGet.httpHeaders }}
+    httpHeaders: {{- range .httpGet.httpHeaders }}
+      - name: {{ .name }}
+        value: {{ .value }}
+    {{- end }}
+    {{- end }}
+    {{- if .httpGet.host }}
+    host: {{ .httpGet.host }}
+    {{- end }}
+    {{- if .httpGet.scheme }}
+    scheme: {{ .httpGet.scheme }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.servingEngineSpec.livenessProbe }}
 livenessProbe:
-{{-     with .Values.servingEngineSpec.livenessProbe }}
-{{-       toYaml . | nindent 2 }}
-{{-     end }}
-{{-   end }}
-{{-   if .Values.servingEngineSpec.readinessProbe  }}
+  {{- with .Values.servingEngineSpec.livenessProbe }}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 15 }}
+  periodSeconds: {{ .periodSeconds | default 10 }}
+  failureThreshold: {{ .failureThreshold | default 3 }}
+  {{- if .timeoutSeconds }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  {{- end }}
+  {{- if .successThreshold }}
+  successThreshold: {{ .successThreshold }}
+  {{- end }}
+  {{- if .tcpSocket }}
+  tcpSocket:
+    {{- if .tcpSocket.host }}
+    host: {{ .tcpSocket.host }}
+    {{- end }}
+    port: {{ .tcpSocket.port }}
+  {{- end }}
+  {{- if .grpc }}
+  grpc:
+    {{- if .grpc.service }}
+    service: {{ .grpc.service }}
+    {{- end }}
+    port: {{ .grpc.port }}
+  {{- end }}
+  {{- if .exec }}
+  exec:
+    command: {{- range .exec.command }}
+      - {{.}} {{- end}}
+  {{- else }}
+  httpGet:
+    path:  {{ .httpGet.path | default "/health" }}
+    port: {{ .httpGet.port | default 8000 }}
+    {{- if .httpGet.httpHeaders }}
+    httpHeaders: {{- range .httpGet.httpHeaders }}
+      - name: {{ .name }}
+        value: {{ .value }}
+    {{- end }}
+    {{- end }}
+    {{- if .httpGet.host }}
+    host: {{ .httpGet.host }}
+    {{- end }}
+    {{- if .httpGet.scheme }}
+    scheme: {{ .httpGet.scheme }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.servingEngineSpec.readinessProbe }}
 readinessProbe:
-{{-     with .Values.servingEngineSpec.readinessProbe }}
-{{-       toYaml . | nindent 2 }}
-{{-     end }}
-{{-   end }}
+  {{- with .Values.servingEngineSpec.readinessProbe }}
+  initialDelaySeconds: {{ .initialDelaySeconds | default 15 }}
+  periodSeconds: {{ .periodSeconds | default 10 }}
+  failureThreshold: {{ .failureThreshold | default 3 }}
+  {{- if .timeoutSeconds }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  {{- end }}
+  {{- if .successThreshold }}
+  successThreshold: {{ .successThreshold }}
+  {{- end }}
+  {{- if .tcpSocket }}
+  tcpSocket:
+    {{- if .tcpSocket.host }}
+    host: {{ .tcpSocket.host }}
+    {{- end }}
+    port: {{ .tcpSocket.port }}
+  {{- end }}
+  {{- if .grpc }}
+  grpc:
+    {{- if .grpc.service }}
+    service: {{ .grpc.service }}
+    {{- end }}
+    port: {{ .grpc.port }}
+  {{- end }}
+  {{- if .exec }}
+  exec:
+    command: {{- range .exec.command }}
+      - {{.}} {{- end}}
+  {{- else }}
+  httpGet:
+    path:  {{ .httpGet.path | default "/health" }}
+    port: {{ .httpGet.port | default 8000 }}
+    {{- if .httpGet.httpHeaders }}
+    httpHeaders: {{- range .httpGet.httpHeaders }}
+      - name: {{ .name }}
+        value: {{ .value }}
+    {{- end }}
+    {{- end }}
+    {{- if .httpGet.host }}
+    host: {{ .httpGet.host }}
+    {{- end }}
+    {{- if .httpGet.scheme }}
+    scheme: {{ .httpGet.scheme }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- end }}
 
 {{- define "chart.hasLimits" -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -264,11 +264,11 @@ servingEngineSpec:
     failureThreshold:
       60
       # -- Configuration of the Kubelet http request on the server
-    httpGet:
-      # -- Path to access on the HTTP server
-      path: /health
-      # -- Name or number of the port to access on the container, on which the server is listening
-      port: 8000
+    #httpGet:
+    #  # -- Path to access on the HTTP server
+    #  path: /health
+    #  # -- Name or number of the port to access on the container, on which the server is listening
+    #  port: 8000
 
   # -- Liveness probe configuration
   livenessProbe:
@@ -279,11 +279,11 @@ servingEngineSpec:
     # -- How often (in seconds) to perform the liveness probe
     periodSeconds: 10
     # -- Configuration of the Kubelet http request on the server
-    httpGet:
-      # -- Path to access on the HTTP server
-      path: /health
-      # -- Name or number of the port to access on the container, on which the server is listening
-      port: 8000
+    #httpGet:
+    #  # -- Path to access on the HTTP server
+    #  path: /health
+    #  # -- Name or number of the port to access on the container, on which the server is listening
+    #  port: 8000
 
   # -- Readiness probe configuration
   readinessProbe:
@@ -294,11 +294,11 @@ servingEngineSpec:
     # -- How often (in seconds) to perform the readiness probe
     periodSeconds: 5
     # -- Configuration of the Kubelet http request on the server
-    httpGet:
-      # -- Path to access on the HTTP server
-      path: /health
-      # -- Name or number of the port to access on the container, on which the server is listening
-      port: 8000
+    #httpGet:
+    #  # -- Path to access on the HTTP server
+    #  path: /health
+    #  # -- Name or number of the port to access on the container, on which the server is listening
+    #  port: 8000
 
   # -- Disruption Budget Configuration
   maxUnavailablePodDisruptionBudget: ""


### PR DESCRIPTION
FIX https://github.com/vllm-project/production-stack/issues/807

## Changes Made
### Values File Modification: 
The serviceEngineSpec.probe.httpGet section in the values file has been commented 
Added equivalent values to the template defaults to prevent the httpGet field from being automatically included in the deployment template.
        
### Helper File Update:
Enhanced the define.probes in the helpers file.
Attempted to accommodate all possible fields to closely align with the Kubernetes probe definitions.

## Impact
These changes ensure that the httpGet field does not get unnecessarily added, thus making the Helm chart more compliant with expected Kubernetes configurations.
