### PR TITLE
fix: add API key auth header to health check requests

### DIFF
--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -121,3 +121,52 @@ def test_is_model_healthy_when_requests_status_with_status_code_not_200_returns_
     monkeypatch.setattr("requests.post", request_mock)
 
     assert utils.is_model_healthy("http://localhost", "test", "chat") is False
+
+
+def test_is_model_healthy_includes_api_key_header_when_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that VLLM_API_KEY env var is included as Authorization header."""
+    monkeypatch.setenv("VLLM_API_KEY", "test-secret-key")
+    request_mock = MagicMock(return_value=MagicMock(status_code=200))
+    monkeypatch.setattr("requests.post", request_mock)
+
+    assert utils.is_model_healthy("http://localhost", "test", "chat") is True
+
+    # Verify Authorization header was included
+    call_kwargs = request_mock.call_args
+    headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+    assert "Authorization" in headers
+    assert headers["Authorization"] == "Bearer test-secret-key"
+
+
+def test_is_model_healthy_no_auth_header_when_env_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that no Authorization header is sent when VLLM_API_KEY is not set."""
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    request_mock = MagicMock(return_value=MagicMock(status_code=200))
+    monkeypatch.setattr("requests.post", request_mock)
+
+    assert utils.is_model_healthy("http://localhost", "test", "chat") is True
+
+    # Verify no Authorization header was included
+    call_kwargs = request_mock.call_args
+    headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+    assert "Authorization" not in headers
+
+
+def test_is_model_healthy_transcription_includes_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that VLLM_API_KEY is included for transcription health checks."""
+    monkeypatch.setenv("VLLM_API_KEY", "test-key")
+    request_mock = MagicMock(return_value=MagicMock(status_code=200))
+    monkeypatch.setattr("requests.post", request_mock)
+
+    assert utils.is_model_healthy("http://localhost", "test", "transcription") is True
+
+    call_kwargs = request_mock.call_args
+    headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer test-key"

--- a/src/vllm_router/utils.py
+++ b/src/vllm_router/utils.py
@@ -2,6 +2,7 @@ import abc
 import enum
 import io
 import json
+import os
 import re
 import resource
 import wave
@@ -239,6 +240,12 @@ def update_content_length(request: Request, request_body: str):
 def is_model_healthy(url: str, model: str, model_type: str) -> bool:
     model_url = ModelType.get_url(model_type)
 
+    # Include API key header if configured, matching the pattern used
+    # throughout the codebase (e.g., service_discovery.py)
+    auth_headers = {}
+    if VLLM_API_KEY := os.getenv("VLLM_API_KEY"):
+        auth_headers["Authorization"] = f"Bearer {VLLM_API_KEY}"
+
     try:
         if model_type == "transcription":
             # for transcription, the backend expects multipart/form-data with a file
@@ -247,13 +254,14 @@ def is_model_healthy(url: str, model: str, model_type: str) -> bool:
                 f"{url}{model_url}",
                 files=ModelType.get_test_payload(model_type),  # multipart/form-data
                 data={"model": model},
+                headers=auth_headers or None,
                 timeout=10,
             )
         else:
             # for other model types (chat, completion, etc.)
             response = requests.post(
                 f"{url}{model_url}",
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": "application/json", **auth_headers},
                 json={"model": model} | ModelType.get_test_payload(model_type),
                 timeout=10,
             )


### PR DESCRIPTION
## Summary

Closes #631

Fixes health checks failing on vLLM instances that require authentication. When \VLLM_API_KEY\ environment variable is set, the \is_model_healthy()\ function now includes the \Authorization: Bearer <key>\ header in health check requests.

## Problem

When \static_backend_health_checks=True\, health checks for vLLM instances with authentication would fail because \is_model_healthy()\ only sent \Content-Type\ headers. This caused routers to incorrectly mark healthy backends as unhealthy.

## Changes

- **\src/vllm_router/utils.py\**: Added \VLLM_API_KEY\ env var lookup and \Authorization\ header to both JSON-based and multipart (transcription) health check requests. Follows the same pattern already used in \service_discovery.py\.
- **\src/tests/test_utils.py\**: Added 3 tests:
  - Auth header included when \VLLM_API_KEY\ is set
  - No auth header when \VLLM_API_KEY\ is not set
  - Auth header included for transcription-type health checks