### PR TITLE
[Doc] Fix a broken relative link in the observability README

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -14,7 +14,7 @@ Make sure to have:
 
 - A running Kubernetes (K8s) environment with GPUs
   - Run `cd utils && bash install-minikube-cluster.sh`
-  - Or follow our [tutorial](tutorials/00-install-kubernetes-env.md)
+  - Or follow our [tutorial](../tutorials/00-install-kubernetes-env.md)
 
 After that you can run:
 


### PR DESCRIPTION
## Summary
- Fixed a broken relative link in `observability/README.md` at line 17
- The link `tutorials/00-install-kubernetes-env.md` was missing the `../` prefix, causing it to resolve incorrectly from within the `observability/` subdirectory
- Corrected to `../tutorials/00-install-kubernetes-env.md`

## Test plan
- [x] Verify the link navigates correctly to `tutorials/00-install-kubernetes-env.md` from the `observability/README.md` page on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)