### PR TITLE
feat(helm): add standard Kubernetes labels to deployments and services

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -232,3 +232,15 @@ app.kubernetes.io/component: router
 app.kubernetes.io/part-of: {{ .chartName }}
 app.kubernetes.io/managed-by: helm
 {{- end -}}
+
+{{/*
+  Define standard Kubernetes labels for cache server
+  Usage: include "chart.cacheserverStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name)
+*/}}
+{{- define "chart.cacheserverStandardLabels" -}}
+app.kubernetes.io/name: cache-server
+app.kubernetes.io/instance: {{ .releaseName }}
+app.kubernetes.io/component: cache-server
+app.kubernetes.io/part-of: {{ .chartName }}
+app.kubernetes.io/managed-by: helm
+{{- end -}}

--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -5,15 +5,18 @@ metadata:
   name: "{{ .Release.Name }}-deployment-cache-server"
   namespace: {{ .Release.Namespace }}
   labels:
+  {{- include "chart.cacheserverStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}
   {{- include "chart.cacheserverLabels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
+    {{- include "chart.cacheserverStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 6 }}
     {{- include "chart.cacheserverLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
+      {{- include "chart.cacheserverStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 8 }}
       {{- include "chart.cacheserverLabels" . | nindent 8 }}
     spec:
       {{- if .Values.cacheserverSpec.priorityClassName}}

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -5,8 +5,8 @@ metadata:
   name: "{{ .Release.Name }}-deployment-router"
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "chart.routerLabels" . | nindent 4 }}
   {{- include "chart.routerStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}
+  {{- include "chart.routerLabels" . | nindent 4 }}
 spec:
 {{- if .Values.routerSpec.autoscaling.enabled }}
   replicas: {{ .Values.routerSpec.autoscaling.minReplicas }}
@@ -16,13 +16,13 @@ spec:
   {{- include "chart.routerStrategy" . | nindent 2 }}
   selector:
     matchLabels:
-    {{- include "chart.routerLabels" . | nindent 6 }}
     {{- include "chart.routerStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 6 }}
+    {{- include "chart.routerLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-      {{- include "chart.routerLabels" . | nindent 8 }}
       {{- include "chart.routerStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 8 }}
+      {{- include "chart.routerLabels" . | nindent 8 }}
       {{- with .Values.routerSpec.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -22,8 +22,8 @@ metadata:
   labels:
     model: {{ $modelSpec.name }}
     helm-release-name: {{ .Release.Name }}
-  {{- include "chart.engineLabels" . | nindent 4 }}
   {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 4 }}
+  {{- include "chart.engineLabels" . | nindent 4 }}
 spec:
   replicas: {{ $modelSpec.replicaCount }}
   {{- include "chart.engineStrategy" . | nindent 2 }}
@@ -31,8 +31,8 @@ spec:
     matchLabels:
       model: {{ $modelSpec.name }}
       helm-release-name: {{ .Release.Name }}
-    {{- include "chart.engineLabels" . | nindent 6 }}
     {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 6 }}
+    {{- include "chart.engineLabels" . | nindent 6 }}
   progressDeadlineSeconds: 1200
   template:
     metadata:
@@ -43,8 +43,8 @@ spec:
       labels:
         model: {{ $modelSpec.name }}
         helm-release-name: {{ .Release.Name }}
-      {{- include "chart.engineLabels" . | nindent 8 }}
       {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 8 }}
+      {{- include "chart.engineLabels" . | nindent 8 }}
     spec:
       {{- if $modelSpec.priorityClassName }}
       priorityClassName: {{ $modelSpec.priorityClassName | quote }}

--- a/helm/templates/scaledobject-vllm.yaml
+++ b/helm/templates/scaledobject-vllm.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     model: {{ $modelSpec.name }}
     helm-release-name: {{ .Release.Name }}
-  {{- include "chart.engineLabels" . | nindent 4 }}
   {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 4 }}
+  {{- include "chart.engineLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/helm/templates/service-cache-server.yaml
+++ b/helm/templates/service-cache-server.yaml
@@ -5,6 +5,7 @@ metadata:
   name: "{{ .Release.Name }}-cache-server-service"
   namespace: {{ .Release.Namespace }}
   labels:
+  {{- include "chart.cacheserverStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}
   {{- include "chart.cacheserverLabels" . | nindent 4 }}
 spec:
   type: ClusterIP
@@ -14,5 +15,6 @@ spec:
       targetPort: {{ .Values.cacheserverSpec.containerPort }}
       protocol: TCP
   selector:
+  {{- include "chart.cacheserverStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}
   {{- include "chart.cacheserverLabels" . | nindent 4 }}
 {{- end -}}

--- a/helm/templates/service-router.yaml
+++ b/helm/templates/service-router.yaml
@@ -8,8 +8,8 @@ metadata:
   annotations: {{- toYaml .Values.routerSpec.serviceAnnotations | nindent 4 }}
   {{- end }}
   labels:
-  {{- include "chart.routerLabels" . | nindent 4 }}
   {{- include "chart.routerStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}
+  {{- include "chart.routerLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.routerSpec.serviceType }}
   ports:
@@ -23,6 +23,6 @@ spec:
       protocol: TCP
   {{- include "chart.routerExtraPorts" $ | nindent 4 }}
   selector:
-  {{- include "chart.routerLabels" . | nindent 4 }}
   {{- include "chart.routerStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}
+  {{- include "chart.routerLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/templates/service-vllm.yaml
+++ b/helm/templates/service-vllm.yaml
@@ -7,8 +7,8 @@ metadata:
   name: "{{ $.Release.Name }}-{{ $modelSpec.name }}-engine-service"
   namespace: {{ $.Release.Namespace }}
   labels:
-  {{- include "chart.engineLabels" $ | nindent 4 }}
   {{- include "chart.engineStandardLabels" (dict "releaseName" $.Release.Name "modelName" $modelSpec.name "chartName" $.Chart.Name) | nindent 4 }}
+  {{- include "chart.engineLabels" $ | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
@@ -28,7 +28,7 @@ spec:
   selector:
     model: "{{ $modelSpec.name }}"
     helm-release-name: "{{ $.Release.Name }}"
-  {{- include "chart.engineLabels" $ | nindent 4 }}
   {{- include "chart.engineStandardLabels" (dict "releaseName" $.Release.Name "modelName" $modelSpec.name "chartName" $.Chart.Name) | nindent 4 }}
+  {{- include "chart.engineLabels" $ | nindent 4 }}
 {{- end }}
 {{- end}}


### PR DESCRIPTION
## Summary
- Add `app.kubernetes.io/*` labels to enable proper recognition by Kubernetes tools like Lens
- Labels added to engine deployments, services, and scaled objects
- Labels added to router deployment and service

## Changes
- Added `chart.engineStandardLabels` and `chart.routerStandardLabels` helpers in `_helpers.tpl`
- Applied standard labels to all relevant resources in:
  - `deployment-vllm-multi.yaml`
  - `deployment-router.yaml`
  - `service-vllm.yaml`
  - `service-router.yaml`
  - `scaledobject-vllm.yaml`

## Test plan
- [x] `helm template` renders all resources correctly
- [x] `helm lint` passes with no errors
- [x] Existing custom labels preserved (`model`, `helm-release-name`)

Closes #671