### PR TITLE
fix/logs

### DIFF
--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -67,8 +67,12 @@ spec:
           {{- end }}
           - name: PYTHONHASHSEED
             value: "123"
+          {{- if .Values.routerSpec.lmcacheConfig }}
+          {{-   if hasKey .Values.routerSpec.lmcacheConfig "logLevel" }}
           - name: LMCACHE_LOG_LEVEL
-            value: "DEBUG"
+            value: {{ .Values.routerSpec.lmcacheConfig.logLevel | quote }}
+          {{-   end }}
+          {{- end }}
           {{- if .Values.servingEngineSpec.enableEngine -}}
           {{- $vllmApiKey := $.Values.servingEngineSpec.vllmApiKey }}
           {{- if $vllmApiKey }}

--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -218,8 +218,6 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           {{- with $modelSpec.vllmConfig}}
-          - name: LMCACHE_LOG_LEVEL
-            value: "DEBUG"
           {{- if and (hasKey . "v0") (eq (toString $modelSpec.vllmConfig.v0) "1") }}
           - name: VLLM_USE_V1
             value: "0"
@@ -270,6 +268,10 @@ spec:
             value: "True"
           - name: VLLM_RPC_TIMEOUT
             value: "1000000"
+          {{-   if hasKey .Values.routerSpec.lmcacheConfig "logLevel" }}
+          - name: LMCACHE_LOG_LEVEL
+            value: {{ .Values.routerSpec.lmcacheConfig.logLevel | quote }}
+          {{-   end }}
           {{-   end }}
           {{- if hasKey $modelSpec.lmcacheConfig "cudaVisibleDevices" }}
           - name: CUDA_VISIBLE_DEVICES

--- a/helm/templates/ray-cluster.yaml
+++ b/helm/templates/ray-cluster.yaml
@@ -53,8 +53,6 @@ spec:
                 value: /tmp
                 {{- end }}
               {{- with $modelSpec.vllmConfig}}
-              - name: LMCACHE_LOG_LEVEL
-                value: "DEBUG"
               {{- if hasKey . "v1" }}
               - name: VLLM_USE_V1
                 value: {{ $modelSpec.vllmConfig.v1 | quote }}
@@ -96,6 +94,13 @@ spec:
               {{- toYaml . | nindent 14 }}
               {{- end }}
               {{- if $modelSpec.lmcacheConfig }}
+              {{-   if hasKey $modelSpec.lmcacheConfig "logLevel" }}
+              - name: LMCACHE_LOG_LEVEL
+                value: {{ $modelSpec.lmcacheConfig.logLevel | quote }}
+              {{-   else }}
+              - name: LMCACHE_LOG_LEVEL
+                value: "INFO"
+              {{-   end }}
               {{-   if $modelSpec.lmcacheConfig.enabled }}
               - name: LMCACHE_USE_EXPERIMENTAL
                 value: "True"
@@ -278,8 +283,6 @@ spec:
                   value: /tmp
                   {{- end }}
                 {{- with $modelSpec.vllmConfig}}
-                - name: LMCACHE_LOG_LEVEL
-                  value: "DEBUG"
                 {{- if hasKey . "v1" }}
                 - name: VLLM_USE_V1
                   value: {{ $modelSpec.vllmConfig.v1 | quote }}
@@ -326,6 +329,10 @@ spec:
                   value: "True"
                 - name: VLLM_RPC_TIMEOUT
                   value: "1000000"
+                {{-   if hasKey .Values.routerSpec.lmcacheConfig "logLevel" }}
+                - name: LMCACHE_LOG_LEVEL
+                  value: {{ .Values.routerSpec.lmcacheConfig.logLevel | quote }}
+                {{-   end }}
                 {{-   end }}
                 {{-   if $modelSpec.lmcacheConfig.cpuOffloadingBufferSize }}
                 - name: LMCACHE_LOCAL_CPU

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -90,6 +90,7 @@ servingEngineSpec:
   # - lmcacheConfig: (optional, map) The configuration of the LMCache for KV offloading, supported options are:
   #   - enabled: (optional, bool) Enable LMCache, e.g., true
   #   - cpuOffloadingBufferSize: (optional, string) The CPU offloading buffer size, e.g., "30"
