### PR TITLE
[Router] Add phase 1 router queue groundwork

### DIFF
--- a/src/tests/test_engine_stats.py
+++ b/src/tests/test_engine_stats.py
@@ -1,0 +1,147 @@
+import threading
+from unittest.mock import MagicMock, patch
+
+from vllm_router.stats.engine_stats import EngineStats, EngineStatsScraper
+
+
+def make_scraper():
+    scraper = object.__new__(EngineStatsScraper)
+    scraper.engine_stats = {}
+    scraper.engine_stats_lock = threading.Lock()
+    scraper.scrape_interval = 30.0
+    scraper.admission_scrape_interval = 1.0
+    scraper.on_metrics_update = None
+    scraper.running = False
+    scraper._stop_event = threading.Event()
+    return scraper
+
+
+def test_queue_only_scrape_merges_waiting_count_without_mutating_existing_stats():
+    scraper = make_scraper()
+    existing_stats = EngineStats(
+        num_running_requests=7,
+        num_queuing_requests=2,
+        gpu_prefix_cache_hit_rate=0.2,
+        gpu_prefix_cache_hits_total=11,
+        gpu_prefix_cache_queries_total=17,
+        gpu_cache_usage_perc=0.5,
+    )
+    scraper.engine_stats = {"http://engine1": existing_stats}
+    scraped_stats = EngineStats(
+        num_running_requests=99,
+        num_queuing_requests=5,
+        gpu_prefix_cache_hit_rate=0.9,
+        gpu_prefix_cache_hits_total=99,
+        gpu_prefix_cache_queries_total=99,
+        gpu_cache_usage_perc=0.9,
+    )
+
+    endpoint = MagicMock(url="http://engine1")
+    with (
+        patch(
+            "vllm_router.stats.engine_stats.get_service_discovery",
+            return_value=MagicMock(
+                get_endpoint_info=MagicMock(return_value=[endpoint])
+            ),
+        ),
+        patch.object(scraper, "_scrape_one_endpoint", return_value=scraped_stats),
+    ):
+        scraper._scrape_metrics(queue_only=True)
+
+    updated_stats = scraper.engine_stats["http://engine1"]
+    assert updated_stats is not existing_stats
+    assert updated_stats.num_queuing_requests == 5
+    assert updated_stats.num_running_requests == 7
+    assert updated_stats.gpu_prefix_cache_hit_rate == 0.2
+    assert updated_stats.gpu_prefix_cache_hits_total == 11
+    assert updated_stats.gpu_prefix_cache_queries_total == 17
+    assert updated_stats.gpu_cache_usage_perc == 0.5
+
+
+def test_scrape_one_endpoint_uses_mode_specific_timeout():
+    scraper = make_scraper()
+    mock_response = MagicMock()
+    mock_response.text = ""
+    mock_response.raise_for_status.return_value = None
+
+    with (
+        patch(
+            "vllm_router.stats.engine_stats.requests.get", return_value=mock_response
+        ) as mock_get,
+        patch(
+            "vllm_router.stats.engine_stats.EngineStats.from_vllm_scrape",
+            return_value=EngineStats(),
+        ),
+    ):
+        scraper._scrape_one_endpoint("http://engine1", queue_only=False)
+        scraper._scrape_one_endpoint("http://engine1", queue_only=True)
+
+    assert mock_get.call_args_list[0].kwargs["timeout"] == scraper.scrape_interval
+    assert (
+        mock_get.call_args_list[1].kwargs["timeout"]
+        == scraper.admission_scrape_interval
+    )
+
+
+def _scrape(scraper, endpoint_urls, scrape_fn, queue_only):
+    endpoints = [MagicMock(url=u) for u in endpoint_urls]
+    with (
+        patch(
+            "vllm_router.stats.engine_stats.get_service_discovery",
+            return_value=MagicMock(get_endpoint_info=MagicMock(return_value=endpoints)),
+        ),
+        patch.object(scraper, "_scrape_one_endpoint", side_effect=scrape_fn),
+    ):
+        scraper._scrape_metrics(queue_only=queue_only)
+
+
+def test_queue_only_scrape_does_not_evict_endpoint_that_failed_to_respond():
+    """An admission scrape uses a tight timeout, so a transient miss must not
+    drop the endpoint's full stats until the next full scrape."""
+    scraper = make_scraper()
+    healthy = EngineStats(num_running_requests=7, num_queuing_requests=2)
+    scraper.engine_stats = {"http://engine1": healthy, "http://engine2": healthy}
+
+    def flaky(url, queue_only=False):
+        if url == "http://engine1":
+            return None  # timed out
+        return EngineStats(num_running_requests=99, num_queuing_requests=5)
+
+    _scrape(scraper, ["http://engine1", "http://engine2"], flaky, queue_only=True)
+
+    assert "http://engine1" in scraper.engine_stats
+    assert scraper.engine_stats["http://engine1"] == healthy
+    assert scraper.engine_stats["http://engine2"].num_queuing_requests == 5
+    assert scraper.engine_stats["http://engine2"].num_running_requests == 7
+
+
+def test_queue_only_scrape_does_not_insert_unknown_endpoint():
+    """Endpoints discovered since the last full scrape are left to it, so a
+    partially-filled record is never published."""
+    scraper = make_scraper()
+    scraper.engine_stats = {}
+
+    _scrape(
+        scraper,
+        ["http://new-engine"],
+        lambda url, queue_only=False: EngineStats(num_queuing_requests=4),
+        queue_only=True,
+    )
+
+    assert scraper.engine_stats == {}
+
+
+def test_full_scrape_still_reconciles_membership():
+    """Membership reconciliation remains the full scrape's job."""
+    scraper = make_scraper()
+    scraper.engine_stats = {"http://gone": EngineStats(num_running_requests=1)}
+
+    _scrape(
+        scraper,
+        ["http://engine1"],
+        lambda url, queue_only=False: EngineStats(num_running_requests=3),
+        queue_only=False,
+    )
+
+    assert "http://gone" not in scraper.engine_stats
+    assert scraper.engine_stats["http://engine1"].num_running_requests == 3

