### PR TITLE
[Router][Fix]: fixed name of images/edits endpoint

### DIFF
--- a/src/vllm_router/routers/main_router.py
+++ b/src/vllm_router/routers/main_router.py
@@ -279,6 +279,6 @@ async def route_v1_images_generations(
     )
 
 
-@main_router.post("/v1/images/edit")
+@main_router.post("/v1/images/edits")
 async def route_v1_images_edit(request: Request, background_tasks: BackgroundTasks):
-    return await route_general_request(request, "/v1/images/edit", background_tasks)
+    return await route_general_request(request, "/v1/images/edits", background_tasks)


### PR DESCRIPTION
A previous PR included endpoints for audio and image API's, implemented by VLLM Omni. This PR included a typo in the `images/edit` (correctly named "edits", plural) route. This PR fixes that typo.

Tagging @ruizhang0101 as he merged the previous PR.

Apologies for the issue, we have been using this feature, but only implemented the /edit feature today, and this typo went to the previous PR unnoticed.

---

- [ X] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [ X] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [ X] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.
