### PR TITLE
[Feat][Router] Add load-balanced KV-aware routing strategy

### DIFF
--- a/src/tests/test_load_balanced_kvaware_router.py
+++ b/src/tests/test_load_balanced_kvaware_router.py
@@ -1,0 +1,326 @@
+import math
+from typing import Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vllm_router.routers.routing_logic import LoadBalancedKvawareRouter
+
+
+class EndpointInfo:
+    def __init__(self, url: str, model_names: List[str] = None):
+        self.url = url
+        self.model_names = model_names or ["test-model"]
+
+
+class EngineStats:
+    def __init__(self, num_running_requests: int = 0, num_queuing_requests: int = 0):
+        self.num_running_requests = num_running_requests
+        self.num_queuing_requests = num_queuing_requests
+
+
+class RequestStats:
+    def __init__(self, qps: float = 0.0):
+        self.qps = qps
+
+
+class Request:
+    def __init__(self, headers: Dict[str, str] = None):
+        self.headers = headers or {}
+
+
+def _make_router(imbalanced_threshold: float = 5.0) -> LoadBalancedKvawareRouter:
+    """Create a LoadBalancedKvawareRouter without starting the KV manager."""
+    router = object.__new__(LoadBalancedKvawareRouter)
+    router.imbalanced_threshold = imbalanced_threshold
+    router.lmcache_controller_port = 9000
+    router.kv_manager = MagicMock()
+    router.req_id = 0
+    router.instance_id_to_ip = {}
+    router.session_key = None
+    router.tokenizer = None
+    router.threshold = 2000
+    router.hash_ring = MagicMock()
+    return router
+
+
+def test_get_queue_length_returns_sum():
+    stats = {"url1": EngineStats(num_running_requests=3, num_queuing_requests=7)}
+    assert LoadBalancedKvawareRouter._get_queue_length(stats, "url1") == 10
+
+
+def test_get_queue_length_missing_url_returns_zero():
+    assert LoadBalancedKvawareRouter._get_queue_length({}, "url1") == 0
+
+
+def test_get_queue_length_zero_stats():
+    stats = {"url1": EngineStats()}
+    assert LoadBalancedKvawareRouter._get_queue_length(stats, "url1") == 0
+
+
+def test_is_load_balanced_when_all_equal():
+    router = _make_router(imbalanced_threshold=5.0)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=10),
+        "b": EngineStats(num_running_requests=10),
+    }
+    assert router._is_load_balanced(endpoints, engine_stats) is True
+
+
+def test_is_load_balanced_diff_below_threshold():
+    router = _make_router(imbalanced_threshold=5.0)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=10),
+        "b": EngineStats(num_running_requests=12, num_queuing_requests=2),
+    }
+    # diff = 14 - 10 = 4 < 5
+    assert router._is_load_balanced(endpoints, engine_stats) is True
+
+
+def test_is_load_balanced_diff_equals_threshold():
+    router = _make_router(imbalanced_threshold=5.0)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=10),
+        "b": EngineStats(num_running_requests=15),
+    }
+    # diff = 5, NOT < 5 → imbalanced
+    assert router._is_load_balanced(endpoints, engine_stats) is False
+
+
+def test_is_load_balanced_diff_above_threshold():
+    router = _make_router(imbalanced_threshold=5.0)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=1),
+        "b": EngineStats(num_running_requests=20),
+    }
+    assert router._is_load_balanced(endpoints, engine_stats) is False
+
+
+def test_is_load_balanced_infinite_threshold():
+    router = _make_router(imbalanced_threshold=math.inf)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=0),
+        "b": EngineStats(num_running_requests=999, num_queuing_requests=999),
+    }
+    assert router._is_load_balanced(endpoints, engine_stats) is True
+
+
+def test_is_load_balanced_empty_endpoints():
+    router = _make_router(imbalanced_threshold=5.0)
+    assert router._is_load_balanced([], {}) is True
+
+
+def test_is_load_balanced_single_endpoint_threshold_zero():
+    router = _make_router(imbalanced_threshold=0.0)
+    endpoints = [EndpointInfo(url="a")]
+    engine_stats = {"a": EngineStats(num_running_requests=100)}
+    # diff = 0, 0 < 0 is False → imbalanced
+    assert router._is_load_balanced(endpoints, engine_stats) is False
+
+
+def test_is_load_balanced_single_endpoint_positive_threshold():
+    router = _make_router(imbalanced_threshold=1.0)
+    endpoints = [EndpointInfo(url="a")]
+    engine_stats = {"a": EngineStats(num_running_requests=100)}
+    # diff = 0 < 1 → balanced
+    assert router._is_load_balanced(endpoints, engine_stats) is True
+
+
+def test_is_load_balanced_three_endpoints_imbalanced():
+    router = _make_router(imbalanced_threshold=10.0)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b"), EndpointInfo(url="c")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=5),
+        "b": EngineStats(num_running_requests=10),
+        "c": EngineStats(num_running_requests=20),
+    }
+    # diff = 20 - 5 = 15 ≥ 10 → imbalanced
+    assert router._is_load_balanced(endpoints, engine_stats) is False
+
+
+def test_is_load_balanced_missing_stats_treated_as_zero():
+    router = _make_router(imbalanced_threshold=5.0)
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=10),
+        # "b" not in engine_stats → queue length = 0
+    }
+    # diff = 10 - 0 = 10 ≥ 5 → imbalanced
+    assert router._is_load_balanced(endpoints, engine_stats) is False
+
+
+def test_route_to_least_loaded_picks_shortest_queue():
+    router = _make_router()
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b"), EndpointInfo(url="c")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=10, num_queuing_requests=5),
+        "b": EngineStats(num_running_requests=2, num_queuing_requests=1),
+        "c": EngineStats(num_running_requests=5, num_queuing_requests=3),
+    }
+    assert router._route_to_least_loaded(endpoints, engine_stats) == "b"
+
+
+def test_route_to_least_loaded_picks_first_on_tie():
+    router = _make_router()
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=5),
+        "b": EngineStats(num_running_requests=5),
+    }
+    assert router._route_to_least_loaded(endpoints, engine_stats) == "a"
+
+
+def test_route_to_least_loaded_missing_stats_treated_as_zero():
+    router = _make_router()
+    endpoints = [EndpointInfo(url="a"), EndpointInfo(url="b")]
+    engine_stats = {
+        "a": EngineStats(num_running_requests=5),
+        # "b" missing → queue length 0
+    }
+    assert router._route_to_least_loaded(endpoints, engine_stats) == "b"
+
+
+@pytest.mark.asyncio
+async def test_route_request_imbalanced_routes_to_least_loaded():
+    router = _make_router(imbalanced_threshold=5.0)
+    endpoints = [EndpointInfo(url="http://a:8000"), EndpointInfo(url="http://b:8000")]
+    engine_stats = {
+        "http://a:8000": EngineStats(num_running_requests=1),
+        "http://b:8000": EngineStats(num_running_requests=20, num_queuing_requests=5),
+    }
+    request = Request()
+    url = await router.route_request(
+        endpoints, engine_stats, {}, request, {"prompt": "hello"}
+    )
+    assert url == "http://a:8000"
+
+
+@pytest.mark.asyncio
+async def test_route_request_threshold_zero_always_load_balances():
+    """With threshold=0, any non-zero spread triggers load balancing."""
+    router = _make_router(imbalanced_threshold=0.0)
+    endpoints = [EndpointInfo(url="http://a:8000"), EndpointInfo(url="http://b:8000")]
+    engine_stats = {
+        "http://a:8000": EngineStats(num_running_requests=5),
+        "http://b:8000": EngineStats(num_running_requests=6),
+    }
+    request = Request()
+    url = await router.route_request(
+        endpoints, engine_stats, {}, request, {"prompt": "test"}
+    )
+    assert url == "http://a:8000"
+
+
+@pytest.mark.asyncio
+async def test_route_request_imbalanced_three_endpoints():
+    """Load balancing tier with three endpoints selects the least loaded."""
+    router = _make_router(imbalanced_threshold=3.0)
+    endpoints = [
+        EndpointInfo(url="http://a:8000"),
+        EndpointInfo(url="http://b:8000"),
+        EndpointInfo(url="http://c:8000"),
+    ]
+    engine_stats = {
+        "http://a:8000": EngineStats(num_running_requests=10, num_queuing_requests=5),
+        "http://b:8000": EngineStats(num_running_requests=2),
+        "http://c:8000": EngineStats(num_running_requests=8, num_queuing_requests=3),
+    }
+    # max=15, min=2, diff=13 ≥ 3 → imbalanced
+    request = Request()
+    url = await router.route_request(
+        endpoints, engine_stats, {}, request, {"prompt": "test"}
+    )
+    assert url == "http://b:8000"
+
+
+@pytest.mark.asyncio
+async def test_route_request_balanced_falls_back_to_qps():
+    """When balanced (infinite threshold), falls back to QPS routing on empty KV hit."""
+    import vllm_router.routers.routing_logic as rl_module
+
+    router = _make_router(imbalanced_threshold=math.inf)
+    endpoints = [
+        EndpointInfo(url="http://a:8000", model_names=["test-model"]),
+        EndpointInfo(url="http://b:8000", model_names=["test-model"]),
+    ]
+    engine_stats = {
+        "http://a:8000": EngineStats(num_running_requests=10),
+        "http://b:8000": EngineStats(num_running_requests=10),
+    }
+    request_stats = {
+        "http://a:8000": RequestStats(qps=5),
+        "http://b:8000": RequestStats(qps=10),
+    }
+    request = Request()
+    request_json = {"prompt": "hello world"}
+
+    router.tokenizer = MagicMock()
+    router.tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+
+    original_lookup = getattr(rl_module, "LookupMsg", None)
+    rl_module.LookupMsg = MagicMock()
+
+    try:
+        mock_result = MagicMock()
+        mock_result.layout_info = {}
+        router.query_manager = AsyncMock(return_value=mock_result)
+
+        url = await router.route_request(
+            endpoints, engine_stats, request_stats, request, request_json
+        )
+        # Empty KV layout → QPS fallback → lowest QPS is http://a:8000
+        assert url == "http://a:8000"
+    finally:
+        if original_lookup is not None:
+            rl_module.LookupMsg = original_lookup
+        elif hasattr(rl_module, "LookupMsg"):
+            delattr(rl_module, "LookupMsg")
+
+
+@pytest.mark.asyncio
+async def test_route_request_balanced_with_session_fallback():
+    """When load is balanced and KV lookup returns no match, fallback to session routing."""
+    import vllm_router.routers.routing_logic as rl_module
+
+    router = _make_router(imbalanced_threshold=math.inf)
+    router.session_key = "x-session-id"
+    endpoints = [
+        EndpointInfo(url="http://a:8000", model_names=["test-model"]),
+        EndpointInfo(url="http://b:8000", model_names=["test-model"]),
+    ]
+    engine_stats = {
+        "http://a:8000": EngineStats(num_running_requests=5),
+        "http://b:8000": EngineStats(num_running_requests=5),
+    }
+    request = Request(headers={"x-session-id": "session-abc"})
+    request_json = {"prompt": "hello"}
+
+    router.tokenizer = MagicMock()
+    router.tokenizer.encode.return_value = [1, 2, 3]
+
+    original_lookup = getattr(rl_module, "LookupMsg", None)
+    rl_module.LookupMsg = MagicMock()
+
+    try:
+        mock_result = MagicMock()
+        mock_result.layout_info = {}
+        router.query_manager = AsyncMock(return_value=mock_result)
+
+        router.hash_ring = MagicMock()
+        router.hash_ring.get_node.return_value = "http://b:8000"
+
+        url = await router.route_request(
+            endpoints, engine_stats, {}, request, request_json
+        )
+        assert url == "http://b:8000"
+        router.hash_ring.get_node.assert_called_once_with("session-abc")
+    finally:
+        if original_lookup is not None:
+            rl_module.LookupMsg = original_lookup
+        elif hasattr(rl_module, "LookupMsg"):
+            delattr(rl_module, "LookupMsg")

