### PR TITLE
[Feat][Router] Add conditional disaggregated routing with threshold-based request classification

### DIFF
--- a/src/tests/test_disaggregated_prefill_router.py
+++ b/src/tests/test_disaggregated_prefill_router.py
@@ -261,3 +261,57 @@ def test_route_request_backward_compatible():
     # Decode request
     url = router.route_request(endpoints, {}, {}, req, {"max_tokens": 256})
     assert url == "http://decode1:8000"
+
+
+# --- Gap 5: Least-loaded selection tests ---
+
+
+class MockEngineStats:
+    def __init__(self, num_running_requests: int = 0, num_queuing_requests: int = 0):
+        self.num_running_requests = num_running_requests
+        self.num_queuing_requests = num_queuing_requests
+
+
+def test_least_loaded_selects_lowest_load():
+    router = DisaggregatedPrefillRouter(
+        ["prefill"], ["decode"], load_balancing_strategy="least_loaded"
+    )
+    endpoints = [
+        EndpointInfo("http://prefill1:8000", "prefill"),
+        EndpointInfo("http://prefill2:8000", "prefill"),
+    ]
+    engine_stats = {
+        "http://prefill1:8000": MockEngineStats(5, 2),
+        "http://prefill2:8000": MockEngineStats(1, 0),
+    }
+    assert router._select_prefill_endpoint(endpoints, engine_stats) == "http://prefill2:8000"
+
+
+def test_least_loaded_fallback_when_stats_missing():
+    router = DisaggregatedPrefillRouter(
+        ["prefill"], ["decode"], load_balancing_strategy="least_loaded"
+    )
+    endpoints = [
+        EndpointInfo("http://prefill1:8000", "prefill"),
+        EndpointInfo("http://prefill2:8000", "prefill"),
+    ]
+    engine_stats = {"http://prefill1:8000": MockEngineStats(5, 2)}
+    url1 = router._select_prefill_endpoint(endpoints, engine_stats)
+    url2 = router._select_prefill_endpoint(endpoints, engine_stats)
+    assert url1 == "http://prefill1:8000"
+    assert url2 == "http://prefill2:8000"
+
+
+def test_round_robin_ignores_engine_stats():
+    router = DisaggregatedPrefillRouter(
+        ["prefill"], ["decode"], load_balancing_strategy="round_robin"
+    )
+    endpoints = [
+        EndpointInfo("http://prefill1:8000", "prefill"),
+        EndpointInfo("http://prefill2:8000", "prefill"),
+    ]
+    engine_stats = {
+        "http://prefill1:8000": MockEngineStats(100, 50),
+        "http://prefill2:8000": MockEngineStats(0, 0),
+    }
+    assert router._select_prefill_endpoint(endpoints, engine_stats) == "http://prefill1:8000"

