### PR TITLE
feat: add ServiceMonitor template for external Prometheus

### DIFF
--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.externalPrometheus }}
+{{- if .Values.externalPrometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: "{{ .Release.Name }}-vllm-servicemonitor"
+  {{- if .Values.externalPrometheus.namespace }}
+  namespace: {{ .Values.externalPrometheus.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/managed-by: helm
+    {{- with .Values.externalPrometheus.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.externalPrometheus.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    {{- if .Values.externalPrometheus.serviceSelector }}
+    {{- toYaml .Values.externalPrometheus.serviceSelector | nindent 4 }}
+    {{- else }}
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: helm
+    {{- end }}
+  endpoints:
+    - port: {{ .Values.externalPrometheus.portName | default "service-port" | quote }}
+      {{- if .Values.externalPrometheus.path }}
+      path: {{ .Values.externalPrometheus.path }}
+      {{- else }}
+      path: /metrics
+      {{- end }}
+      interval: {{ .Values.externalPrometheus.interval | default "30s" }}
+      {{- if .Values.externalPrometheus.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.externalPrometheus.scrapeTimeout }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -846,6 +846,51 @@
           }
         }
       }
+    },
+    "externalPrometheus": {
+      "type": "object",
+      "description": "Configuration for creating a ServiceMonitor resource for external Prometheus operators",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable creation of a ServiceMonitor resource",
+          "default": false
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where the ServiceMonitor will be created (defaults to release namespace)"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Additional labels to add to the ServiceMonitor for Prometheus serviceMonitorSelector matching",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "serviceSelector": {
+          "type": "object",
+          "description": "Custom selector to target vLLM services"
+        },
+        "portName": {
+          "type": "string",
+          "description": "Name of the port in the Service to scrape",
+          "default": "service-port"
+        },
+        "path": {
+          "type": "string",
+          "description": "Metrics endpoint path",
+          "default": "/metrics"
+        },
+        "interval": {
+          "type": "string",
+          "description": "Scrape interval",
+          "default": "30s"
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "description": "Scrape timeout"
+        }
+      }
     }
   }
 }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -733,3 +733,28 @@ loraController:
 
 # -- Array of extra K8s manifests to deploy. Supports use of custom Helm templates
 extraObjects: []
+
+# -- Configuration for creating a ServiceMonitor resource for external Prometheus operators.
+# This allows teams with an existing Prometheus stack (e.g., kube-prometheus-stack) to scrape
+# vLLM metrics without deploying the bundled observability stack.
+externalPrometheus:
+  # -- Enable creation of a ServiceMonitor resource
+  enabled: false
+  # -- Namespace where the ServiceMonitor will be created (defaults to release namespace).
+  # Set this to the namespace where your Prometheus Operator watches for ServiceMonitors.
+  namespace: ""
+  # -- Additional labels to add to the ServiceMonitor (e.g., for Prometheus serviceMonitorSelector matching)
+  labels: {}
+  #   release: "kube-prometheus-stack"
+  # -- Custom selector to target vLLM services. Defaults to matching the Helm release instance labels.
+  serviceSelector: {}
+  #   matchLabels:
+  #     app.kubernetes.io/instance: my-release
+  # -- Name of the port in the Service to scrape (defaults to "service-port")
+  portName: "service-port"
+  # -- Metrics endpoint path (defaults to /metrics)
+  path: "/metrics"
+  # -- Scrape interval (defaults to 30s)
+  interval: "30s"
+  # -- Scrape timeout (optional)
+  scrapeTimeout: ""


### PR DESCRIPTION
## Summary

Closes #606

Adds a conditional `ServiceMonitor` Helm template that allows teams with existing Prometheus stacks (e.g., kube-prometheus-stack, EKS Blueprint addons) to scrape vLLM metrics without deploying the bundled observability stack.

## Motivation

Currently, vLLM metrics are only scraped when the bundled observability stack is installed. Users with pre-existing Prometheus setups must manually create and apply ServiceMonitor resources.

## Configuration

New `externalPrometheus` section in `values.yaml`:

```yaml
externalPrometheus:
  enabled: false
  namespace: "monitoring"
  labels:
    release: "kube-prometheus-stack"
  serviceSelector: {}
  portName: "service-port"
  path: "/metrics"
  interval: "30s"
  scrapeTimeout: ""
```

## Changes

- **`helm/templates/servicemonitor.yaml`** (new): Conditional ServiceMonitor template with namespaceSelector support for cross-namespace monitoring
- **`helm/values.yaml`**: Added `externalPrometheus` configuration section
- **`helm/values.schema.json`**: Added schema definition for `externalPrometheus`

## Backward Compatibility

Fully backward compatible - disabled by default (`enabled: false`). Existing deployments are unaffected.