--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -151,6 +151,72 @@ def test_validate_args_when_service_discovery_is_set_to_static_and_static_backen
         )
 
 
+def test_validate_args_when_router_queue_enabled_with_non_roundrobin_raises_value_error() -> (
+    None
+):
+    with pytest.raises(ValueError):
+        parser.validate_args(
+            MagicMock(
+                routing_logic="session",
+                service_discovery="static",
+                static_backends="http://localhost:8000",
+                static_models="m1",
+                static_backend_health_checks=False,
+                enable_router_queue=True,
+                router_max_queued_requests=10,
+                router_max_queue_wait_seconds=5.0,
+                router_waiting_threshold_per_endpoint=1,
+                router_admission_scrape_interval_seconds=1.0,
+            )
+        )
+
+
+def test_validate_args_when_router_queue_size_is_not_positive_raises_value_error() -> (
+    None
+):
+    with pytest.raises(ValueError):
+        parser.validate_args(
+            MagicMock(
+                routing_logic="roundrobin",
+                service_discovery="static",
+                static_backends="http://localhost:8000",
+                static_models="m1",
+                static_backend_health_checks=False,
+                enable_router_queue=True,
+                router_max_queued_requests=0,
+                router_max_queue_wait_seconds=5.0,
+                router_waiting_threshold_per_endpoint=1,
+                router_admission_scrape_interval_seconds=1.0,
+            )
+        )
+
+
+def test_validate_args_skips_router_queue_checks_when_queue_disabled() -> None:
+    """Queue settings are inert unless the queue is on, so they are not validated."""
+    parser.validate_args(
+        MagicMock(
+            routing_logic="session",
+            session_key="x-session-id",
+            service_discovery="static",
+            static_backends="http://localhost:8000",
+            static_models="m1",
+            static_backend_health_checks=False,
+            enable_router_queue=False,
+            # Invalid on purpose: these must not be inspected while disabled.
+            router_max_queued_requests=0,
+            router_max_queue_wait_seconds=0,
+            router_waiting_threshold_per_endpoint=0,
+            router_admission_scrape_interval_seconds=0,
+            # Unrelated checks further down validate_args.
+            log_stats=False,
+            engine_stats_interval=10,
+            request_stats_window=60,
+            sentry_traces_sample_rate=0.1,
+            sentry_profile_session_sample_rate=1.0,
+        )
+    )
+
+
 def test_validate_static_model_types_when_model_types_is_not_defines_raises_value_error() -> (
     None
 ):

--- a/src/tests/test_roundrobin_router.py
+++ b/src/tests/test_roundrobin_router.py
@@ -3,6 +3,7 @@ from collections import Counter
 from typing import Dict, List, Tuple
 
 import pytest