--- a/src/tests/test_xpyd_routing.py
+++ b/src/tests/test_xpyd_routing.py
@@ -1,0 +1,87 @@
+# Copyright 2024-2025 The vLLM Production Stack Authors.
+# Tests for xPyD multi-endpoint routing and dynamic disagg_spec construction.
+
+import pytest
+from unittest.mock import MagicMock
+
+from vllm_router.routers.routing_logic import DisaggregatedPrefillRouter
+from vllm_router.utils import SingletonABCMeta
+from vllm_router.services.request_service.request import _build_disagg_spec
+
+
+class EndpointInfo:
+    def __init__(self, url: str, model_label: str):
+        self.url = url
+        self.model_label = model_label
+
+
+@pytest.fixture(autouse=True)
+def clear_singleton():
+    if DisaggregatedPrefillRouter in SingletonABCMeta._instances:
+        del SingletonABCMeta._instances[DisaggregatedPrefillRouter]
+    yield
+    if DisaggregatedPrefillRouter in SingletonABCMeta._instances:
+        del SingletonABCMeta._instances[DisaggregatedPrefillRouter]
+
+
+class TestBuildDisaggSpec:
+    def test_nixl_connector_returns_none(self):
+        app_state = MagicMock()
+        assert _build_disagg_spec(app_state, "nixl", "http://dec:8000") is None
+
+    def test_lmcache_static_fallback(self):
+        app_state = MagicMock()
+        app_state.decoder_registry = {}
+        app_state.disagg_spec = {"receiver_host": "dec-0.svc"}
+        result = _build_disagg_spec(app_state, "lmcache", "http://dec:8000")
+        assert result == app_state.disagg_spec
+
+    def test_lmcache_dynamic_from_registry(self):
+        app_state = MagicMock()
+        app_state.decoder_registry = {
+            "http://dec-0:8000": {"receiver_host": "dec-0.svc"},
+            "http://dec-1:8000": {"receiver_host": "dec-1.svc"},
+        }
+        result = _build_disagg_spec(app_state, "lmcache", "http://dec-0:8000")
+        assert result["receiver_host"] == "dec-0.svc"
+        result = _build_disagg_spec(app_state, "lmcache", "http://dec-1:8000")
+        assert result["receiver_host"] == "dec-1.svc"
+
+    def test_lmcache_dynamic_returns_copy(self):
+        spec = {"receiver_host": "dec-0.svc"}
+        app_state = MagicMock()
+        app_state.decoder_registry = {"http://dec-0:8000": spec}
+        result = _build_disagg_spec(app_state, "lmcache", "http://dec-0:8000")
+        result["req_id"] = "test"
+        assert "req_id" not in spec
+
+    def test_unknown_decoder_falls_back(self):
+        app_state = MagicMock()
+        app_state.decoder_registry = {"http://dec-0:8000": {"receiver_host": "d0"}}
+        app_state.disagg_spec = {"receiver_host": "static"}
+        result = _build_disagg_spec(app_state, "lmcache", "http://unknown:8000")
+        assert result["receiver_host"] == "static"
+
+
+class TestXPyDRoundRobin:
+    def test_2p4d_distributes(self):
+        router = DisaggregatedPrefillRouter(["prefill"], ["decode"], routing_threshold=4096)
+        pf = [EndpointInfo(f"http://pf-{i}:8000", "prefill") for i in range(2)]
+        dec = [EndpointInfo(f"http://dec-{i}:8000", "decode") for i in range(4)]
+        for i in range(4):
+            assert router._select_prefill_endpoint(pf) == f"http://pf-{i % 2}:8000"
+            assert router._select_decode_endpoint(dec) == f"http://dec-{i % 4}:8000"
+
+    def test_disagg_spec_matches_decoder(self):
+        router = DisaggregatedPrefillRouter(["prefill"], ["decode"], routing_threshold=4096)
+        dec = [EndpointInfo(f"http://dec-{i}:8000", "decode") for i in range(2)]
+        registry = {
+            "http://dec-0:8000": {"receiver_host": "dec-0.svc"},
+            "http://dec-1:8000": {"receiver_host": "dec-1.svc"},
+        }
+        app_state = MagicMock()
+        app_state.decoder_registry = registry
+        for i in range(4):
+            url = router._select_decode_endpoint(dec)
+            spec = _build_disagg_spec(app_state, "lmcache", url)
+            assert spec["receiver_host"] == f"dec-{i % 2}.svc"

--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -256,8 +256,41 @@ def initialize_all(app: FastAPI, args):
         max_instance_failover_reroute_attempts=args.max_instance_failover_reroute_attempts,
         lmcache_health_check_interval=args.lmcache_health_check_interval,
         lmcache_worker_timeout=args.lmcache_worker_timeout,
-        routing_threshold=getattr(args, "routing_threshold", 0),
+        routing_threshold=args.routing_threshold,
+        load_balancing_strategy=args.load_balancing_strategy,
     )
