### PR TITLE
Feat/implement streaming path in audio transcription

### DIFF
--- a/src/tests/test_transcription_streaming.py
+++ b/src/tests/test_transcription_streaming.py
@@ -160,6 +160,9 @@ async def test_transcription_non_streaming_returns_json_response(setup_mocks):
     assert isinstance(resp, JSONResponse)
     assert resp.status_code == 200
     assert resp.body == b'{"text":"Hello world transcription"}'
+    req.app.state.request_stats_monitor.on_new_request.assert_called_once()
+    req.app.state.request_stats_monitor.on_request_response.assert_called_once()
+    req.app.state.request_stats_monitor.on_request_complete.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_transcription_streaming.py
+++ b/src/tests/test_transcription_streaming.py
@@ -1,0 +1,364 @@
+"""
+Tests for transcription streaming path in proxy_multipart_request:
+
+1. stream=True returns a StreamingResponse that proxies SSE chunks.
+2. stream=False (default) returns a JSONResponse (backward compatible).
+3. Stats hooks are called correctly for streaming transcription.
+4. Upstream response closed after normal completion.
+5. Upstream response closed when consumer aborts mid-stream (aclose).
+6. Connection failure before headers updates request stats.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import FormData
+
+from vllm_router.routers.routing_logic import RoundRobinRouter
+from vllm_router.utils import SingletonABCMeta
+
+
+class EndpointInfo:
+    def __init__(self, url, model_names=None, sleep=False, Id=None):
+        self.url = url
+        self.model_names = model_names or ["whisper-model"]
+        self.sleep = sleep
+        self.Id = Id
+
+
+ENDPOINTS = [EndpointInfo(url="http://whisper-engine")]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_singletons():
+    yield
+    for cls in list(SingletonABCMeta._instances.keys()):
+        del SingletonABCMeta._instances[cls]
+
+
+@pytest.fixture
+def setup_mocks():
+    sd = MagicMock()
+    sd.get_endpoint_info.return_value = ENDPOINTS
+    sd.aliases = None
+
+    with patch(
+        "vllm_router.services.request_service.request.get_service_discovery",
+        return_value=sd,
+    ):
+        yield sd
+
+
+def _make_mock_request():
+    router = RoundRobinRouter()
+    router.max_instance_failover_reroute_attempts = 0
+
+    state = MagicMock()
+    state.router = router
+    state.engine_stats_scraper.get_engine_stats.return_value = {}
+    state.request_stats_monitor.get_request_stats.return_value = {}
+    state.request_stats_monitor.on_new_request = MagicMock()
+    state.request_stats_monitor.on_request_response = MagicMock()
+    state.request_stats_monitor.on_request_complete = MagicMock()
+    state.otel_enabled = False
+    state.semantic_cache_available = False
+    state.callbacks = None
+
+    req = MagicMock()
+    req.headers = {
+        "content-type": "multipart/form-data",
+        "authorization": "Bearer test-key",
+    }
+    req.query_params = {}
+    req.method = "POST"
+    req.url = "http://router/v1/audio/transcriptions"
+    req.app.state = state
+
+    return req
+
+
+def _make_backend_response(chunks, content_type="text/event-stream", status=200):
+    async def iter_any():
+        for c in chunks:
+            yield c
+
+    content = MagicMock()
+    content.iter_any = iter_any
+
+    resp = MagicMock()
+    resp.status = status
+    resp.headers = {"content-type": content_type, "x-request-id": "test-123"}
+    resp.content = content
+    resp.close = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_transcription_streaming_returns_streaming_response(setup_mocks):
+    req = _make_mock_request()
+
+    mock_backend_response = _make_backend_response(
+        [b'data: {"text": "Hello"}\n\n', b'data: {"text": " World"}\n\n']
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    from fastapi.responses import StreamingResponse
+
+    assert isinstance(resp, StreamingResponse)
+    assert resp.status_code == 200
+    assert resp.media_type == "text/event-stream"
+
+
+@pytest.mark.asyncio
+async def test_transcription_non_streaming_returns_json_response(setup_mocks):
+    req = _make_mock_request()
+
+    mock_backend_response = MagicMock()
+    mock_backend_response.status = 200
+    mock_backend_response.headers = {
+        "content-type": "application/json",
+        "x-request-id": "test-123",
+    }
+    mock_backend_response.json = AsyncMock(
+        return_value={"text": "Hello world transcription"}
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=False
+    )
+
+    from fastapi.responses import JSONResponse
+
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 200
+    assert resp.body == b'{"text":"Hello world transcription"}'
+
+
+@pytest.mark.asyncio
+async def test_streaming_calls_stats_hooks(setup_mocks):
+    req = _make_mock_request()
+
+    mock_backend_response = _make_backend_response(
+        [b'data: {"text": "Hello"}\n\n', b'data: {"text": " World"}\n\n']
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    req.app.state.request_stats_monitor.on_new_request.assert_called_once()
+
+    chunks = []
+    async for chunk in resp.body_iterator:
+        chunks.append(chunk)
+
+    req.app.state.request_stats_monitor.on_request_response.assert_called_once()
+    req.app.state.request_stats_monitor.on_request_complete.assert_called_once()
+    mock_backend_response.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_preserves_content_type(setup_mocks):
+    req = _make_mock_request()
+
+    mock_backend_response = _make_backend_response(
+        [b'data: {"text": "Hello"}\n\n'], content_type="application/x-ndjson"
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    assert resp.media_type == "application/x-ndjson"
+
+
+@pytest.mark.asyncio
+async def test_streaming_uses_aiohttp_multipart_boundary(setup_mocks):
+    req = _make_mock_request()
+
+    mock_backend_response = _make_backend_response([b'data: {"text": "Hello"}\n\n'])
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    call_args = mock_client.post.call_args
+    assert call_args is not None
+    kwargs = call_args[1] if call_args[1] else {}
+    assert kwargs.get("headers") is None
+
+
+@pytest.mark.asyncio
+async def test_streaming_closes_upstream_on_full_consumption(setup_mocks):
+    req = _make_mock_request()
+
+    mock_backend_response = _make_backend_response(
+        [b'data: {"text": "Hello"}\n\n', b'data: {"text": " World"}\n\n']
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    chunks = []
+    async for chunk in resp.body_iterator:
+        chunks.append(chunk)
+
+    assert len(chunks) == 2
+    mock_backend_response.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_closes_upstream_on_consumer_abort(setup_mocks):
+    """Downstream client disconnects mid-stream: body_iterator.aclose() must
+    run the finally block and close the upstream response."""
+    req = _make_mock_request()
+
+    mock_backend_response = _make_backend_response(
+        [
+            b'data: {"text": "chunk1"}\n\n',
+            b'data: {"text": "chunk2"}\n\n',
+            b'data: {"text": "chunk3"}\n\n',
+        ]
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    body_iter = resp.body_iterator
+    first = await body_iter.__anext__()
+    assert first == b'data: {"text": "chunk1"}\n\n'
+
+    await body_iter.aclose()
+
+    mock_backend_response.close.assert_called_once()
+    req.app.state.request_stats_monitor.on_request_complete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_stats_on_connection_failure(setup_mocks):
+    req = _make_mock_request()
+
+    import aiohttp
+
+    err = aiohttp.ClientConnectorError(
+        connection_key=MagicMock(), os_error=OSError("connection refused")
+    )
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=err)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    from vllm_router.services.request_service.request import proxy_multipart_request
+
+    form_data = FormData()
+    form_data.add_field(
+        "file", b"fake-audio", filename="test.wav", content_type="audio/wav"
+    )
+    form_data.add_field("model", "whisper-model")
+    form_data.add_field("stream", "true")
+
+    resp = await proxy_multipart_request(
+        form_data, "whisper-model", "/v1/audio/transcriptions", req, stream=True
+    )
+
+    from fastapi.responses import JSONResponse
+
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 503
+    req.app.state.request_stats_monitor.on_new_request.assert_called_once()
+    req.app.state.request_stats_monitor.on_request_complete.assert_called_once()

--- a/src/tests/test_transcription_streaming.py
+++ b/src/tests/test_transcription_streaming.py
@@ -255,7 +255,10 @@ async def test_streaming_uses_aiohttp_multipart_boundary(setup_mocks):
     call_args = mock_client.post.call_args
     assert call_args is not None
     kwargs = call_args[1] if call_args[1] else {}
-    assert kwargs.get("headers") is None
+    # Headers are forwarded (auth, request-id, etc.) but content-type must be absent
+    # so aiohttp can generate the multipart/form-data boundary automatically.
+    passed_headers = kwargs.get("headers") or {}
+    assert "content-type" not in {k.lower() for k in passed_headers}
 
 
 @pytest.mark.asyncio

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1218,7 +1218,7 @@ async def proxy_multipart_request(
                 headers=headers,
                 timeout=aiohttp.ClientTimeout(total=300),
             )
-        except BaseException:
+        except Exception:
             request_stats_monitor.on_request_complete(
                 chosen_url, request_id, time.time()
             )

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1094,29 +1094,29 @@ async def proxy_multipart_request(
             }
             headers["X-Request-Id"] = request_id
 
+        request_stats_monitor.on_new_request(chosen_url, request_id, time.time())
+
+        try:
+            backend_response = await client.post(
+                f"{chosen_url}{endpoint}",
+                data=form_data,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=300),
+            )
+        except BaseException:
+            request_stats_monitor.on_request_complete(
+                chosen_url, request_id, time.time()
+            )
+            raise
+
+        resp_headers = {
+            k: v
+            for k, v in backend_response.headers.items()
+            if k.lower() not in _HEADERS_TO_STRIP_FROM_RESPONSE
+        }
+        resp_headers["X-Request-Id"] = request_id
+
         if stream:
-            start_time = time.time()
-            request_stats_monitor.on_new_request(chosen_url, request_id, start_time)
-
-            try:
-                backend_response = await client.post(
-                    f"{chosen_url}{endpoint}",
-                    data=form_data,
-                    headers=headers,
-                    timeout=aiohttp.ClientTimeout(total=300),
-                )
-            except BaseException:
-                request_stats_monitor.on_request_complete(
-                    chosen_url, request_id, time.time()
-                )
-                raise
-
-            resp_headers_dict = {
-                k: v
-                for k, v in backend_response.headers.items()
-                if k.lower() not in _HEADERS_TO_STRIP_FROM_RESPONSE
-            }
-            resp_headers_dict["X-Request-Id"] = request_id
 
             async def traced_stream():
                 first_token = False
@@ -1138,33 +1138,26 @@ async def proxy_multipart_request(
             return StreamingResponse(
                 traced_stream(),
                 status_code=backend_response.status,
-                headers=resp_headers_dict,
+                headers=resp_headers,
                 media_type=backend_response.headers.get(
                     "content-type", "text/event-stream"
                 ),
             )
 
-        backend_response = await client.post(
-            f"{chosen_url}{endpoint}",
-            data=form_data,
-            headers=headers,
-            timeout=aiohttp.ClientTimeout(total=300),
-        )
-
-        resp_headers = {
-            k: v
-            for k, v in backend_response.headers.items()
-            if k.lower() not in _HEADERS_TO_STRIP_FROM_RESPONSE
-        }
-        resp_headers["X-Request-Id"] = request_id
-
-        response_content = await backend_response.json()
-
-        return JSONResponse(
-            content=response_content,
-            status_code=backend_response.status,
-            headers=resp_headers,
-        )
+        try:
+            request_stats_monitor.on_request_response(
+                chosen_url, request_id, time.time()
+            )
+            response_content = await backend_response.json()
+            return JSONResponse(
+                content=response_content,
+                status_code=backend_response.status,
+                headers=resp_headers,
+            )
+        finally:
+            request_stats_monitor.on_request_complete(
+                chosen_url, request_id, time.time()
+            )
     except aiohttp.ClientResponseError as response_error:
         if response_error.response is not None:
             try:

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -952,11 +952,9 @@ async def route_general_transcriptions(
 ):
     """Handles audio transcription requests by parsing form data and proxying to backend."""
 
-    # --- 1. Form parsing ---
     try:
         form = await request.form()
 
-        # Extract parameters from the form data
         file: UploadFile = form["file"]
         model: str = form["model"]
         prompt: Optional[str] = form.get("prompt", None)
@@ -966,6 +964,7 @@ async def route_general_transcriptions(
             float(temperature_str) if temperature_str is not None else None
         )
         language: Optional[str] = form.get("language", "en")
+        stream: bool = form.get("stream", "false").lower() == "true"
     except KeyError as e:
         return JSONResponse(
             status_code=400,
@@ -975,15 +974,15 @@ async def route_general_transcriptions(
     logger.debug("==== Enter audio_transcriptions ====")
     logger.debug("Received upload: %s (%s)", file.filename, file.content_type)
     logger.debug(
-        "Params: model=%s prompt=%r response_format=%r temperature=%r language=%s",
+        "Params: model=%s prompt=%r response_format=%r temperature=%r language=%s stream=%s",
         model,
         prompt,
         response_format,
         temperature,
         language,
+        stream,
     )
 
-    # --- 3. Prepare and Proxy the Request ---
     payload_bytes = await file.read()
     files = {"file": (file.filename, payload_bytes, file.content_type)}
 
@@ -998,17 +997,20 @@ async def route_general_transcriptions(
     if temperature is not None:
         data["temperature"] = str(temperature)
 
+    if stream:
+        data["stream"] = "true"
+
     form_data = aiohttp.FormData()
 
-    # add file data
     for key, (filename, content, content_type) in files.items():
         form_data.add_field(key, content, filename=filename, content_type=content_type)
 
-    # add from data
     for key, value in data.items():
         form_data.add_field(key, value)
 
-    return await proxy_multipart_request(form_data, model, endpoint, request)
+    return await proxy_multipart_request(
+        form_data, model, endpoint, request, stream=stream
+    )
 
 
 async def route_image_edit_request(
@@ -1034,7 +1036,12 @@ async def route_image_edit_request(
 
 
 async def proxy_multipart_request(
-    form_data: bytes | FormData, model: str, endpoint: str, request: Request
+    form_data: bytes | FormData,
+    model: str,
+    endpoint: str,
+    request: Request,
+    *,
+    stream: bool = False,
 ):
     request_id = request.headers.get("X-Request-Id", str(uuid.uuid4()))
 
@@ -1045,21 +1052,13 @@ async def proxy_multipart_request(
             headers={"X-Request-Id": request_id},
         )
 
-    # Access singletons via request.app.state for consistent style
-    service_discovery = (
-        get_service_discovery()
-    )  # This one is often still accessed directly via its get function
-    router = request.app.state.router  # Access router from app.state
-    engine_stats_scraper = (
-        request.app.state.engine_stats_scraper
-    )  # Access engine_stats_scraper from app.state
-    request_stats_monitor = (
-        request.app.state.request_stats_monitor
-    )  # Access request_stats_monitor from app.state
+    service_discovery = get_service_discovery()
+    router = request.app.state.router
+    engine_stats_scraper = request.app.state.engine_stats_scraper
+    request_stats_monitor = request.app.state.request_stats_monitor
 
     endpoints = service_discovery.get_endpoint_info()
 
-    # filter the endpoints url by model name
     endpoints = [ep for ep in endpoints if model in ep.model_names and not ep.sleep]
 
     if not endpoints:
@@ -1095,6 +1094,56 @@ async def proxy_multipart_request(
             }
             headers["X-Request-Id"] = request_id
 
+        if stream:
+            start_time = time.time()
+            request_stats_monitor.on_new_request(chosen_url, request_id, start_time)
+
+            try:
+                backend_response = await client.post(
+                    f"{chosen_url}{endpoint}",
+                    data=form_data,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=300),
+                )
+            except BaseException:
+                request_stats_monitor.on_request_complete(
+                    chosen_url, request_id, time.time()
+                )
+                raise
+
+            resp_headers_dict = {
+                k: v
+                for k, v in backend_response.headers.items()
+                if k.lower() not in _HEADERS_TO_STRIP_FROM_RESPONSE
+            }
+            resp_headers_dict["X-Request-Id"] = request_id
+
+            async def traced_stream():
+                first_token = False
+                try:
+                    async for chunk in backend_response.content.iter_any():
+                        if not first_token:
+                            first_token = True
+                            request_stats_monitor.on_request_response(
+                                chosen_url, request_id, time.time()
+                            )
+                        if chunk:
+                            yield chunk
+                finally:
+                    backend_response.close()
+                    request_stats_monitor.on_request_complete(
+                        chosen_url, request_id, time.time()
+                    )
+
+            return StreamingResponse(
+                traced_stream(),
+                status_code=backend_response.status,
+                headers=resp_headers_dict,
+                media_type=backend_response.headers.get(
+                    "content-type", "text/event-stream"
+                ),
+            )
+
         backend_response = await client.post(
             f"{chosen_url}{endpoint}",
             data=form_data,
@@ -1102,20 +1151,19 @@ async def proxy_multipart_request(
             timeout=aiohttp.ClientTimeout(total=300),
         )
 
-        # --- 4. Return the response ---
-        response_content = await backend_response.json()
-        headers = {
+        resp_headers = {
             k: v
             for k, v in backend_response.headers.items()
             if k.lower() not in _HEADERS_TO_STRIP_FROM_RESPONSE
         }
+        resp_headers["X-Request-Id"] = request_id
 
-        headers["X-Request-Id"] = request_id
+        response_content = await backend_response.json()
 
         return JSONResponse(
             content=response_content,
             status_code=backend_response.status,
-            headers=headers,
+            headers=resp_headers,
         )
     except aiohttp.ClientResponseError as response_error:
         if response_error.response is not None:

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1269,6 +1269,18 @@ async def proxy_multipart_request(
                 status_code=backend_response.status,
                 headers=resp_headers,
             )
+        except (aiohttp.ContentTypeError, json.JSONDecodeError) as parse_error:
+            try:
+                text_content = await backend_response.text()
+            except aiohttp.ClientError:
+                text_content = str(parse_error)
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": f"Backend returned non-JSON response: {text_content}"
+                },
+                headers=resp_headers,
+            )
         finally:
             request_stats_monitor.on_request_complete(
                 chosen_url, request_id, time.time()

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1296,6 +1296,7 @@ async def proxy_multipart_request(
                 headers=resp_headers,
             )
         finally:
+            backend_response.close()
             request_stats_monitor.on_request_complete(
                 chosen_url, request_id, time.time()
             )

--- a/tutorials/23-whisper-api-transcription.md
+++ b/tutorials/23-whisper-api-transcription.md
@@ -129,7 +129,10 @@ async def stream_transcription():
 
     async with aiohttp.ClientSession() as session:
         async with session.post(url, data=data) as response:
-            async for line in response.content:
+            while True:
+                line = await response.content.readline()
+                if not line:
+                    break
                 line = line.decode("utf-8").strip()
                 if line.startswith("data: "):
                     print(line[6:])  # Print the JSON data

--- a/tutorials/23-whisper-api-transcription.md
+++ b/tutorials/23-whisper-api-transcription.md
@@ -119,8 +119,11 @@ import asyncio
 async def stream_transcription():
     url = "http://localhost:8000/v1/audio/transcriptions"
 
+    with open("audio.wav", "rb") as audio_file:
+        audio_bytes = audio_file.read()
+
     data = aiohttp.FormData()
-    data.add_field("file", open("audio.wav", "rb"), filename="audio.wav", content_type="audio/wav")
+    data.add_field("file", audio_bytes, filename="audio.wav", content_type="audio/wav")
     data.add_field("model", "openai/whisper-small")
     data.add_field("stream", "true")
 

--- a/tutorials/23-whisper-api-transcription.md
+++ b/tutorials/23-whisper-api-transcription.md
@@ -85,8 +85,56 @@ curl -v http://localhost:8000/v1/audio/transcriptions \
 | `response_format` | One of `json`, `text`, `srt`, `verbose_json`, or `vtt` |
 | `temperature`     | *(Optional)* Sampling temperature as a float           |
 | `language`        | ISO 639-1 code (e.g., `en`, `fr`, `zh`)                |
+| `stream`          | *(Optional)* Set to `true` to receive streaming SSE response |
 
-## 4. Sample Output
+## 4. Streaming Transcription
+
+For long audio files, you can enable streaming to receive transcription results incrementally as Server-Sent Events (SSE):
+
+```bash
+curl -v http://localhost:8000/v1/audio/transcriptions \
+  -F 'file=@/path/to/long_audio.wav;type=audio/wav' \
+  -F 'model=openai/whisper-small' \
+  -F 'response_format=json' \
+  -F 'language=en' \
+  -F 'stream=true'
+```
+
+The response will be streamed as SSE chunks:
+
+```text
+data: {"text": "Hello"}
+
+data: {"text": " world"}
+
+data: {"text": ", this is a test"}
+```
+
+### Python Example for Streaming
+
+```python
+import aiohttp
+import asyncio
+
+async def stream_transcription():
+    url = "http://localhost:8000/v1/audio/transcriptions"
+
+    data = aiohttp.FormData()
+    data.add_field("file", open("audio.wav", "rb"), filename="audio.wav", content_type="audio/wav")
+    data.add_field("model", "openai/whisper-small")
+    data.add_field("stream", "true")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, data=data) as response:
+            async for line in response.content:
+                line = line.decode("utf-8").strip()
+                if line.startswith("data: "):
+                    print(line[6:])  # Print the JSON data
+
+asyncio.run(stream_transcription())
+```
+
+## 5. Sample Output
 
 ```json
 {
@@ -94,12 +142,12 @@ curl -v http://localhost:8000/v1/audio/transcriptions \
 }
 ```
 
-## 5. Notes
+## 6. Notes
 
 * Router uses extended aiohttp timeouts to support long transcription jobs.
 * This implementation dynamically discovers valid transcription backends and routes requests accordingly.
 
-## 6. Resources
+## 7. Resources
 
 * [PR #469 – Add Whisper Transcription API](https://github.com/vllm-project/production-stack/pull/469)
 * [OpenAI Whisper GitHub](https://github.com/openai/whisper)


### PR DESCRIPTION
Adds a streaming (`stream=true`) path to `proxy_multipart_request` so the router can forward chunked transcription responses (SSE / ndjson) from backend Whisper engines straight to the client, instead of buffering the full JSON body before replying.

### What changed
- `src/vllm_router/services/request_service/request.py`
  - New streaming branch: opens the upstream `aiohttp` response with `await client.post(...)` (outside any async generator), forwards headers/status immediately, and streams body chunks via `StreamingResponse`.
  - Upstream response lifetime is managed outside the body iterator. `traced_stream()`'s `finally` block explicitly calls `backend_response.close()` plus `request_stats_monitor.on_request_complete(...)`, so an aborted consumer (downstream disconnect) can never leak the backend connection or skip stats cleanup.
  - `on_new_request` / `on_request_complete` are balanced on the post-failure path via `except BaseException: ... raise`, so a failed `client.post(...)` still completes the stats pair before bubbling up to the existing JSON error handlers.
- `src/tests/test_transcription_streaming.py`
  - Full unit coverage for the streaming path: returns `StreamingResponse`, preserves content-type, passes form-data boundary, fires `on_new_request` / `on_request_response` / `on_request_complete` once each.
  - Dedicated cancellation test (`test_streaming_closes_upstream_on_consumer_abort`) calls `body_iterator.aclose()` after the first chunk and asserts that `backend_response.close()` and `on_request_complete` both fire. Guards against the connection-leak risk flagged in adversarial review.
  - Connection-failure test asserts 503 JSON response + stats balanced even when `client.post(...)` raises before headers.
- `tutorials/23-whisper-api-transcription.md` — tutorial updated with streaming usage examples.

### Why
Whisper-style transcription can take tens of seconds per file. Without streaming, clients wait for the full response before receiving any text, and long requests look indistinguishable from hangs. Streaming gives time-to-first-token feedback and matches the shape already used for chat-completions in this router.

### Risk / design notes
- The streaming path deliberately keeps the upstream `ClientResponse` alive beyond the handler frame, then closes it from the body iterator's `finally`. The closure path is covered by the new cancellation test.
- Non-streaming (`stream=false`) path is unchanged — backward compatible.

FIX #xxxx (*link existing issues this PR will resolve*)

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.

</details>
