### PR TITLE
[Bugfix][Router] Fix dynamic config reload stuck after invalid JSON (#659)

### DIFF
--- a/src/tests/test_dynamic_config.py
+++ b/src/tests/test_dynamic_config.py
@@ -1,0 +1,250 @@
+# Copyright 2024-2025 The vLLM Production Stack Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for dynamic config watcher recovery behavior.
+
+Covers:
+- Recovery after invalid JSON config (issue #659)
+- Recovery after partial reconfiguration failure
+- Normal config change detection
+"""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from vllm_router.dynamic_config import (
+    DynamicConfigWatcher,
+    DynamicRouterConfig,
+)
+from vllm_router.utils import SingletonMeta
+
+
+def _reset_singleton():
+    """Reset the DynamicConfigWatcher singleton for test isolation."""
+    if DynamicConfigWatcher in SingletonMeta._instances:
+        del SingletonMeta._instances[DynamicConfigWatcher]
+
+
+def _make_config(routing_logic="roundrobin", **kwargs):
+    """Create a minimal DynamicRouterConfig for testing."""
+    return DynamicRouterConfig(
+        service_discovery="static",
+        routing_logic=routing_logic,
+        static_backends="http://localhost:8001",
+        static_models="test-model",
+        **kwargs,
+    )
+
+
+def _write_config(path, config_dict):
+    """Write a config dict as JSON to a file."""
+    with open(path, "w") as f:
+        json.dump(config_dict, f)
+
+
+def _write_invalid_json(path):
+    """Write invalid JSON to a file."""
+    with open(path, "w") as f:
+        f.write('{"service_discovery": "static" "routing_logic": "roundrobin"}')
+
+
+class TestDynamicConfigWatcherRecovery(unittest.TestCase):
+    """Tests for DynamicConfigWatcher recovery after errors."""
+
+    def setUp(self):
+        _reset_singleton()
+        self.tmpdir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.tmpdir, "config.json")
+        self.app = MagicMock()
+        self.app.state = MagicMock()
+
+        self.initial_config_dict = {
+            "service_discovery": "static",
+            "routing_logic": "roundrobin",
+            "static_backends": "http://localhost:8001",
+            "static_models": "test-model",
+        }
+        _write_config(self.config_path, self.initial_config_dict)
+        self.initial_config = DynamicRouterConfig(**self.initial_config_dict)
+
+    def tearDown(self):
+        if hasattr(self, "watcher") and self.watcher is not None:
+            self.watcher.close()
+        _reset_singleton()
+        if os.path.exists(self.config_path):
+            os.remove(self.config_path)
+
+    @patch.object(DynamicConfigWatcher, "reconfigure_all")
+    def test_recovery_after_invalid_json(self, mock_reconfigure_all):
+        """
+        Test that after an invalid JSON config is fixed back to the same
+        valid config, the system still triggers reconfiguration.
+        This is the core scenario from issue #659.
+        """
+        # Start watcher with a short interval
+        self.watcher = DynamicConfigWatcher(
+            config_path=self.config_path,
+            config_file_type="JSON",
+            watch_interval=1,
+            init_config=self.initial_config,
+            app=self.app,
+        )
+
+        # Wait for initial watch cycle (no change expected)
+        time.sleep(1.5)
+        mock_reconfigure_all.assert_not_called()
+
+        # Step 1: Break the config with invalid JSON
+        _write_invalid_json(self.config_path)
+        time.sleep(1.5)
+
+        # Reconfigure should NOT have been called (parse error)
+        mock_reconfigure_all.assert_not_called()
+
+        # The force_reconfigure flag should be set
+        self.assertTrue(self.watcher._force_reconfigure)
+
+        # Step 2: Fix the config back to valid (same content as initial)
+        _write_config(self.config_path, self.initial_config_dict)
+        time.sleep(1.5)
+
+        # Reconfigure SHOULD have been called despite config being identical
+        # to current_config, because _force_reconfigure was set
+        mock_reconfigure_all.assert_called_once()
+
+    @patch.object(DynamicConfigWatcher, "reconfigure_all")
+    def test_normal_config_change_detection(self, mock_reconfigure_all):
+        """Test that normal config changes are detected and applied."""
+        self.watcher = DynamicConfigWatcher(
+            config_path=self.config_path,
+            config_file_type="JSON",
+            watch_interval=1,
+            init_config=self.initial_config,
+            app=self.app,
+        )
+
+        # Change config to a different routing logic
+        new_config_dict = {**self.initial_config_dict, "routing_logic": "session"}
+        _write_config(self.config_path, new_config_dict)
+        time.sleep(1.5)
+
+        # Reconfigure should have been called
+        mock_reconfigure_all.assert_called_once()
+
+    @patch.object(DynamicConfigWatcher, "reconfigure_all")
+    def test_force_reconfigure_after_reconfigure_failure(
+        self, mock_reconfigure_all
+    ):
+        """
+        Test that after reconfigure_all fails, the system retries
+        on the next iteration even if config hasn't changed.
+        """
+        # Make reconfigure_all fail on first call, succeed on second
+        mock_reconfigure_all.side_effect = [
+            RuntimeError("Simulated reconfigure failure"),
+            None,
+        ]
+
+        self.watcher = DynamicConfigWatcher(
+            config_path=self.config_path,
+            config_file_type="JSON",
+            watch_interval=1,
+            init_config=self.initial_config,
+            app=self.app,
+        )
+
+        # Change config to trigger reconfiguration
+        new_config_dict = {**self.initial_config_dict, "routing_logic": "session"}
+        _write_config(self.config_path, new_config_dict)
+        time.sleep(1.5)
+
+        # First call should have failed
+        self.assertEqual(mock_reconfigure_all.call_count, 1)
+        self.assertTrue(self.watcher._force_reconfigure)
+
+        # Wait for retry
+        time.sleep(1.5)
+
+        # Second call should have succeeded via force retry
+        self.assertEqual(mock_reconfigure_all.call_count, 2)
+        self.assertFalse(self.watcher._force_reconfigure)
+
+
+class TestReconfigureAllRobustness(unittest.TestCase):
+    """Tests for reconfigure_all partial failure handling."""
+
+    def setUp(self):
+        _reset_singleton()
+        self.app = MagicMock()
+        self.app.state = MagicMock()
+        self.config = _make_config()
+
+    def tearDown(self):
+        if hasattr(self, "watcher") and self.watcher is not None:
+            self.watcher.close()
+        _reset_singleton()
+
+    def test_partial_failure_continues_other_subsystems(self):
+        """
+        Test that if one subsystem fails in reconfigure_all,
+        the other subsystems are still reconfigured.
+        """
+        tmpdir = tempfile.mkdtemp()
+        config_path = os.path.join(tmpdir, "config.json")
+        _write_config(config_path, {
+            "service_discovery": "static",
+            "routing_logic": "roundrobin",
+            "static_backends": "http://localhost:8001",
+            "static_models": "test-model",
+        })
+
+        self.watcher = DynamicConfigWatcher(
+            config_path=config_path,
+            config_file_type="JSON",
+            watch_interval=60,  # long interval, we'll call manually
+            init_config=self.config,
+            app=self.app,
+        )
+
+        # Mock individual reconfigure methods
+        self.watcher.reconfigure_service_discovery = MagicMock(
+            side_effect=ValueError("SD failed")
+        )
+        self.watcher.reconfigure_routing_logic = MagicMock()
+        self.watcher.reconfigure_batch_api = MagicMock()
+        self.watcher.reconfigure_stats = MagicMock()
+        self.watcher.reconfigure_callbacks = MagicMock()
+
+        # reconfigure_all should raise but all subsystems should be attempted
+        with self.assertRaises(RuntimeError):
+            self.watcher.reconfigure_all(self.config)
+
+        # Service discovery failed, but others should have been called
+        self.watcher.reconfigure_service_discovery.assert_called_once()
+        self.watcher.reconfigure_routing_logic.assert_called_once()
+        self.watcher.reconfigure_batch_api.assert_called_once()
+        self.watcher.reconfigure_stats.assert_called_once()
+        self.watcher.reconfigure_callbacks.assert_called_once()
+
+        # Cleanup
+        os.remove(config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/vllm_router/dynamic_config.py
+++ b/src/vllm_router/dynamic_config.py
@@ -145,6 +145,11 @@ class DynamicConfigWatcher(metaclass=SingletonMeta):
         self.current_config = init_config
         self.app = app
 
+        # Flag to force reconfiguration on next successful parse,
+        # even if the config hasn't changed. This is needed to recover
+        # from scenarios where a previous parse or reconfigure failed.
+        self._force_reconfigure = False
+
         # Watcher thread
         self.running = True
         self.watcher_thread = threading.Thread(target=self._watch_worker)
@@ -236,12 +241,35 @@ class DynamicConfigWatcher(metaclass=SingletonMeta):
     def reconfigure_all(self, config: DynamicRouterConfig):
         """
         Reconfigures the router with the given config.
+
+        Each sub-reconfiguration is wrapped in its own try/except to ensure
+        that a failure in one subsystem does not prevent the others from
+        being reconfigured. If any subsystem fails, the error is logged
+        and the method raises the last encountered exception so the caller
+        knows reconfiguration was not fully successful.
         """
-        self.reconfigure_service_discovery(config)
-        self.reconfigure_routing_logic(config)
-        self.reconfigure_batch_api(config)
-        self.reconfigure_stats(config)
-        self.reconfigure_callbacks(config)
+        errors = []
+        subsystems = [
+            ("service_discovery", self.reconfigure_service_discovery),
+            ("routing_logic", self.reconfigure_routing_logic),
+            ("batch_api", self.reconfigure_batch_api),
+            ("stats", self.reconfigure_stats),
+            ("callbacks", self.reconfigure_callbacks),
+        ]
+        for name, reconfigure_fn in subsystems:
+            try:
+                reconfigure_fn(config)
+            except Exception as e:
+                logger.error(
+                    f"DynamicConfigWatcher: Failed to reconfigure {name}: {e}"
+                )
+                errors.append((name, e))
+
+        if errors:
+            failed_names = ", ".join(name for name, _ in errors)
+            raise RuntimeError(
+                f"DynamicConfigWatcher: Reconfiguration failed for: {failed_names}"
+            )
 
     def _sleep_or_break(self, check_interval: float = 1):
         """
@@ -258,8 +286,17 @@ class DynamicConfigWatcher(metaclass=SingletonMeta):
         Watches the config file for changes and updates the DynamicRouterConfig accordingly.
         On every watch_interval, it will try loading the config file and compare the changes.
         If the config file has changed, it will reconfigure the system with the new config.
+
+        Recovery behavior:
+        - If the config file cannot be parsed, a force-reconfigure flag is set so that
+          the next successfully parsed config will trigger reconfiguration even if it
+          matches the current config. This handles the scenario where a user breaks the
+          config file (e.g., invalid JSON), then fixes it back to the same content.
+        - If reconfiguration partially fails, the force-reconfigure flag is also set
+          to ensure a retry on the next iteration.
         """
         while self.running:
+            # Step 1: Parse the config file
             try:
                 if self.config_file_type == "YAML":
                     config = DynamicRouterConfig.from_yaml(self.config_path)
@@ -267,15 +304,45 @@ class DynamicConfigWatcher(metaclass=SingletonMeta):
                     config = DynamicRouterConfig.from_json(self.config_path)
                 else:
                     raise ValueError("Unsupported config file type.")
-                if config != self.current_config:
-                    logger.info(
-                        "DynamicConfigWatcher: Config changed, reconfiguring..."
-                    )
-                    self.reconfigure_all(config)
-                    logger.info("DynamicConfigWatcher: Config reconfiguration complete")
-                    self.current_config = config
             except Exception as e:
-                logger.warning(f"DynamicConfigWatcher: Error loading config file: {e}")
+                logger.warning(
+                    f"DynamicConfigWatcher: Error parsing config file: {e}"
+                )
+                # Force reconfigure on next successful parse to ensure
+                # the system recovers even if the fixed config is identical
+                # to the current config.
+                self._force_reconfigure = True
+                self._sleep_or_break()
+                continue
+
+            # Step 2: Check if reconfiguration is needed
+            config_changed = config != self.current_config
+            if not config_changed and not self._force_reconfigure:
+                self._sleep_or_break()
+                continue
+
+            # Step 3: Apply the new config
+            reason = (
+                "config changed"
+                if config_changed
+                else "retrying after previous error"
+            )
+            logger.info(
+                f"DynamicConfigWatcher: Reconfiguring ({reason})..."
+            )
+            try:
+                self.reconfigure_all(config)
+                logger.info(
+                    "DynamicConfigWatcher: Config reconfiguration complete"
+                )
+                self.current_config = config
+                self._force_reconfigure = False
+            except Exception as e:
+                logger.warning(
+                    f"DynamicConfigWatcher: Error during reconfiguration: {e}"
+                )
+                # Force retry on next iteration
+                self._force_reconfigure = True
 
             self._sleep_or_break()
 


### PR DESCRIPTION
## Summary

Fixes #659

The DynamicConfigWatcher gets stuck in a bad state after encountering an invalid config file (e.g., malformed JSON with a missing comma). Even after the user fixes the config back to valid JSON, the router does not recover and requires a manual restart.

## Root Cause

The \_watch_worker\ method used a single \	ry/except\ block for both config parsing and reconfiguration. After a parse error:
1. The \current_config\ is **not** updated (stays at the last valid config)
2. When the user fixes the config **back to the same content**, the comparison \config != self.current_config\ returns \False\
3. The watcher skips reconfiguration  the system appears stuck

Additionally, \econfigure_all()\ would abort entirely if any subsystem failed, leaving the router in a partially-reconfigured state.

## Fix

### 1. Force-reconfigure flag
Added \_force_reconfigure\ flag that is set on **any error** (parse or reconfigure). On the next successful parse, reconfiguration is triggered even if the config matches \current_config\.

### 2. Separated error handling
Parse errors and reconfiguration errors are now handled in separate code paths with distinct log messages:
- \Error parsing config file\  for malformed JSON/YAML
- \Error during reconfiguration\  for failures applying the config

### 3. Resilient reconfigure_all()
Each subsystem reconfiguration is now wrapped in its own \	ry/except\. If one subsystem fails (e.g., service_discovery), the remaining subsystems (routing_logic, callbacks, etc.) are still reconfigured. The method raises an error after all subsystems have been attempted, listing which ones failed.

## Test Plan
Added unit tests in \src/tests/test_dynamic_config.py\:
- \	est_recovery_after_invalid_json\  the core scenario from #659
- \	est_normal_config_change_detection\  regression test
- \	est_force_reconfigure_after_reconfigure_failure\  partial failure recovery
- \	est_partial_failure_continues_other_subsystems\  verify remaining subsystems are configured even when one fails

Signed-off-by: NJX-njx <njx_zhuan@163.com>