+
+    # Initialize LMCache DPD connector state if configured
+    disagg_connector_type = getattr(args, "disagg_connector_type", "nixl")
+    app.state.disagg_connector_type = disagg_connector_type
+    app.state.decoder_registry = {}
+    if disagg_connector_type == "lmcache":
+        decoder_host = getattr(args, "decoder_host", None)
+        decoder_init_port = getattr(args, "decoder_init_port", None)
+        decoder_alloc_port = getattr(args, "decoder_alloc_port", None)
+        decoder_registry_json = getattr(args, "decoder_registry", None)
+
+        if decoder_registry_json:
+            import json as json_module
+            app.state.decoder_registry = json_module.loads(decoder_registry_json)
+            app.state.disagg_spec = None
+            logger.info(
+                f"LMCache DPD xPyD mode: {len(app.state.decoder_registry)} decoders registered"
+            )
+        elif all([decoder_host, decoder_init_port, decoder_alloc_port]):
+            app.state.disagg_spec = {
+                "receiver_host": decoder_host,
+                "receiver_init_port": [int(p) for p in decoder_init_port.split(",")],
+                "receiver_alloc_port": [int(p) for p in decoder_alloc_port.split(",")],
+            }
+            logger.info(f"LMCache DPD connector configured: decoder_host={decoder_host}")
+        else:
+            raise ValueError(
+                "When --disagg-connector-type=lmcache, provide either "
+                "--decoder-registry or --decoder-host/init-port/alloc-port"
+            )
+    else:
+        app.state.disagg_spec = None
 
     # Initialize feature gates
     initialize_feature_gates(args.feature_gates)

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -412,9 +412,57 @@ def parse_args():
         type=int,
         default=0,
         help="Token count threshold for conditional disaggregation. Requests with estimated "
-        "input tokens above this threshold go through DPD (prefill then decode). Requests "
-        "at or below this threshold are sent directly to decoder for local prefill. "
+        "input tokens at or above this threshold go through DPD (prefill then decode). Requests "
+        "below this threshold are sent directly to decoder for local prefill. "
         "Default 0 means always disaggregate (original behavior). Recommended: 4096.",
+    )
+
+    parser.add_argument(
+        "--load-balancing-strategy",
+        type=str,
+        default="round_robin",
+        choices=["round_robin", "least_loaded"],
+        help="Load balancing strategy for disaggregated prefill routing across multiple "
+        "prefill/decode endpoints. 'round_robin' (default) cycles through endpoints. "
+        "'least_loaded' routes to the endpoint with fewest running+queued requests. "
+        "Falls back to round_robin if stats unavailable.",
+    )
+
+    parser.add_argument(
+        "--disagg-connector-type",
+        type=str,
+        default="nixl",
+        choices=["nixl", "lmcache"],
+        help="DPD connector type. 'nixl' uses kv_transfer_params with do_remote_decode. "
+        "'lmcache' uses disagg_spec with ZMQ ports and ret_first_tok protocol. Default: nixl.",
+    )
+    parser.add_argument(
+        "--decoder-host",
+        type=str,
+        default=None,
+        help="Decoder hostname for LMCache disagg_spec. "
+        "Required when --disagg-connector-type=lmcache in single-decoder mode.",
+    )
+    parser.add_argument(
+        "--decoder-init-port",
+        type=str,
+        default=None,
+        help="Comma-separated decoder NIXL init ports for LMCache disagg_spec. "
+        "Required when --disagg-connector-type=lmcache in single-decoder mode.",
+    )
+    parser.add_argument(
+        "--decoder-alloc-port",
+        type=str,
+        default=None,
+        help="Comma-separated decoder NIXL alloc ports for LMCache disagg_spec. "
+        "Required when --disagg-connector-type=lmcache in single-decoder mode.",
+    )
+    parser.add_argument(
+        "--decoder-registry",
+        type=str,
+        default=None,
+        help='JSON string mapping decoder URLs to their NIXL metadata for xPyD mode. '
+        "When provided, --decoder-host/init-port/alloc-port are ignored.",
     )
 
     parser.add_argument(

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -494,10 +494,12 @@ class DisaggregatedPrefillRouter(RoutingInterface):
         prefill_model_labels: List[str],
         decode_model_labels: List[str],
         routing_threshold: int = 0,
+        load_balancing_strategy: str = "round_robin",
     ):
         self.prefill_model_labels = prefill_model_labels
         self.decode_model_labels = decode_model_labels
         self.routing_threshold = routing_threshold