+from fastapi import HTTPException
 
 from vllm_router.routers.routing_logic import RoundRobinRouter, cleanup_routing_logic
 
@@ -133,3 +134,45 @@ def test_roundrobin_rejects_empty_endpoint_list():
 
     with pytest.raises(ValueError, match="at least one endpoint"):
         router.route_request([], {}, {}, generate_request())
+
+
+def test_pick_admissible_endpoint_skips_inadmissible_endpoints():
+    """The cursor walks past rejected endpoints and lands on the first accepted one."""
+    router = RoundRobinRouter()
+    endpoints = [EndpointInfo(url=f"e{i}") for i in range(4)]
+
+    # e0 is next in round-robin order, but only e2 is admissible.
+    chosen = router.pick_admissible_endpoint(endpoints, lambda e: e.url == "e2")
+    assert chosen.url == "e2"
+
+    # The cursor advanced past e2, so an always-admissible pick resumes at e3.
+    assert router.pick_admissible_endpoint(endpoints, lambda _: True).url == "e3"
+
+
+def test_pick_admissible_endpoint_returns_none_when_nothing_admissible():
+    router = RoundRobinRouter()
+    endpoints = [EndpointInfo(url="e0"), EndpointInfo(url="e1")]
+
+    assert router.pick_admissible_endpoint(endpoints, lambda _: False) is None
+
+
+def test_pick_admissible_endpoint_keeps_cursor_when_nothing_admissible():
+    """A fully-rejected pass must not consume a slot, or endpoints get starved."""
+    router = RoundRobinRouter()
+    endpoints = [EndpointInfo(url="e0"), EndpointInfo(url="e1")]
+
+    assert router.pick_admissible_endpoint(endpoints, lambda _: False) is None
+    assert router.pick_admissible_endpoint(endpoints, lambda _: True).url == "e0"
+
+
+def test_route_request_raises_503_when_no_endpoint_admissible(monkeypatch):
+    """Guards the `chosen is None` path once a real admission predicate exists."""
+    router = RoundRobinRouter()
+    endpoints = [EndpointInfo(url="e0")]
+    monkeypatch.setattr(router, "pick_admissible_endpoint", lambda *a, **kw: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        router.route_request(endpoints, {}, {}, generate_request())
+
+    assert exc_info.value.status_code == 503
+    assert "NO_ADMISSIBLE_ENDPOINT" in exc_info.value.detail

--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -243,7 +243,15 @@ def initialize_all(app: FastAPI, args):
         raise ValueError(f"Invalid service discovery type: {args.service_discovery}")
 
     # Initialize singletons via custom functions.
-    initialize_engine_stats_scraper(args.engine_stats_interval)
+    app.state.admission_controller = None
+    initialize_engine_stats_scraper(
+        args.engine_stats_interval,
+        admission_scrape_interval=(
+            args.router_admission_scrape_interval_seconds
+            if args.enable_router_queue
+            else None
+        ),
+    )
     initialize_request_stats_monitor(args.request_stats_window)
 
     if args.enable_batch_api:

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -90,6 +90,10 @@ def validate_static_model_types(model_types: str | None) -> None:
 
 # --- Argument Parsing and Initialization ---
 def validate_args(args):
+    def _get_numeric_arg(name: str, default):
+        value = getattr(args, name, default)
+        return value if isinstance(value, (int, float)) else default
+
     verify_required_args_provided(args)
     if args.service_discovery == "static":
         if args.static_backends is None:
@@ -108,6 +112,25 @@ def validate_args(args):
         raise ValueError(
             "Session key must be provided when using session routing logic."
         )
+    # The router queue settings only take effect when the queue is enabled, so
+    # they are only validated in that case.
+    if getattr(args, "enable_router_queue", False) is True:
+        if args.routing_logic != "roundrobin":
+            raise ValueError(
+                "Router queue is only supported with roundrobin routing in phase 1."
+            )
+        if _get_numeric_arg("router_max_queued_requests", 256) <= 0:
+            raise ValueError("Router max queued requests must be greater than 0.")
+        if _get_numeric_arg("router_max_queue_wait_seconds", 5.0) <= 0:
+            raise ValueError("Router max queue wait seconds must be greater than 0.")
+        if _get_numeric_arg("router_waiting_threshold_per_endpoint", 1) <= 0:
+            raise ValueError(
+                "Router waiting threshold per endpoint must be greater than 0."
+            )
+        if _get_numeric_arg("router_admission_scrape_interval_seconds", 1.0) <= 0:
+            raise ValueError(
+                "Router admission scrape interval seconds must be greater than 0."
+            )
     if args.log_stats and args.log_stats_interval <= 0:
         raise ValueError("Log stats interval must be greater than 0.")
     if args.engine_stats_interval <= 0:
@@ -278,6 +301,35 @@ def parse_args():
         default="noop",
         choices=["noop"],
         help="The request rewriter to use. Default is 'noop' (no rewriting).",
+    )
+    parser.add_argument(
+        "--enable-router-queue",
+        action="store_true",
+        help="Enable router-side request queueing (phase 1 supports roundrobin only).",
+    )
+    parser.add_argument(
+        "--router-max-queued-requests",
+        type=int,
+        default=256,
+        help="Maximum number of requests that can wait in the router queue.",
+    )
+    parser.add_argument(
+        "--router-max-queue-wait-seconds",
+        type=float,
+        default=5.0,
+        help="Maximum time a request may wait in the router queue.",
+    )
+    parser.add_argument(
+        "--router-waiting-threshold-per-endpoint",
+        type=int,
+        default=1,
+        help="Maximum backend waiting depth per endpoint before router queueing kicks in.",
+    )
+    parser.add_argument(
+        "--router-admission-scrape-interval-seconds",
+        type=float,
+        default=1.0,
+        help="Admission-oriented metrics refresh interval when router queueing is enabled.",
     )
 
     # Batch API

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -20,7 +20,7 @@ import math
 import random
 import threading
 import uuid
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import requests
 from fastapi import HTTPException, Request
