### PR TITLE
[Feat] feat(aliases): allow setting reasoning level

### DIFF
--- a/src/tests/test_alias_routing.py
+++ b/src/tests/test_alias_routing.py
@@ -1,0 +1,206 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_router.routers.routing_logic import RoundRobinRouter
+from vllm_router.utils import AliasConfig, SingletonABCMeta
+
+
+class FakeEndpointInfo:
+    def __init__(self, url, model_names=None, sleep=False, Id=None):
+        self.url = url
+        self.model_names = model_names or ["deepseek-r1"]
+        self.sleep = sleep
+        self.Id = Id
+
+
+ENDPOINTS = [FakeEndpointInfo(url="http://engine1")]
+
+MOCK_HEADERS = MagicMock()
+MOCK_HEADERS.items.return_value = [("content-type", "text/event-stream")]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_singletons():
+    yield
+    for cls in list(SingletonABCMeta._instances.keys()):
+        del SingletonABCMeta._instances[cls]
+
+
+def _make_service_discovery(aliases):
+    sd = MagicMock()
+    sd.get_endpoint_info.return_value = ENDPOINTS
+    sd.aliases = aliases
+    sd.has_ever_seen_model.return_value = True
+    return sd
+
+
+def _make_request(body_dict, router):
+    state = MagicMock()
+    state.router = router
+    state.engine_stats_scraper.get_engine_stats.return_value = {}
+    state.request_stats_monitor.get_request_stats.return_value = {}
+    state.otel_enabled = False
+    state.semantic_cache_available = False
+    state.callbacks = None
+    state.external_provider_registry = None
+
+    req = MagicMock()
+    req.headers = {"content-type": "application/json"}
+    req.query_params = {}
+    req.method = "POST"
+    req.url = "http://router/v1/chat/completions"
+    req.app.state = state
+
+    raw = json.dumps(body_dict).encode()
+
+    async def body():
+        return raw
+
+    req.body = body
+    return req
+
+
+async def _run_routing_test(
+    aliases,
+    request_body,
+    expect_model,
+    expect_reasoning=None,
+    expect_enable_thinking=None,
+):
+    """Route a request through route_general_request and verify the forwarded body."""
+    router = RoundRobinRouter()
+    setattr(router, "max_instance_failover_reroute_attempts", 0)
+    req = _make_request(request_body, router)
+    captured = {}
+
+    async def fake_process(request, body, server_url, *a, **kw):
+        captured["body"] = json.loads(body)
+        yield MOCK_HEADERS, 200
+        yield b'{"id":"x"}'
+
+    with (
+        patch(
+            "vllm_router.services.request_service.request.get_service_discovery",
+            return_value=_make_service_discovery(aliases),
+        ),
+        patch(
+            "vllm_router.services.request_service.request.is_request_rewriter_initialized",
+            return_value=False,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.process_request",
+            side_effect=fake_process,
+        ),
+    ):
+        from vllm_router.services.request_service.request import route_general_request
+
+        resp = await route_general_request(req, "/v1/chat/completions", MagicMock())
+
+    assert resp.status_code == 200
+    assert captured["body"]["model"] == expect_model
+    if expect_reasoning is not None:
+        assert captured["body"]["reasoning_effort"] == expect_reasoning
+    else:
+        assert "reasoning_effort" not in captured["body"]
+    if expect_enable_thinking is not None:
+        assert (
+            captured["body"]["chat_template_kwargs"]["enable_thinking"]
+            == expect_enable_thinking
+        )
+    else:
+        assert "chat_template_kwargs" not in captured["body"]
+
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_alias_injects_reasoning_effort():
+    """When alias has reasoning_effort and request doesn't, it should be injected."""
+    await _run_routing_test(
+        aliases={
+            "reasoning-model": AliasConfig(model="deepseek-r1", reasoning_effort="high")
+        },
+        request_body={
+            "model": "reasoning-model",
+            "stream": False,
+            "messages": _MESSAGES,
+        },
+        expect_model="deepseek-r1",
+        expect_reasoning="high",
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_reasoning_effort_not_overwritten():
+    """When client already provides reasoning_effort, alias should NOT overwrite it."""
+    await _run_routing_test(
+        aliases={
+            "reasoning-model": AliasConfig(model="deepseek-r1", reasoning_effort="high")
+        },
+        request_body={
+            "model": "reasoning-model",
+            "stream": False,
+            "reasoning_effort": "low",
+            "messages": _MESSAGES,
+        },
+        expect_model="deepseek-r1",
+        expect_reasoning="low",
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_alias_no_reasoning_effort():
+    """A plain alias (no reasoning_effort) should not inject reasoning_effort."""
+    await _run_routing_test(
+        aliases={"short-name": AliasConfig(model="deepseek-r1")},
+        request_body={"model": "short-name", "stream": False, "messages": _MESSAGES},
+        expect_model="deepseek-r1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_plain_string_alias():
+    """A plain-string alias value (from a custom ServiceDiscovery) must still work."""
+    await _run_routing_test(
+        aliases={"short-name": "deepseek-r1"},
+        request_body={"model": "short-name", "stream": False, "messages": _MESSAGES},
+        expect_model="deepseek-r1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_none_injects_enable_thinking_false():
+    """When reasoning_effort is 'none', chat_template_kwargs.enable_thinking should be False."""
+    await _run_routing_test(
+        aliases={
+            "no-thinking": AliasConfig(model="deepseek-r1", reasoning_effort="none")
+        },
+        request_body={
+            "model": "no-thinking",
+            "stream": False,
+            "messages": _MESSAGES,
+        },
+        expect_model="deepseek-r1",
+        expect_reasoning="none",
+        expect_enable_thinking=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_high_no_enable_thinking():
+    """When reasoning_effort is not 'none', chat_template_kwargs should not be injected."""
+    await _run_routing_test(
+        aliases={
+            "reasoning-model": AliasConfig(model="deepseek-r1", reasoning_effort="high")
+        },
+        request_body={
+            "model": "reasoning-model",
+            "stream": False,
+            "messages": _MESSAGES,
+        },
+        expect_model="deepseek-r1",
+        expect_reasoning="high",
+    )

--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -92,6 +92,63 @@ def test_load_initial_config_from_config_file_if_required_when_yaml_config_file_
         assert args.static_aliases == "text-embedding-3-small:bge-m3"
 
 
+def test_load_initial_config_from_config_file_if_required_when_yaml_config_with_extended_aliases_is_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        monkeypatch.setattr(sys, "argv", [sys.argv[0], "--dynamic-config-yaml", f.name])
+        f.write(
+            yaml.safe_dump(
+                {
+                    "static_aliases": {
+                        "text": "llama3",
+                        "reasoning": {"model": "llama3", "reasoning_effort": "high"},
+                    },
+                }
+            ).encode()
+        )
+        f.seek(0)
+        test_parser = argparse.ArgumentParser("test")
+        test_parser.add_argument("--dynamic-config-yaml", type=str)
+        test_parser.add_argument("--dynamic-config-json", type=str)
+        args = test_parser.parse_args()
+        args = parser.load_initial_config_from_config_file_if_required(
+            test_parser, args
+        )
+        assert "text:llama3" in args.static_aliases
+        assert "reasoning:llama3|reasoning_effort=high" in args.static_aliases
+
+
+def test_generate_static_aliases_rejects_unknown_key() -> None:
+    from vllm_router.parsers.yaml_utils import generate_static_aliases
+
+    with pytest.raises(ValueError, match="unknown keys"):
+        generate_static_aliases({"r1": {"model": "llama3", "reasoning_effrot": "high"}})
+
+
+def test_generate_static_aliases_rejects_missing_model() -> None:
+    from vllm_router.parsers.yaml_utils import generate_static_aliases
+
+    with pytest.raises(ValueError, match="missing required key 'model'"):
+        generate_static_aliases({"r1": {"reasoning_effort": "high"}})
+
+
+def test_generate_static_aliases_rejects_invalid_type() -> None:
+    from vllm_router.parsers.yaml_utils import generate_static_aliases
+
+    with pytest.raises(ValueError, match="expected string or dict"):
+        generate_static_aliases({"bad": 42})
+
+
+def test_generate_static_aliases_rejects_invalid_reasoning_effort() -> None:
+    from vllm_router.parsers.yaml_utils import generate_static_aliases
+
+    with pytest.raises(ValueError, match="Invalid reasoning_effort"):
+        generate_static_aliases(
+            {"r1": {"model": "llama3", "reasoning_effort": "urgent"}}
+        )
+
+
 def test_load_initial_config_from_config_file_if_required_when_json_config_file_is_provided_adds_values_to_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/tests/test_static_service_discovery.py
+++ b/src/tests/test_static_service_discovery.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from vllm_router.service_discovery import StaticServiceDiscovery
+from vllm_router.utils import AliasConfig
 
 
 def test_init_when_static_backend_health_checks_calls_start_health_checks(
@@ -162,7 +163,7 @@ def test_has_ever_seen_model_when_model_is_alias_returns_true():
         None,
         ["http://localhost.com"],
         ["llama3"],
-        {"llama": "llama3"},
+        {"llama": AliasConfig(model="llama3")},
         None,
         ["chat"],
         static_backend_health_checks=False,
@@ -172,3 +173,36 @@ def test_has_ever_seen_model_when_model_is_alias_returns_true():
     assert discovery_instance.has_ever_seen_model("llama") is True
     assert discovery_instance.has_ever_seen_model("llama3") is True
     assert discovery_instance.has_ever_seen_model("unknown-model") is False
+
+
+def _make_discovery(aliases=None):
+    return StaticServiceDiscovery(
+        None,
+        ["http://localhost.com"],
+        ["llama3"],
+        aliases,
+        None,
+        ["chat"],
+        static_backend_health_checks=False,
+        prefill_model_labels=None,
+        decode_model_labels=None,
+    )
+
+
+def test_init_normalizes_legacy_str_aliases_to_alias_config():
+    """Programmatic callers passing dict[str, str] should still work."""
+    d = _make_discovery({"llama": "llama3"})
+    assert d.aliases == {"llama": AliasConfig(model="llama3")}
+    assert d.has_ever_seen_model("llama") is True
+
+
+def test_init_accepts_alias_config_values():
+    d = _make_discovery(
+        {"reasoning": AliasConfig(model="llama3", reasoning_effort="high")}
+    )
+    assert d.aliases["reasoning"].reasoning_effort == "high"
+
+
+def test_init_rejects_invalid_alias_value_type():
+    with pytest.raises(TypeError, match="expected str or AliasConfig"):
+        _make_discovery({"bad": 123})

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -6,32 +6,80 @@ import requests
 from starlette.datastructures import MutableHeaders
 
 from vllm_router import utils
+from vllm_router.utils import AliasConfig, normalize_alias_config
 
 
 @pytest.mark.parametrize(
     "aliases,expected_result",
     (
-        ("gpt-4:mistral-nemo-instruct-2407", {"gpt-4": "mistral-nemo-instruct-2407"}),
+        (
+            "gpt-4:mistral-nemo-instruct-2407",
+            {"gpt-4": AliasConfig(model="mistral-nemo-instruct-2407")},
+        ),
         (
             "gpt-4:mistral-nemo-instruct-2407,gpt-3.5:mistral-nemo-instruct-2407",
             {
-                "gpt-4": "mistral-nemo-instruct-2407",
-                "gpt-3.5": "mistral-nemo-instruct-2407",
+                "gpt-4": AliasConfig(model="mistral-nemo-instruct-2407"),
+                "gpt-3.5": AliasConfig(model="mistral-nemo-instruct-2407"),
             },
         ),
         (
             "gpt-4:deepseek-r1-distill-qwen-7b,mistral-7b-instruct:mistral-nemo-instruct-2407",
             {
-                "gpt-4": "deepseek-r1-distill-qwen-7b",
-                "mistral-7b-instruct": "mistral-nemo-instruct-2407",
+                "gpt-4": AliasConfig(model="deepseek-r1-distill-qwen-7b"),
+                "mistral-7b-instruct": AliasConfig(model="mistral-nemo-instruct-2407"),
+            },
+        ),
+        (
+            "reasoning:deepseek-r1-distill-qwen-7b|reasoning_effort=high",
+            {
+                "reasoning": AliasConfig(
+                    model="deepseek-r1-distill-qwen-7b", reasoning_effort="high"
+                )
+            },
+        ),
+        (
+            "text:mistral-nemo-instruct-2407,reasoning:deepseek-r1-distill-qwen-7b|reasoning_effort=low",
+            {
+                "text": AliasConfig(model="mistral-nemo-instruct-2407"),
+                "reasoning": AliasConfig(
+                    model="deepseek-r1-distill-qwen-7b", reasoning_effort="low"
+                ),
             },
         ),
     ),
 )
-def test_parse_static_aliases_when_aliases_as_string_supplied_returns_dict(
-    aliases: str, expected_result: dict
-) -> None:
+def test_parse_static_aliases(aliases: str, expected_result: dict) -> None:
     assert utils.parse_static_aliases(aliases) == expected_result
+
+
+def test_alias_config_rejects_invalid_reasoning_effort() -> None:
+    with pytest.raises(ValueError, match="Invalid reasoning_effort"):
+        AliasConfig(model="test", reasoning_effort="invalid")
+
+
+def test_normalize_alias_config_accepts_plain_string() -> None:
+    assert normalize_alias_config("gpt-4", "llama3") == AliasConfig(model="llama3")
+
+
+def test_normalize_alias_config_accepts_alias_config() -> None:
+    config = AliasConfig(model="llama3", reasoning_effort="high")
+    assert normalize_alias_config("reasoning", config) == config
+
+
+def test_normalize_alias_config_rejects_invalid_value() -> None:
+    with pytest.raises(TypeError, match="expected str or AliasConfig"):
+        normalize_alias_config("bad", 123)
+
+
+def test_parse_static_aliases_rejects_unknown_parameter() -> None:
+    with pytest.raises(ValueError, match="Unknown alias parameter 'reasoning_effrot'"):
+        utils.parse_static_aliases("r1:llama3|reasoning_effrot=high")
+
+
+def test_parse_static_aliases_rejects_invalid_entry() -> None:
+    with pytest.raises(ValueError, match="Invalid alias entry"):
+        utils.parse_static_aliases("missing-model")
 
 
 def test_replace_model_in_request_body_replaces_model() -> None:
@@ -110,7 +158,6 @@ def test_is_model_healthy_when_requests_raises_exception_returns_false(
 def test_is_model_healthy_when_requests_status_with_status_code_not_200_returns_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-
     # Mock an internal server error response
     mock_response = MagicMock(status_code=500)
 

--- a/src/vllm_router/README.md
+++ b/src/vllm_router/README.md
@@ -27,7 +27,7 @@ The router can be configured using command-line arguments. Below are the availab
 - `--service-discovery`: The service discovery type. Options are `static` or `k8s`. This option is required.
 - `--static-backends`: The URLs of static serving engines, separated by commas (e.g., `http://localhost:8000,http://localhost:8001`).
 - `--static-models`: The models running in the static serving engines, separated by commas (e.g., `model1,model2`).
-- `--static-aliases`: The aliases of the models running in the static serving engines, separated by commas and associated using colons (e.g., `model_alias1:model,mode_alias2:model`).
+- `--static-aliases`: The aliases of the models running in the static serving engines, separated by commas and associated using colons (e.g., `model_alias1:model,mode_alias2:model`). Aliases can optionally include parameter overrides using a pipe separator (e.g., `reasoning-alias:deepseek-r1|reasoning_effort=high`).
 - `--static-backend-health-checks`: Enable this flag to make vllm-router check periodically if the models work by sending dummy requests to their endpoints.
 - `--k8s-port`: The port of vLLM processes when using K8s service discovery. Default is `8000`.
 - `--k8s-namespace`: The namespace of vLLM pods when using K8s service discovery. Default is `default`.
@@ -88,7 +88,7 @@ vllm-router --port 8000 \
     --service-discovery static \
     --static-backends "http://localhost:9001,http://localhost:9002,http://localhost:9003" \
     --static-models "facebook/opt-125m,meta-llama/Llama-3.1-8B-Instruct,facebook/opt-125m" \
-    --static-aliases "gpt4:meta-llama/Llama-3.1-8B-Instruct" \
+    --static-aliases "gpt4:meta-llama/Llama-3.1-8B-Instruct,reasoning:deepseek-r1|reasoning_effort=high" \
     --static-model-types "chat,chat,chat" \
     --static-backend-health-checks \
     --engine-stats-interval 10 \
@@ -126,7 +126,7 @@ Currently, the dynamic config supports the following fields:
 - `callbacks`: The path to the callback instance extending CustomCallbackHandler.
 - (When using `static` service discovery) `static_backends`: The URLs of static serving engines, separated by commas (e.g., `http://localhost:9001,http://localhost:9002,http://localhost:9003`).
 - (When using `static` service discovery) `static_models`: The models running in the static serving engines, separated by commas (e.g., `model1,model2`).
-- (When using `static` service discovery) `static_aliases`: The aliases of the models running in the static serving engines, separated by commas and associated using colons (e.g., `model_alias1:model,mode_alias2:model`).
+- (When using `static` service discovery) `static_aliases`: The aliases of the models running in the static serving engines. In CLI/JSON format: comma-separated `alias:model` pairs with optional pipe-separated parameters (e.g., `my-alias:model,reasoning:model|reasoning_effort=high`). In YAML format: a mapping where values are either a plain model name string or a dict with `model` and optional `reasoning_effort` keys.
 - (When using `static` service discovery and if you enable the `--static-backend-health-checks` flag) `static_model_types`: The model types running in the static serving engines, separated by commas (e.g., `chat,chat`).
 - (When using `k8s` service discovery) `k8s_port`: The port of vLLM processes when using K8s service discovery. Default is `8000`.
 - (When using `k8s` service discovery) `k8s_namespace`: The namespace of vLLM pods when using K8s service discovery. Default is `default`.
@@ -152,6 +152,9 @@ static_models:
 static_aliases:
     "my-alias": "facebook/opt-125m"
     "my-other-alias": "meta-llama/Llama-3.1-8B-Instruct"
+    "reasoning":
+        model: "meta-llama/Llama-3.1-8B-Instruct"
+        reasoning_effort: "high"
 ```
 
 Here is an example of a dynamic JSON config file:
@@ -164,7 +167,7 @@ Here is an example of a dynamic JSON config file:
     "static_backends": "http://localhost:9001,http://localhost:9002,http://localhost:9003",
     "static_models": "facebook/opt-125m,meta-llama/Llama-3.1-8B-Instruct,facebook/opt-125m",
     "static_model_types": "completion,chat,completion",
-    "static_aliases": "my-alias:meta-llama/Llama-3.1-8B-Instruct,my-other-alias:meta-llama/Llama-3.1-8B-Instruct"
+    "static_aliases": "my-alias:meta-llama/Llama-3.1-8B-Instruct,reasoning:meta-llama/Llama-3.1-8B-Instruct|reasoning_effort=high"
 }
 ```
 

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -164,7 +164,10 @@ def parse_args():
         "--static-aliases",
         type=str,
         default=None,
-        help="The aliases of static backends, separated by commas. E.g., your-custom-model:llama3",
+        help="The aliases of static backends, separated by commas. "
+        "Simple: your-custom-model:llama3. "
+        "With reasoning effort: reasoning:qwen-3.5-27b|reasoning_effort=high. "
+        "Valid reasoning_effort values: none, low, medium, high",
     )
     parser.add_argument(
         "--static-model-types",

--- a/src/vllm_router/parsers/yaml_utils.py
+++ b/src/vllm_router/parsers/yaml_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 import yaml
 
 from vllm_router.log import init_logger
+from vllm_router.utils import AliasConfig
 
 logger = init_logger(__name__)
 
@@ -23,8 +24,41 @@ def generate_static_models(models: dict[str, Any]) -> str:
     return ",".join(static_models)
 
 
+_VALID_ALIAS_DICT_KEYS = {"model", "reasoning_effort"}
+
+
+def _parse_alias_config(alias: str, config: Any) -> AliasConfig:
+    if isinstance(config, str):
+        return AliasConfig(model=config)
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"Invalid alias config for '{alias}': expected string or dict, got {type(config).__name__}"
+        )
+    if "model" not in config:
+        raise ValueError(f"Alias '{alias}' is missing required key 'model'")
+
+    unknown_keys = set(config.keys()) - _VALID_ALIAS_DICT_KEYS
+    if unknown_keys:
+        raise ValueError(
+            f"Alias '{alias}' contains unknown keys: {sorted(unknown_keys)}. "
+            f"Supported keys: {sorted(_VALID_ALIAS_DICT_KEYS)}"
+        )
+
+    return AliasConfig(
+        model=config["model"],
+        reasoning_effort=config.get("reasoning_effort"),
+    )
+
+
 def generate_static_aliases(aliases: dict[str, Any]) -> str:
-    return ",".join(f"{alias}:{model}" for alias, model in aliases.items())
+    parts = []
+    for alias, raw_config in aliases.items():
+        config = _parse_alias_config(alias, raw_config)
+        entry = f"{alias}:{config.model}"
+        if config.reasoning_effort is not None:
+            entry += f"|reasoning_effort={config.reasoning_effort}"
+        parts.append(entry)
+    return ",".join(parts)
 
 
 def generate_static_model_types(models: dict[str, Any]) -> str:

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -28,6 +28,7 @@ from kubernetes import client, config, watch
 
 from vllm_router import utils
 from vllm_router.log import init_logger
+from vllm_router.utils import AliasConfig, normalize_alias_config
 
 logger = init_logger(__name__)
 
@@ -226,7 +227,7 @@ class StaticServiceDiscovery(ServiceDiscovery):
         app,
         urls: List[str],
         models: List[str],
-        aliases: List[str] | None = None,
+        aliases: dict[str, str | AliasConfig] | None = None,
         model_labels: List[str] | None = None,
         model_types: List[str] | None = None,
         static_backend_health_checks: bool = False,
@@ -239,7 +240,14 @@ class StaticServiceDiscovery(ServiceDiscovery):
         assert len(urls) == len(models), "URLs and models should have the same length"
         self.urls = urls
         self.models = models
-        self.aliases = aliases
+        self.aliases = (
+            {
+                alias: normalize_alias_config(alias, value)
+                for alias, value in aliases.items()
+            }
+            if aliases is not None
+            else None
+        )
         self.model_labels = model_labels
         self.model_types = model_types
         self.engines_id = [str(uuid.uuid4()) for i in range(0, len(urls))]

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -40,6 +40,7 @@ from vllm_router.services.request_service.rewriter import (
     is_request_rewriter_initialized,
 )
 from vllm_router.utils import (
+    normalize_alias_config,
     replace_model_in_request_body,
     update_content_length,
 )
@@ -467,8 +468,15 @@ async def route_general_request(
     endpoints = service_discovery.get_endpoint_info()
 
     aliases = getattr(service_discovery, "aliases", None)
-    if aliases and requested_model in aliases.keys():
-        requested_model = aliases[requested_model]
+    if aliases and requested_model in aliases:
+        alias_config = normalize_alias_config(requested_model, aliases[requested_model])
+        requested_model = alias_config.model
+        if alias_config.reasoning_effort and "reasoning_effort" not in request_json:
+            request_json["reasoning_effort"] = alias_config.reasoning_effort
+        if alias_config.reasoning_effort == "none":
+            request_json.setdefault("chat_template_kwargs", {})[
+                "enable_thinking"
+            ] = False
         request_body = replace_model_in_request_body(request_json, requested_model)
         update_content_length(request, request_body)
 

--- a/src/vllm_router/utils.py
+++ b/src/vllm_router/utils.py
@@ -5,6 +5,7 @@ import json
 import re
 import resource
 import wave
+from dataclasses import dataclass
 from typing import Optional
 
 import requests
@@ -215,12 +216,76 @@ def parse_comma_separated_args(comma_separated_string: Optional[str]):
     return comma_separated_string.split(",")
 
 
-def parse_static_aliases(static_aliases: str):
-    aliases = {}
-    for alias_and_model in static_aliases.split(","):
-        alias, model = alias_and_model.split(":")
-        aliases[alias] = model
-    logger.info(f"Loaded aliases {aliases}")
+VALID_REASONING_EFFORTS = ("none", "low", "medium", "high")
+
+
+@dataclass(frozen=True)
+class AliasConfig:
+    """Configuration for a model alias with optional request overrides."""
+
+    model: str
+    reasoning_effort: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.reasoning_effort is None:
+            return
+        if self.reasoning_effort not in VALID_REASONING_EFFORTS:
+            raise ValueError(
+                f"Invalid reasoning_effort '{self.reasoning_effort}' "
+                f"(expected one of {VALID_REASONING_EFFORTS})"
+            )
+
+
+def normalize_alias_config(alias_name: str, value: object) -> AliasConfig:
+    if isinstance(value, AliasConfig):
+        return value
+    if isinstance(value, str):
+        return AliasConfig(model=value)
+    raise TypeError(
+        f"Invalid alias value for '{alias_name}': expected str or AliasConfig, "
+        f"got {type(value).__name__}"
+    )
+
+
+def _parse_alias_entry(entry: str) -> tuple[str, AliasConfig]:
+    alias_and_model, *raw_params = entry.split("|")
+    alias, separator, model = alias_and_model.partition(":")
+    alias = alias.strip()
+    model = model.strip()
+
+    if not separator or not alias or not model:
+        raise ValueError(
+            "Invalid alias entry "
+            f"'{entry}'. Expected format alias:model[|reasoning_effort=value]"
+        )
+
+    reasoning_effort = None
+    for raw_param in raw_params:
+        param = raw_param.strip()
+        key, separator, value = param.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not separator or not key or not value:
+            raise ValueError(f"Invalid alias parameter '{param}' in entry '{entry}'")
+        if key != "reasoning_effort":
+            raise ValueError(
+                f"Unknown alias parameter '{key}' in entry '{entry}'. "
+                "Supported parameters: reasoning_effort"
+            )
+        reasoning_effort = value
+
+    return alias, AliasConfig(model=model, reasoning_effort=reasoning_effort)
+
+
+def parse_static_aliases(static_aliases: str) -> dict[str, AliasConfig]:
+    aliases: dict[str, AliasConfig] = {}
+    for raw_entry in static_aliases.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        alias, config = _parse_alias_entry(entry)
+        aliases[alias] = config
+    logger.info("Loaded aliases %s", aliases)
     return aliases
 
 


### PR DESCRIPTION
Adds optional reasoning_effort support to static model aliases. The main use case is replacing non-reasoning models with reasoning ones without changing client behaviour: map the old alias to the new model with reasoning_effort=none and clients see no difference. It also makes it easy to expose multiple capability tiers (fast, thorough, etc.) from a single engine.

Aliases can be configured as alias:model|reasoning_effort=high (CLI/JSON) or as a dict with model and reasoning_effort keys (YAML). The router injects the configured value into forwarded requests unless the client already set one.

FIX #911

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.



<b> Detailed Checklist (Click to Expand) </b>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO" rel="nofollow noreferrer noopener" target="_blank">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.

⚒️ with ❤️ by @siemens