+  #   - logLevel: (optional, string) The log level for LMCache, e.g., "DEBUG", "INFO", "WARNING", "ERROR"
   #
   # - hf_token: (optional) Hugging Face token configuration. Can be either:
   #   - A string containing the token directly (will be stored in a generated secret)
@@ -199,6 +200,7 @@ servingEngineSpec:
   #   lmcacheConfig:
   #     enabled: true
   #     cpuOffloadingBufferSize: "30"
+  #     logLevel: "INFO"
   #
   #   hf_token: "hf_xxxxxxxxxxxxx"
   #


### PR DESCRIPTION
- **[Bugfix] kv aware routing for lmcache 0.3.9 (#697)**
- **[Feat] Ability to add labels to model pvc (#754)**
- **[Bugfix] Helm: Add security context support, fix #756 (#757)**
- **[Bugfix] lmcache server points to wrong file in entrypoint (#730)**
- **[Feat] Add per-model runtimeClassName configuration support (#755)**
- **bumping version (#738)**
- **[Feat] Add imagePullSecrets support for router and cache-server deployment. (#762)**
- **Add production-ready vLLM Nebius MK8s terraform stack (#748)**
- **Add resources alternative to serving engine (#729)**
- **Add responses endpoint for router (#691)**
- **fix(router): avoid startup race when scheduling sessions (#768)**
- **[Docs] Correct parameter in transcription API tutorial (#685)**
- **[Bugfix] Concurrent requests to model are currently limited to 100 due to aiohttp default (#767)**
- **Fix: Update nixlPeerHost to pd-llama-decode-engine-service (#771)**
- **[Feat] Router: Add OpenTelemetry tracing support with W3C context propagation (#772)**
- **[Feat]: Add support for chatTemplates (#779)**
- **[Build][Router] Update vllm to v0.13.0 (#770)**
- **[Feat] Add nodeSelectorTerms for vllmRunTimes (#778)**
- **Update calendar link for community meetings (#783)**
- **Update hte documentation of the semantic router deployment to use helm charts and helm command (#786)**
- **Fix incorrect import path in batch processor initialization (#784)**
- **[Build][Router] Update aiohttp (#793)**
- **Update Slack channel link in README (#798)**
- **[Doc] Remove official email link from README (#805)**
- **feat(oci): Add Oracle Cloud Infrastructure (OKE) deployment support (#794)**
- **add scaled object (#781)**
- **[CI/Build] Add stable version tags to Docker images during release (#801)**
- **Fix score payload typo and add regression test (#769)**
- **[Feat] Include runner and convert flag (#803)**
- **feat: Add servingEngineSpec environment variable (#799)**
- **[Fix] Handle missing max_tokens in disaggregated prefill requests (#797)**
- **[Router]: add routes for Image API (#820)**
- **[Router][Fix]: fixed name of images/edits endpoint (#822)**
- **Update contact information in README.md (#821)**
- **Fix OCI OKE deployment script (entry_point.sh) — end-to-end tested (#811)**
- **mention resources at the values.yaml as valid option (#806)**
- **docs: Update README for global env on servingEngineSpec (#814)**
- **feat(helm): add standard Kubernetes labels to deployments and services (#810)**
- **[BugFix][Feat]: fix serviceEngineSpec probe field and improve probe management in helm template (#809)**
- **[Bugfix] Increase router default memory size (#804)**
- **[FEAT] Add per-model token and error Prometheus metrics (part of #699) (#813)**
- **[CI/CD] Add stable router image (#823)**
- **[Feat] Add toleration for vllmRunTimes (#825)**
- **[Feat] add GPUType for resources (#829)**
- **feat: Update aiohttp and python-multipart (#831)**
- **fix: make --log-level CLI argument actually control router log levels (#832)**
- **fix: Exclude content-length from response headers in route_general_transcriptions (#733)**
- **[Feat] Reorder hfTokenSecret for vllmRunTimes (#826)**
- **feat(router): add initial support for anthropic messages endpoint (#775)**
- **[Feat] Add token redaction for logger debug (#824)**
- **refactor: replace logging.getLogger() with init_logger() across codebase (#835)**
- **[CI/CD] Add CI for crd controller (#843)**
- **Expose LMCache log level as configurable Helm value and default to INFO.**