@@ -149,6 +149,9 @@ class RoundRobinRouter(RoutingInterface):
             return
         self._next_index: dict[tuple[str, ...], int] = {}
         self._sorted_cache: dict[frozenset[str], tuple[str, ...]] = {}
+        # The router is a singleton shared by every concurrent request handler,
+        # so the cursor and caches below need to be guarded.
+        self._lock = threading.Lock()
         self._initialized = True
 
     def _endpoint_key(self, endpoints: List[EndpointInfo]) -> tuple[str, ...]:
@@ -164,6 +167,40 @@ class RoundRobinRouter(RoutingInterface):
             key = tuple(sorted(urls))
             self._sorted_cache[urls] = key
         return key
+
+    def pick_admissible_endpoint(
+        self,
+        endpoints: List[EndpointInfo],
+        is_admissible: Callable[[EndpointInfo], bool],
+    ) -> Optional[EndpointInfo]:
+        """Return the next round-robin endpoint accepted by ``is_admissible``.
+
+        Walks the endpoint set in round-robin order starting at the current
+        cursor and returns the first endpoint the predicate accepts, advancing
+        the cursor past it. Returns None when no endpoint is admissible; the
+        cursor is left untouched in that case so no endpoint is skipped.
+
+        ``is_admissible`` runs while the router lock is held, so it must be
+        cheap and must not block on locks another thread could hold while
+        waiting on this router.
+        """
+        with self._lock:
+            endpoint_urls = self._endpoint_key(endpoints)
+            endpoints_by_url = {e.url: e for e in endpoints}
+            idx = self._next_index.get(endpoint_urls, 0)
+            if (
+                len(self._next_index) >= self._MAX_CACHE_SIZE
+                and endpoint_urls not in self._next_index
+            ):
+                self._next_index.clear()
+
+            total = len(endpoint_urls)
+            for offset in range(total):
+                endpoint = endpoints_by_url[endpoint_urls[(idx + offset) % total]]
+                if is_admissible(endpoint):
+                    self._next_index[endpoint_urls] = idx + offset + 1
+                    return endpoint
+            return None
 
     def route_request(
         self,
@@ -184,15 +221,22 @@ class RoundRobinRouter(RoutingInterface):
                 indicating the request-level performance of each engine
             request (Request): The incoming request
         """
-        endpoint_urls = self._endpoint_key(endpoints)
-        idx = self._next_index.get(endpoint_urls, 0)
-        if (
-            len(self._next_index) >= self._MAX_CACHE_SIZE
-            and endpoint_urls not in self._next_index
-        ):
-            self._next_index.clear()
-        self._next_index[endpoint_urls] = idx + 1
-        return endpoint_urls[idx % len(endpoint_urls)]
+        # Phase 1: router queueing is not wired into the request path yet, so
+        # the admissibility check is always skipped and this is a plain
+        # round-robin pick. Once the admission controller lands, the check will
+        # also be skipped whenever the router queue is disabled.
+        chosen = self.pick_admissible_endpoint(endpoints, lambda _: True)
+        if chosen is None:
+            # Unreachable while the predicate is always-true (_endpoint_key
+            # already rejects an empty endpoint list), but guard it so a real
+            # admission predicate cannot turn "nothing admissible" into an
+            # AttributeError on the request path.
+            raise HTTPException(
+                status_code=503,
+                detail="NO_ADMISSIBLE_ENDPOINT: All endpoints are over the "
+                "configured queue threshold",
+            )
+        return chosen.url
 
 
 class SessionRouter(RoutingInterface):

--- a/src/vllm_router/stats/engine_stats.py
+++ b/src/vllm_router/stats/engine_stats.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import threading
 import time
-from dataclasses import dataclass
-from typing import Dict
+from dataclasses import dataclass, replace
+from typing import Callable, Dict, Optional
 
 import requests
 from prometheus_client.parser import text_string_to_metric_families
@@ -86,7 +86,12 @@ class EngineStats:
 
 
 class EngineStatsScraper(metaclass=SingletonMeta):
-    def __init__(self, scrape_interval: float):
+    def __init__(
+        self,
+        scrape_interval: float,
+        admission_scrape_interval: Optional[float] = None,
+        on_metrics_update: Optional[Callable[[], None]] = None,
+    ):
         """
         Initialize the scraper to periodically fetch metrics from all serving engines.
 
@@ -109,14 +114,21 @@ class EngineStatsScraper(metaclass=SingletonMeta):
         self.engine_stats: Dict[str, EngineStats] = {}
         self.engine_stats_lock = threading.Lock()
         self.scrape_interval = scrape_interval
+        self.admission_scrape_interval = (
+            admission_scrape_interval
+            if admission_scrape_interval is not None
+            else scrape_interval
+        )
+        self.on_metrics_update = on_metrics_update
 
         # scrape thread
         self.running = True
+        self._stop_event = threading.Event()
         self.scrape_thread = threading.Thread(target=self._scrape_worker, daemon=True)
         self.scrape_thread.start()
         self._initialized = True
 
-    def _scrape_one_endpoint(self, url: str):
+    def _scrape_one_endpoint(self, url: str, queue_only: bool = False):
         """
         Scrape metrics from a single serving engine.
 
@@ -124,7 +136,13 @@ class EngineStatsScraper(metaclass=SingletonMeta):
             url (str): The URL of the serving engine (does not contain endpoint)
         """
         try:
-            response = requests.get(url + "/metrics", timeout=self.scrape_interval)
+            timeout = (
+                self.admission_scrape_interval if queue_only else self.scrape_interval
+            )
+            response = requests.get(
+                url + "/metrics",
+                timeout=timeout,
+            )
             response.raise_for_status()
             engine_stats = EngineStats.from_vllm_scrape(response.text)
         except Exception as e:
@@ -132,7 +150,7 @@ class EngineStatsScraper(metaclass=SingletonMeta):
             return None
         return engine_stats
 
-    def _scrape_metrics(self):
+    def _scrape_metrics(self, queue_only: bool = False):
         """
         Scrape metrics from all serving engines.
 
@@ -143,30 +161,37 @@ class EngineStatsScraper(metaclass=SingletonMeta):
         """
         collected_engine_stats = {}
         endpoints = get_service_discovery().get_endpoint_info()
-        logger.info(f"Scraping metrics from {len(endpoints)} serving engine(s)")
+        log_fn = logger.debug if queue_only else logger.info
+        log_fn(f"Scraping metrics from {len(endpoints)} serving engine(s)")
         for info in endpoints:
             url = info.url
-            engine_stats = self._scrape_one_endpoint(url)
+            engine_stats = self._scrape_one_endpoint(url, queue_only=queue_only)
             if engine_stats:
                 collected_engine_stats[url] = engine_stats
 
         with self.engine_stats_lock:
+            if queue_only:
+                # An admission scrape only refreshes the queue depth of engines
+                # already known to us. It deliberately does not reconcile
+                # membership: its timeout is tight by design, so a transient
+                # miss would otherwise evict an endpoint's full stats until the
+                # next full scrape. Endpoints discovered since the last full
+                # scrape are left for that scrape to populate, so we never
+                # publish a partially-filled record.
+                for url, stats in collected_engine_stats.items():
+                    if url in self.engine_stats:
+                        self.engine_stats[url] = replace(
+                            self.engine_stats[url],
+                            num_queuing_requests=stats.num_queuing_requests,
+                        )
+                return
+
             old_urls = list(self.engine_stats.keys())
             for old_url in old_urls:
                 if old_url not in collected_engine_stats:
                     del self.engine_stats[old_url]
             for url, stats in collected_engine_stats.items():
                 self.engine_stats[url] = stats
-
-    def _sleep_or_break(self, check_interval: float = 1):
-        """
-        Sleep for self.scrape_interval seconds if self.running is True.
-        Otherwise, break the loop.
-        """
-        for _ in range(int(self.scrape_interval / check_interval)):
-            if not self.running:
-                break
-            time.sleep(check_interval)
 
     def _scrape_worker(self):
         """
@@ -177,9 +202,39 @@ class EngineStatsScraper(metaclass=SingletonMeta):
         metrics from all serving engines and store them in self.engine_stats.
 
         """
+        next_full_scrape = 0.0
+        next_admission_scrape = 0.0
+        fast_admission_enabled = self.admission_scrape_interval < self.scrape_interval
         while self.running:
-            self._scrape_metrics()
-            self._sleep_or_break()
+            now = time.monotonic()
+            did_scrape = False
+
+            if now >= next_full_scrape:
+                self._scrape_metrics(queue_only=False)
+                next_full_scrape = now + self.scrape_interval
+                next_admission_scrape = now + self.admission_scrape_interval
+                did_scrape = True
+            elif fast_admission_enabled and now >= next_admission_scrape:
+                self._scrape_metrics(queue_only=True)
+                next_admission_scrape = now + self.admission_scrape_interval
+                did_scrape = True
+
+            if did_scrape and self.on_metrics_update is not None:
+                try:
+                    self.on_metrics_update()
+                except Exception as e:
+                    logger.warning(f"Engine stats refresh callback failed: {e}")
+
+            next_wakeup = (
+                min(next_full_scrape, next_admission_scrape)
+                if fast_admission_enabled
+                else next_full_scrape
+            )
+            # Wait on the stop event rather than sleeping in fixed slices: this
+            # hits the next deadline exactly (a floor would overshoot short
+            # admission intervals) and makes close() return immediately instead
+            # of waiting out the current slice.
+            self._stop_event.wait(max(next_wakeup - time.monotonic(), 0.0))
 
     def get_engine_stats(self) -> Dict[str, EngineStats]:
         """
@@ -206,11 +261,20 @@ class EngineStatsScraper(metaclass=SingletonMeta):
         Stop the background thread and cleanup resources.
         """
         self.running = False
+        self._stop_event.set()
         self.scrape_thread.join()
 
 
-def initialize_engine_stats_scraper(scrape_interval: float) -> EngineStatsScraper:
-    return EngineStatsScraper(scrape_interval)
+def initialize_engine_stats_scraper(
+    scrape_interval: float,
+    admission_scrape_interval: Optional[float] = None,
+    on_metrics_update: Optional[Callable[[], None]] = None,
+) -> EngineStatsScraper:
+    return EngineStatsScraper(
+        scrape_interval,
+        admission_scrape_interval=admission_scrape_interval,
+        on_metrics_update=on_metrics_update,
+    )
 
 
 def get_engine_stats_scraper() -> EngineStatsScraper:


### PR DESCRIPTION
Refs #855

## Summary

This PR adds the Phase 1 groundwork for router-side request queueing.

It does not yet enable router-side request queueing in the request path. Instead, it lands the supporting pieces needed for follow-up PRs:
- router queue CLI/config validation
- round-robin admissible endpoint selection helper
- fast admission-oriented engine stats refresh support
- app initialization plumbing for the admission scrape path

## What is included

- add router queue config flags and validation
- add round-robin helper for selecting the next admissible endpoint
- extend engine stats scraping with an admission-oriented fast refresh interval
- add parser tests for the new validation

## What is not included yet

- no admission controller
- no request queueing in route_general_request
- no lease lifecycle or first-token release
- no router queue metrics

## Testing

- `uv run --group lint pre-commit run --all-files`
- `uv run --group test pytest src/tests/test_parser.py -q`