### PR TITLE
[Minor Improvements] Vllmruntime Autoscaling in Operator

### DIFF
--- a/operator/api/v1alpha1/vllmruntime_types.go
+++ b/operator/api/v1alpha1/vllmruntime_types.go
@@ -328,6 +328,15 @@ type VLLMRuntimeStatus struct {
 	// Current replica count (used by scale subresource)
 	Replicas int32 `json:"replicas,omitempty"`
 
+	// Number of pods that are ready and serving traffic
+	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
+
+	// Number of pods running the latest pod template
+	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
+
+	// Number of pods that are not yet available
+	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty"`
+
 	// Label selector for pods (used by scale subresource for HPA AverageValue)
 	Selector string `json:"selector,omitempty"`
 }

--- a/operator/config/crd/bases/production-stack.vllm.ai_vllmruntimes.yaml
+++ b/operator/config/crd/bases/production-stack.vllm.ai_vllmruntimes.yaml
@@ -546,6 +546,10 @@ spec:
           status:
             description: VLLMRuntimeStatus defines the observed state of VLLMRuntime
             properties:
+              availableReplicas:
+                description: Number of pods that are ready and serving traffic
+                format: int32
+                type: integer
               lastUpdated:
                 description: Last updated timestamp
                 format: date-time
@@ -561,6 +565,14 @@ spec:
                 description: Label selector for pods (used by scale subresource for
                   HPA AverageValue)
                 type: string
+              unavailableReplicas:
+                description: Number of pods that are not yet available
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Number of pods running the latest pod template
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/operator/internal/controller/vllmruntime_controller.go
+++ b/operator/internal/controller/vllmruntime_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1066,6 +1067,11 @@ func (r *VLLMRuntimeReconciler) updateStatus(
 		latestVR.Status.Replicas = dep.Status.Replicas
 		latestVR.Status.Selector = metav1.FormatLabelSelector(dep.Spec.Selector)
 
+		// Expose additional deployment status fields
+		latestVR.Status.AvailableReplicas = dep.Status.AvailableReplicas
+		latestVR.Status.UpdatedReplicas = dep.Status.UpdatedReplicas
+		latestVR.Status.UnavailableReplicas = dep.Status.UnavailableReplicas
+
 		return r.Status().Update(ctx, latestVR)
 	})
 }
@@ -1089,6 +1095,13 @@ func (r *VLLMRuntimeReconciler) reconcileScaledObject(
 
 	prometheusAddr := cfg.Triggers.PrometheusAddress
 	servedModelName := vllmRuntime.Spec.Model.ModelURL
+	// Check extraArgs for --served-model-name override
+	for _, arg := range vllmRuntime.Spec.VLLMConfig.ExtraArgs {
+		if strings.HasPrefix(arg, "--served-model-name=") {
+			servedModelName = strings.TrimPrefix(arg, "--served-model-name=")
+			break
+		}
+	}
 
 	spec := map[string]interface{}{
 		"scaleTargetRef": map[string]interface{}{
@@ -1125,7 +1138,7 @@ func (r *VLLMRuntimeReconciler) reconcileScaledObject(
 				"metadata": map[string]string{
 					"serverAddress": prometheusAddr,
 					"metricName":    "vllm_incoming_keepalive",
-					"query":         fmt.Sprintf(`sum(rate(vllm:num_incoming_requests_total{namespace="%s", model="%s"}[1m]) > bool 0)`, vllmRuntime.Namespace, servedModelName),
+					"query":         fmt.Sprintf(`sum(rate(vllm:num_incoming_requests_total{namespace="%s", model="%s"}[2m]) > bool 0)`, vllmRuntime.Namespace, servedModelName),
 					"threshold":     "1",
 				},
 			},


### PR DESCRIPTION
 ## Summary

  ### Three improvements to VLLMRuntime KEDA autoscaling:

  1. Fix: resolve --served-model-name override in Prometheus queries — The keepalive trigger queries Prometheus with model="<name>". Previously it always used ModelURL (e.g., meta-llama/Llama-3.1-8B-Instruct), ignoring --served-model-name in ExtraArgs. If a user overrides the served model name, the query returns no data and KEDA may incorrectly scale to zero while traffic is active.
  2. Widen keepalive rate window from [1m] to [2m] — A 1-minute window is tight; delayed Prometheus scrapes or brief metric gaps can return 0 and trigger a false scale-to-zero. A 2-minute window is more resilient.
  3. Add AvailableReplicas, UpdatedReplicas, UnavailableReplicas to VLLMRuntimeStatus — Exposes deployment replica status directly on the CR, so users can observe scaling progress via kubectl get vr without inspecting the underlying Deployment.

  ### Changes:

  - operator/api/v1alpha1/vllmruntime_types.go — Add 3 status fields
  - operator/internal/controller/vllmruntime_controller.go — Served-model-name parsing, 2m keepalive window, populate new status fields
  - operator/api/v1alpha1/zz_generated.deepcopy.go — Regenerated
  - operator/config/crd/bases/production-stack.vllm.ai_vllmruntimes.yaml — Regenerated

  ### Tests Done: 

  - make generate manifests — regenerated without errors
  - make test — all VLLMRuntime and autoscaling tests pass (11/11)
  - Deploy with a VLLMRuntime CR using --served-model-name override and verify KEDA ScaledObject uses the correct model name in Prometheus queries
  - Verify kubectl get vr shows the new replica status fields