### PR TITLE
[BugFix][Feat]: fix serviceEngineSpec probe field and improve probe management in helm template

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -266,9 +266,9 @@ servingEngineSpec:
       60
       # -- Configuration of the Kubelet http request on the server
     httpGet:
-    # -- Path to access on the HTTP server
+      # -- Path to access on the HTTP server
       path: /health
-    # -- Name or number of the port to access on the container, on which the server is listening
+      # -- Name or number of the port to access on the container, on which the server is listening
       port: 8000
 
   # -- Liveness probe configuration
@@ -281,9 +281,9 @@ servingEngineSpec:
     periodSeconds: 10
     # -- Configuration of the Kubelet http request on the server
     httpGet:
-    # -- Path to access on the HTTP server
+      # -- Path to access on the HTTP server
       path: /health
-    # -- Name or number of the port to access on the container, on which the server is listening
+      # -- Name or number of the port to access on the container, on which the server is listening
       port: 8000
 
   # -- Readiness probe configuration
@@ -296,9 +296,9 @@ servingEngineSpec:
     periodSeconds: 5
     # -- Configuration of the Kubelet http request on the server
     httpGet:
-    # -- Path to access on the HTTP server
+      # -- Path to access on the HTTP server
       path: /health
-    # -- Name or number of the port to access on the container, on which the server is listening
+      # -- Name or number of the port to access on the container, on which the server is listening
       port: 8000
 
   # -- Disruption Budget Configuration


### PR DESCRIPTION
FIX https://github.com/vllm-project/production-stack/issues/807
## Changes Made
### Values File Modification:

The serviceEngineSpec.probe.httpGet section in the values file has been commented
Added equivalent values to the template defaults to prevent the httpGet field from being automatically included in the deployment template.
### Helper File Update:

Enhanced the define.probes in the helpers file.
Attempted to accommodate all possible fields to closely align with the Kubernetes probe definitions.