+        self.load_balancing_strategy = load_balancing_strategy
         self.request_cache = {}  # Cache to store prefill results
         self._prefill_rr_idx = 0
         self._decode_rr_idx = 0
@@ -526,19 +528,69 @@ class DisaggregatedPrefillRouter(RoutingInterface):
             return total_chars // 4
         return 0
 
-    def _select_prefill_endpoint(self, prefiller_endpoints: List[EndpointInfo]) -> str:
-        """Round-robin selection among prefill endpoints."""
+    def _select_least_loaded(
+        self,
+        candidates: List[EndpointInfo],
+        engine_stats: Dict[str, EngineStats],
+    ) -> Optional[str]:
+        """Select endpoint with fewest running + queued requests.
+
+        Returns None (caller uses round-robin) if stats are unavailable.
+        """
+        if not candidates:
+            raise ValueError("No endpoints available")
+
+        best_url = None
+        best_load = float("inf")
+
+        for ep in candidates:
+            stats = engine_stats.get(ep.url)
+            if stats is None:
+                logger.debug(
+                    "Engine stats incomplete, falling back to round-robin"
+                )
+                return None
+            load = stats.num_running_requests + stats.num_queuing_requests
+            if load < best_load:
+                best_load = load
+                best_url = ep.url
+
+        logger.debug(f"Least-loaded: chose {best_url} with load={best_load}")
+        return best_url
+
+    def _select_prefill_endpoint(
+        self,
+        prefiller_endpoints: List[EndpointInfo],
+        engine_stats: Optional[Dict[str, EngineStats]] = None,
+    ) -> str:
+        """Select prefill endpoint using configured strategy."""
         if not prefiller_endpoints:
             raise ValueError("No prefill endpoints available")
+
+        if self.load_balancing_strategy == "least_loaded" and engine_stats:
+            url = self._select_least_loaded(prefiller_endpoints, engine_stats)
+            if url is not None:
+                return url
+
         sorted_eps = sorted(prefiller_endpoints, key=lambda e: e.url)
         idx = self._prefill_rr_idx % len(sorted_eps)
         self._prefill_rr_idx += 1
         return sorted_eps[idx].url
 
-    def _select_decode_endpoint(self, decoder_endpoints: List[EndpointInfo]) -> str:
-        """Round-robin selection among decode endpoints."""
+    def _select_decode_endpoint(
+        self,
+        decoder_endpoints: List[EndpointInfo],
+        engine_stats: Optional[Dict[str, EngineStats]] = None,
+    ) -> str:
+        """Select decode endpoint using configured strategy."""
         if not decoder_endpoints:
             raise ValueError("No decode endpoints available")
+
+        if self.load_balancing_strategy == "least_loaded" and engine_stats:
+            url = self._select_least_loaded(decoder_endpoints, engine_stats)
+            if url is not None:
+                return url
+
         sorted_eps = sorted(decoder_endpoints, key=lambda e: e.url)
         idx = self._decode_rr_idx % len(sorted_eps)
         self._decode_rr_idx += 1
@@ -554,7 +606,7 @@ class DisaggregatedPrefillRouter(RoutingInterface):
         if self.routing_threshold <= 0:
             return True
         estimated_tokens = self._estimate_input_tokens(request_json)