--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -253,6 +253,7 @@ def initialize_all(app: FastAPI, args):
         prefill_model_labels=args.prefill_model_labels,
         decode_model_labels=args.decode_model_labels,
         kv_aware_threshold=args.kv_aware_threshold,
+        imbalanced_threshold=args.imbalanced_threshold,
         max_instance_failover_reroute_attempts=args.max_instance_failover_reroute_attempts,
         lmcache_health_check_interval=args.lmcache_health_check_interval,
         lmcache_worker_timeout=args.lmcache_worker_timeout,

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -213,6 +213,7 @@ def parse_args():
             "roundrobin",
             "session",
             "kvaware",
+            "load_balanced_kvaware",
             "prefixaware",
             "disaggregated_prefill",
             "disaggregated_prefill_orchestrated",
@@ -412,6 +413,18 @@ def parse_args():
         type=int,
         default=2000,
         help="The threshold for kv-aware routing.",
+    )
+
+    parser.add_argument(
+        "--imbalanced-threshold",
+        type=float,
+        default=float("inf"),
+        help=(
+            "Queue length difference threshold for considering load balanced. "
+            "Only used with 'load_balanced_kvaware' routing logic. "
+            "Lower values prioritize load balancing over cache locality. "
+            "Default: infinity (always use KV-aware routing)."
+        ),
     )
 
     parser.add_argument(

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -53,6 +53,7 @@ class RoutingLogic(str, enum.Enum):
     ROUND_ROBIN = "roundrobin"
     SESSION_BASED = "session"
     KVAWARE = "kvaware"
+    LOAD_BALANCED_KVAWARE = "load_balanced_kvaware"
     PREFIXAWARE = "prefixaware"
     DISAGGREGATED_PREFILL = "disaggregated_prefill"
     DISAGGREGATED_PREFILL_ORCHESTRATED = "disaggregated_prefill_orchestrated"
@@ -398,6 +399,111 @@ class KvawareRouter(RoutingInterface):
             return self.instance_id_to_ip[queried_instance_ids[0]]
 
 
+class LoadBalancedKvawareRouter(KvawareRouter):
+    """
+    Route the request using KV-aware routing with a load-balancing first tier.
+
+    Before performing KV-aware cache lookup, the router evaluates whether the
+    current load is balanced across replicas by comparing queue lengths
+    (num_running_requests + num_queuing_requests).  If the difference between
+    the highest and lowest queue lengths exceeds *imbalanced_threshold*, the
+    request is sent to the least-loaded replica so that load is re-balanced.
+    Otherwise the standard KV-aware routing logic is applied.
+
+    Args:
+        imbalanced_threshold: Queue length difference threshold for
+            considering load balanced.  Lower values prioritize load
+            balancing over cache locality.  Default is ``math.inf``
+            (always use KV-aware routing).
+    """
+
+    def __init__(
+        self,
+        lmcache_controller_port: int,
+        session_key: str,
+        kv_aware_threshold: int = 2000,
+        imbalanced_threshold: float = math.inf,
+        lmcache_health_check_interval: int = 5,
+        lmcache_worker_timeout: int = 30,
+    ):
+        super().__init__(
+            lmcache_controller_port=lmcache_controller_port,
+            session_key=session_key,
+            kv_aware_threshold=kv_aware_threshold,
+            lmcache_health_check_interval=lmcache_health_check_interval,
+            lmcache_worker_timeout=lmcache_worker_timeout,
+        )
+        self.imbalanced_threshold = imbalanced_threshold
+        logger.info(
+            f"LoadBalancedKvawareRouter initialized with "
+            f"imbalanced_threshold: {self.imbalanced_threshold}"
+        )
+
+    @staticmethod
+    def _get_queue_length(engine_stats: Dict[str, EngineStats], url: str) -> int:
+        """Return the total queue length (running + waiting) for *url*."""
+        stats = engine_stats.get(url)
+        if stats is None:
+            return 0
+        return stats.num_running_requests + stats.num_queuing_requests
+
+    def _is_load_balanced(
+        self,
+        endpoints: List[EndpointInfo],
+        engine_stats: Dict[str, EngineStats],
+    ) -> bool:
+        """Return True when the queue-length spread is within threshold."""
+        if not endpoints:
+            return True
+        lengths = [self._get_queue_length(engine_stats, ep.url) for ep in endpoints]
+        return (max(lengths) - min(lengths)) < self.imbalanced_threshold
+
+    def _route_to_least_loaded(
+        self,
+        endpoints: List[EndpointInfo],
+        engine_stats: Dict[str, EngineStats],
+    ) -> str:
+        """Return the URL of the endpoint with the shortest queue."""
+        return min(
+            endpoints, key=lambda ep: self._get_queue_length(engine_stats, ep.url)
+        ).url
+
+    async def route_request(
+        self,
+        endpoints: List[EndpointInfo],
+        engine_stats: Dict[str, EngineStats],
+        request_stats: Dict[str, RequestStats],
+        request: Request,
+        request_json: Dict,
+    ) -> str:
+        """
+        Route a request with a load-balancing first tier followed by
+        KV-aware routing.
+
+        1. **Load balance check** - compare queue lengths across replicas.
+           If the spread exceeds *imbalanced_threshold*, route to the
+           least-loaded replica immediately.
+        2. **KV-aware routing** - look up the longest prefix match in the
+           LMCache controller and route accordingly.
+        3. **Fallback** - if no suitable KV cache hit is found, fall back
+           to session-based consistent hashing or QPS-based routing.
+        """
+
+        # --- Tier 1: Load balance check ---
+        if not self._is_load_balanced(endpoints, engine_stats):
+            url = self._route_to_least_loaded(endpoints, engine_stats)
+            logger.debug(
+                f"LoadBalancedKvawareRouter: load imbalanced, routing to "
+                f"least-loaded endpoint {url}"
+            )
+            return url
+
+        # --- Tier 2 & 3: Delegate to parent KV-aware logic ---
+        return await super().route_request(
+            endpoints, engine_stats, request_stats, request, request_json
+        )
+
+
 class PrefixAwareRouter(RoutingInterface):
     """
     Route the request to the appropriate engine URL by where the longest
@@ -648,6 +754,17 @@ def initialize_routing_logic(
             lmcache_worker_timeout=kwargs.get("lmcache_worker_timeout"),
         )
         router.start_kv_manager()
+    elif routing_logic == RoutingLogic.LOAD_BALANCED_KVAWARE:
+        logger.info("Initializing load-balanced kvaware routing logic")
+        router = LoadBalancedKvawareRouter(
+            lmcache_controller_port=kwargs.get("lmcache_controller_port"),
+            session_key=kwargs.get("session_key"),
+            kv_aware_threshold=kwargs.get("kv_aware_threshold"),
+            imbalanced_threshold=kwargs.get("imbalanced_threshold", math.inf),
+            lmcache_health_check_interval=kwargs.get("lmcache_health_check_interval"),
+            lmcache_worker_timeout=kwargs.get("lmcache_worker_timeout"),
+        )
+        router.start_kv_manager()
     elif routing_logic == RoutingLogic.PREFIXAWARE:
         logger.info("Initializing prefix-aware routing logic")
         router = PrefixAwareRouter()
@@ -684,6 +801,7 @@ def get_routing_logic() -> RoutingInterface:
         SessionRouter,
         RoundRobinRouter,
         KvawareRouter,
+        LoadBalancedKvawareRouter,
         PrefixAwareRouter,
         DisaggregatedPrefillRouter,
         DisaggregatedPrefillOrchestratedRouter,
@@ -699,6 +817,7 @@ def cleanup_routing_logic():
         SessionRouter,
         RoundRobinRouter,
         KvawareRouter,
+        LoadBalancedKvawareRouter,
         PrefixAwareRouter,
         DisaggregatedPrefillRouter,
         DisaggregatedPrefillOrchestratedRouter,

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -31,6 +31,7 @@ from vllm_router.routers.routing_logic import (
     DisaggregatedPrefillOrchestratedRouter,
     DisaggregatedPrefillRouter,
     KvawareRouter,
+    LoadBalancedKvawareRouter,
     PrefixAwareRouter,
     SessionRouter,
 )
@@ -411,7 +412,8 @@ async def route_general_request(
         )
 
     elif isinstance(
-        request.app.state.router, (KvawareRouter, PrefixAwareRouter, SessionRouter)
+        request.app.state.router,
+        (KvawareRouter, LoadBalancedKvawareRouter, PrefixAwareRouter, SessionRouter),
     ):
         server_url = await request.app.state.router.route_request(
             endpoints, engine_stats, request_stats, request, request_json
@@ -459,7 +461,12 @@ async def route_general_request(
                 server_url = remaining[0].url
             elif isinstance(
                 request.app.state.router,
-                (KvawareRouter, PrefixAwareRouter, SessionRouter),
+                (
+                    KvawareRouter,
+                    LoadBalancedKvawareRouter,
+                    PrefixAwareRouter,
+                    SessionRouter,
+                ),
             ):
                 server_url = await request.app.state.router.route_request(
                     remaining, engine_stats, request_stats, request, request_json


### PR DESCRIPTION
## Add `load_balanced_kvaware` routing strategy

The existing `kvaware` router always routes based on KV cache locality (via LMCache), which can cause uneven load distribution when some replicas accumulate a large backlog while others sit idle. This PR introduces a new `load_balanced_kvaware` routing strategy that adds a load-balance check as a first tier before the KV-aware lookup, ensuring that heavily overloaded replicas are relieved before cache locality is considered.

### How it works

`LoadBalancedKvawareRouter` inherits from `KvawareRouter` and operates in three tiers:

1. **Tier 1 — Load balance check:** Compute `queue_length = num_running_requests + num_queuing_requests` for each replica. If `max(queue_lengths) - min(queue_lengths) >= imbalanced_threshold`, route immediately to the least-loaded replica.
2. **Tier 2 — KV-aware routing:** If load is balanced, delegate to the parent `KvawareRouter.route_request()` which performs the standard LMCache prefix lookup.
3. **Tier 3 — Fallback:** If no KV cache hit is found, fall back to session-based consistent hashing (if a session ID header is present) or QPS-based routing.

The default value for `--imbalanced-threshold` is `infinity`, which means the router behaves identically to `kvaware` unless the threshold is explicitly set.

### New CLI argument

| Argument | Type | Default | Description |
|---|---|---|---|
| `--imbalanced-threshold` | `float` | `inf` | Queue length spread above which load balancing takes priority over KV cache locality. Lower values prioritize load balancing. |

### Example usage

```bash
# Always KV-aware (same as kvaware)
--routing-logic load_balanced_kvaware

# Rebalance when any replica is 10+ requests ahead of the lightest
--routing-logic load_balanced_kvaware --imbalanced-threshold 10
```

### Helm values

```yaml
routerSpec:
  routingLogic: "load_balanced_kvaware"
  lmcacheControllerPort: 9000
  sessionKey: "x-user-id"
  extraArgs:
    - "--imbalanced-threshold"
    - "10"
```

### Files changed

| File | Change |
|---|---|
| `src/vllm_router/routers/routing_logic.py` | New `LoadBalancedKvawareRouter` class inheriting from `KvawareRouter`. Adds a load-balance tier and delegates KV-aware logic to the parent implementation. Registered in `initialize_routing_logic`, `get_routing_logic`, and `cleanup_routing_logic`. |
| `src/vllm_router/parsers/parser.py` | Added `load_balanced_kvaware` to `--routing-logic` choices and introduced the `--imbalanced-threshold` argument. |
| `src/vllm_router/app.py` | Passes `imbalanced_threshold` during router initialization. |
| `src/vllm_router/services/request_service/request.py` | Added `LoadBalancedKvawareRouter` to the async routing and failover retry `isinstance` checks. |
| `src/tests/test_load_balanced_kvaware_router.py` | Added 21 unit tests covering `_get_queue_length`, `_is_load_balanced`, `_route_to_least_loaded`, and end-to-end `route_request` behavior for load balancing and KV-aware fallback paths. |

---