-        should_dpd = estimated_tokens > self.routing_threshold
+        should_dpd = estimated_tokens >= self.routing_threshold
         logger.info(
             f"Conditional routing: estimated_tokens={estimated_tokens}, "
             f"threshold={self.routing_threshold}, disaggregate={should_dpd}"
@@ -589,9 +641,9 @@ class DisaggregatedPrefillRouter(RoutingInterface):
             e for e in endpoints if e.model_label in self.decode_model_labels
         ]
         if is_prefill:
-            return self._select_prefill_endpoint(prefiller_endpoints)
+            return self._select_prefill_endpoint(prefiller_endpoints, engine_stats)
         else:
-            return self._select_decode_endpoint(decoder_endpoints)
+            return self._select_decode_endpoint(decoder_endpoints, engine_stats)
 
 
 class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
@@ -731,6 +783,7 @@ def initialize_routing_logic(
             kwargs.get("prefill_model_labels"),
             kwargs.get("decode_model_labels"),
             routing_threshold=kwargs.get("routing_threshold", 0),
+            load_balancing_strategy=kwargs.get("load_balancing_strategy", "round_robin"),
         )
     elif routing_logic == RoutingLogic.DISAGGREGATED_PREFILL_ORCHESTRATED:
         logger.info("Initializing disaggregated prefill orchestrated routing logic")

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -527,27 +527,38 @@ async def route_general_request(
 
 
 async def send_request_to_prefiller(
-    client: aiohttp.ClientSession, endpoint: str, req_data: dict, request_id: str
+    client: aiohttp.ClientSession,
+    endpoint: str,
+    req_data: dict,
+    request_id: str,
+    disagg_connector_type: str = "nixl",
+    disagg_spec: dict = None,
+    base_url: str = None,
 ):
     """Send a request to a prefiller service.
 
-    Supports both LMCache-based DPD (ZMQ side-channel) and NixlConnector-based DPD
-    (kv_transfer_params in request/response). Returns the prefill response JSON so
-    the caller can extract kv_transfer_params if present.
+    Supports both LMCache-based DPD (disagg_spec + ret_first_tok) and NixlConnector-based
+    DPD (kv_transfer_params with do_remote_decode).
     """
     req_data = req_data.copy()
     req_data["max_tokens"] = 1
     if "max_completion_tokens" in req_data:
         req_data["max_completion_tokens"] = 1
 
-    # For NixlConnector: signal that this is a DPD prefill request
-    if "kv_transfer_params" not in req_data:
+    if disagg_connector_type == "lmcache" and disagg_spec is not None:
+        spec = disagg_spec.copy()
+        spec["req_id"] = request_id
+        req_data["kv_transfer_params"] = {
+            "ret_first_tok": True,
+            "disagg_spec": spec,
+        }
+        req_data.pop("min_tokens", None)
+    elif "kv_transfer_params" not in req_data:
         req_data["kv_transfer_params"] = {
             "do_remote_decode": True,
             "do_remote_prefill": False,
         }
 
-    # Force non-streaming for prefill (need full response for kv_transfer_params)
     req_data["stream"] = False
     req_data.pop("stream_options", None)
 
@@ -556,13 +567,19 @@ async def send_request_to_prefiller(
         "X-Request-Id": request_id,
     }
 
-    async with client.post(endpoint, json=req_data, headers=headers) as response:
+    url = f"{base_url}{endpoint}" if base_url else endpoint
+
+    async with client.post(url, json=req_data, headers=headers) as response:
         response.raise_for_status()
         return await response.json()
 
 
 async def send_request_to_decode(
-    client: aiohttp.ClientSession, endpoint: str, req_data: dict, request_id: str
+    client: aiohttp.ClientSession,
+    endpoint: str,
+    req_data: dict,
+    request_id: str,
+    base_url: str = None,
 ):
     """Asynchronously stream the response from a service using a persistent client."""
     headers = {
@@ -570,10 +587,29 @@ async def send_request_to_decode(
         "X-Request-Id": request_id,
     }
 
-    async with client.post(endpoint, json=req_data, headers=headers) as response:
+    url = f"{base_url}{endpoint}" if base_url else endpoint
+
+    async with client.post(url, json=req_data, headers=headers) as response:
         response.raise_for_status()
         async for chunk in response.content.iter_any():
             yield chunk
+
+
+def _build_disagg_spec(app_state, disagg_connector_type: str, decode_base_url: str) -> dict:
+    """Build disagg_spec for the selected decoder endpoint.
+
+    For LMCache connector, constructs a disagg_spec with the selected decoder's
+    NIXL metadata. Supports both static (legacy) and dynamic (xPyD) modes.
+    For NixlConnector, returns None.
+    """
+    if disagg_connector_type != "lmcache":
+        return None
+
+    decoder_registry = getattr(app_state, "decoder_registry", None)
+    if decoder_registry and decode_base_url in decoder_registry:
+        return decoder_registry[decode_base_url].copy()
+
+    return getattr(app_state, "disagg_spec", None)
 
 
 async def route_orchestrated_disaggregated_request(
@@ -782,49 +818,97 @@ async def route_disaggregated_prefill_request(
     background_tasks: BackgroundTasks,
 ):
     in_router_time = time.time()
-    # Same as vllm, Get request_id from X-Request-Id header if available
     request_id = request.headers.get("X-Request-Id") or str(uuid.uuid4())
     request_json = await request.json()
 
-    # Check conditional disaggregation: short inputs bypass DPD
+    # Use router to select prefill and decode endpoints
     router = request.app.state.router
+    service_discovery = get_service_discovery()
+    endpoints = service_discovery.get_endpoint_info()
+    engine_stats = getattr(request.app.state, "engine_stats", {})
+
+    prefiller_endpoints = [
+        e for e in endpoints if e.model_label in router.prefill_model_labels
+    ]
+    decoder_endpoints = [
+        e for e in endpoints if e.model_label in router.decode_model_labels
+    ]
+
+    decode_base_url = router._select_decode_endpoint(decoder_endpoints, engine_stats)
+
+    # Check conditional disaggregation: short inputs bypass DPD
     if not router.should_disaggregate(request_json):
-        # Direct-to-decoder path: send as normal request (local chunked prefill)
         logger.info(
-            f"{request_id} below routing threshold, sending directly to decoder"
+            f"{request_id} below routing threshold, sending directly to decoder {decode_base_url}"
         )
         return await _route_direct_to_decoder(
-            request, endpoint, request_json, request_id, background_tasks
+            request, endpoint, request_json, request_id, background_tasks,
+            decode_base_url=decode_base_url,
         )
 
-    # DPD path: prefill on prefiller, then stream from decoder
-    # Save original request for decode phase
-    orig_request_json = request_json.copy()
+    prefill_base_url = router._select_prefill_endpoint(prefiller_endpoints, engine_stats)
 
-    # Prepare prefill request: set max_tokens=1 and remove max_completion_tokens
-    # (max_completion_tokens takes precedence over max_tokens in OpenAI API,
-    # so we must remove it to ensure prefill generates only 1 token)
+    disagg_connector_type = getattr(request.app.state, "disagg_connector_type", "nixl")
+    disagg_spec = _build_disagg_spec(request.app.state, disagg_connector_type, decode_base_url)
+
+    # DPD path
+    orig_request_json = request_json.copy()
+    orig_max_tokens = request_json.get("max_tokens", 0)
+    orig_min_tokens = request_json.get("min_tokens", None)
+
     request_json["max_tokens"] = 1
     request_json.pop("max_completion_tokens", None)
 
     st = time.time()
     try:
         prefill_response = await send_request_to_prefiller(
-            request.app.state.prefill_client, endpoint, request_json, request_id
+            request.app.state.prefill_client,
+            endpoint,
+            request_json,
+            request_id,
+            disagg_connector_type=disagg_connector_type,
+            disagg_spec=disagg_spec,
+            base_url=prefill_base_url,
         )
         et = time.time()
         logger.info(f"{request_id} prefill time (TTFT): {et - st:.4f}")
         logger.info(
-            f"Routing request {request_id} with session id None to {request.app.state.prefill_client._base_url} at {et}, process time = {et - in_router_time:.4f}"
+            f"Routing request {request_id} to {prefill_base_url} at {et}, "
+            f"process time = {et - in_router_time:.4f}"
         )
-        # Use original request for decode phase
         request_json = orig_request_json
+        request_json["max_tokens"] = orig_max_tokens
 
-        # Forward kv_transfer_params from prefiller to decoder (NixlConnector support)
-        kv_transfer_params = prefill_response.get("kv_transfer_params")
-        if kv_transfer_params:
-            request_json["kv_transfer_params"] = kv_transfer_params
-            logger.info(f"{request_id} forwarding kv_transfer_params to decoder")
+        if disagg_connector_type == "lmcache":
+            kv_params = prefill_response.get("kv_transfer_params", {})
+            first_tok = kv_params.get("first_tok")
+
+            prompt = request_json.get("prompt", None)
+            if isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], int):
+                token_ids = prompt
+            else:
+                token_ids = prompt if isinstance(prompt, list) else []
+
+            if first_tok is not None:
+                token_ids = list(token_ids) + [first_tok]
+                request_json["prompt"] = token_ids
+                request_json["max_tokens"] = orig_max_tokens - 1
+                if orig_min_tokens is not None and orig_min_tokens > 1:
+                    request_json["min_tokens"] = orig_min_tokens - 1
+                logger.info(
+                    f"{request_id} LMCache: appended first_tok={first_tok}, "
+                    f"prompt now {len(token_ids)} tokens"
+                )
+            else:
+                logger.warning(f"{request_id} LMCache: no first_tok in prefill response")
+
+            request_json.pop("kv_transfer_params", None)
+            request_json.pop("messages", None)
+        else:
+            kv_transfer_params = prefill_response.get("kv_transfer_params")
+            if kv_transfer_params:
+                request_json["kv_transfer_params"] = kv_transfer_params
+                logger.info(f"{request_id} forwarding kv_transfer_params to decoder")
     except aiohttp.ClientResponseError as e:
         logger.error(f"HTTP error in prefiller: {e}", exc_info=True)
         return JSONResponse(
@@ -855,19 +939,15 @@ async def route_disaggregated_prefill_request(
     async def generate_stream():
         try:
             async for chunk in send_request_to_decode(
-                request.app.state.decode_client, endpoint, request_json, request_id
+                request.app.state.decode_client, endpoint, request_json, request_id,
+                base_url=decode_base_url,
             ):
                 yield chunk
         except aiohttp.ClientResponseError as e:
             logger.error(f"HTTP error in decoder: {e}", exc_info=True)
-            try:
-                error_text = e.message
-            except Exception:
-                error_text = f"HTTP {e.status}"
-            # Yield error as JSON response
             error_response = {
                 "error": {
-                    "message": f"Decoder error: {error_text}",
+                    "message": f"Decoder error: {e.message}",
                     "type": "decoder_error",
                     "code": e.status,
                 }
@@ -875,7 +955,6 @@ async def route_disaggregated_prefill_request(
             yield json.dumps(error_response).encode("utf-8")
         except Exception as e:
             logger.error(f"Unexpected error in decoder: {e}", exc_info=True)
-            # Yield error as JSON response
             error_response = {
                 "error": {
                     "message": f"Decoder error: {str(e)}",
@@ -887,7 +966,8 @@ async def route_disaggregated_prefill_request(
 
     curr_time = time.time()
     logger.info(
-        f"Routing request {request_id} with session id None to {request.app.state.decode_client._base_url} at {curr_time}, process time = {curr_time - et:.4f}"
+        f"Routing request {request_id} to decoder {decode_base_url} at {curr_time}, "
+        f"process time = {curr_time - et:.4f}"
     )
 
     return StreamingResponse(
@@ -903,18 +983,16 @@ async def _route_direct_to_decoder(
     request_json: dict,
     request_id: str,
     background_tasks: BackgroundTasks,
+    decode_base_url: str = None,
 ):
-    """Route request directly to decoder, bypassing DPD.
-
-    Used for short-input requests where local chunked prefill on the decoder
-    is faster than remote prefill + KV transfer.
-    """
+    """Route request directly to decoder, bypassing DPD."""
     st = time.time()
 
     async def generate_stream():
         try:
             async for chunk in send_request_to_decode(
-                request.app.state.decode_client, endpoint, request_json, request_id
+                request.app.state.decode_client, endpoint, request_json, request_id,
+                base_url=decode_base_url,
             ):
                 yield chunk
         except aiohttp.ClientResponseError as e:
@@ -940,8 +1018,7 @@ async def _route_direct_to_decoder(
 
     curr_time = time.time()
     logger.info(
-        f"Direct-to-decoder request {request_id} to "
-        f"{request.app.state.decode_client._base_url} at {curr_time}, "
+        f"Direct-to-decoder request {request_id} to {decode_base_url} at {curr_time}, "
         f"process time = {curr_time - st:.4f}"
     )
 


### PR DESCRIPTION
Add conditional disaggregated prefill/decode (DPD) routing and multi-endpoint load balancing to DisaggregatedPrefillRouter.

## Conditional Routing

Add `routing_threshold` parameter that routes requests based on estimated input token count. Requests at or above the threshold go through the DPD path (remote prefill, then stream from decoder). Requests below the threshold bypass DPD and go directly to the decoder for local chunked prefill, which is faster for short inputs.

- Token estimation via char/4 heuristic (string prompts, chat messages) or direct length (token ID lists)
- Configurable `--routing-threshold` CLI arg (default 0 = always disaggregate, preserving backward compatibility)
- Direct-to-decoder path with `_route_direct_to_decoder()` for short-input requests
- `kv_transfer_params` forwarding from prefiller to decoder for NixlConnector DPD support
- `>=` boundary: requests exactly at threshold go through DPD

## xPyD Load Balancing

Add multi-endpoint load balancing across prefill and decode pools for xPyD topologies (e.g., 2P:1D, 1P:2D).

- `--load-balancing-strategy` CLI arg: `round_robin` (default) or `least_loaded`
- Least-loaded strategy uses `engine_stats` (running + queued requests), falls back to round-robin when stats unavailable
- `--disagg-connector-type` CLI arg: `nixl` (default) or `lmcache`
- LMCache DPD protocol: `disagg_spec` injection, `ret_first_tok` handling, first token extraction and prompt augmentation
- `--decoder-registry` JSON arg for xPyD mode with per-decoder NIXL metadata
- `--decoder-host/init-port/alloc-port` for single-decoder legacy mode
- `_build_disagg_spec()` for dynamic per-request decoder spec construction
- `base_url` parameter on `send_request_to_prefiller`/`send_request_to_decode` for shared HTTP client


## Tests

- 22 unit tests for conditional routing: token estimation, threshold logic, boundary conditions, round-robin selection, backward compatibility
- 7 unit tests for xPyD: `_build_disagg_spec` (static/dynamic/fallback), round-robin distribution across 2P:4D topology, disagg_spec-decoder consistency
- 3 unit tests for least-loaded: selection, fallback, round-robin ignoring stats
- Validated with 410+ workload configurations on P5 (8xH100) cross-node DPD with EFA LIBFABRIC. Zero regression vs NixlConnector on TTFT, ITL, E2E latency, and throughput.

---

- [x] Make sure the code changes pass the pre-commit checks.
- [x] Sign-off your commit by using `-s` when doing `git commit`
- [x] Try to classify PRs for easy understanding of the type of
      changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.


<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
