### PR TITLE
[Bugfix][Router] Preserve full backend model metadata in /v1/models

### DIFF
--- a/src/tests/test_main_router_models.py
+++ b/src/tests/test_main_router_models.py
@@ -1,0 +1,115 @@
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_router.routers.main_router import show_models
+from vllm_router.service_discovery import EndpointInfo, ModelInfo
+
+
+def _build_request():
+    request = MagicMock()
+    request.app.state = MagicMock()
+    request.app.state.external_provider_registry = None
+    return request
+
+
+def _build_endpoint(model_payload):
+    model_id = model_payload["id"]
+    return EndpointInfo(
+        url="http://engine",
+        model_names=[model_id],
+        Id="engine-1",
+        added_timestamp=0.0,
+        model_label=model_id,
+        sleep=False,
+        model_info={model_id: ModelInfo.from_dict(model_payload)},
+    )
+
+
+def test_model_info_preserves_extra_fields():
+    payload = {
+        "id": "test-model",
+        "object": "model",
+        "created": 123,
+        "owned_by": "vllm",
+        "root": "models/test-model",
+        "parent": None,
+        "max_model_len": 8192,
+        "permission": [{"id": "perm-1", "allow_sampling": True}],
+    }
+
+    model_info = ModelInfo.from_dict(payload)
+
+    assert model_info.extra_fields == {
+        "max_model_len": 8192,
+        "permission": [{"id": "perm-1", "allow_sampling": True}],
+    }
+    assert model_info.to_dict() == payload
+
+
+@pytest.mark.asyncio
+async def test_show_models_returns_full_backend_model_payload(monkeypatch):
+    payload = {
+        "id": "rich-model",
+        "object": "model",
+        "created": 1774275193,
+        "owned_by": "vllm",
+        "root": "models/rich-model",
+        "parent": None,
+        "max_model_len": 262144,
+        "permission": [
+            {
+                "id": "modelperm-1",
+                "object": "model_permission",
+                "allow_sampling": True,
+                "allow_logprobs": True,
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        "vllm_router.routers.main_router.get_service_discovery",
+        lambda: MagicMock(get_endpoint_info=lambda: [_build_endpoint(payload)]),
+    )
+
+    response = await show_models(_build_request())
+
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert body["data"] == [payload]
+
+
+@pytest.mark.asyncio
+async def test_show_models_does_not_warn_for_preserved_backend_fields(
+    monkeypatch, caplog
+):
+    payload = {
+        "id": "rich-model",
+        "object": "model",
+        "created": 1774275193,
+        "owned_by": "vllm",
+        "root": "models/rich-model",
+        "parent": None,
+        "max_model_len": 262144,
+        "permission": [
+            {
+                "id": "modelperm-1",
+                "object": "model_permission",
+                "allow_sampling": True,
+                "allow_logprobs": True,
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        "vllm_router.routers.main_router.get_service_discovery",
+        lambda: MagicMock(get_endpoint_info=lambda: [_build_endpoint(payload)]),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="vllm_router.protocols"):
+        response = await show_models(_build_request())
+
+    assert response.status_code == 200
+    assert "ignored" not in caplog.text

--- a/src/vllm_router/protocols.py
+++ b/src/vllm_router/protocols.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -11,11 +11,12 @@ logger = init_logger(__name__)
 class OpenAIBaseModel(BaseModel):
     # OpenAI API does allow extra fields
     model_config = ConfigDict(extra="allow")
+    _warn_on_extra_fields: ClassVar[bool] = True
 
     @model_validator(mode="before")
     @classmethod
     def __log_extra_fields__(cls, data):
-        if isinstance(data, dict):
+        if cls._warn_on_extra_fields and isinstance(data, dict):
             # Get all class field names and their potential aliases
             field_names = set()
             for field_name, field in cls.model_fields.items():
@@ -43,6 +44,7 @@ class ErrorResponse(OpenAIBaseModel):
 
 
 class ModelCard(OpenAIBaseModel):
+    _warn_on_extra_fields: ClassVar[bool] = False
     id: str
     object: str = "model"
     created: int = Field(default_factory=lambda: int(time.time()))

--- a/src/vllm_router/routers/main_router.py
+++ b/src/vllm_router/routers/main_router.py
@@ -152,13 +152,7 @@ async def show_models(request: Request):
             if model_id in existing_models:
                 continue
 
-            model_card = ModelCard(
-                id=model_id,
-                object="model",
-                created=model_info.created,
-                owned_by=model_info.owned_by,
-                parent=model_info.parent,
-            )
+            model_card = ModelCard(**model_info.to_dict())
             model_cards.append(model_card)
             existing_models.add(model_id)
 

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -32,6 +32,16 @@ from vllm_router.log import init_logger
 logger = init_logger(__name__)
 
 _global_service_discovery: "Optional[ServiceDiscovery]" = None
+_MODEL_INFO_KNOWN_FIELDS = frozenset(
+    {
+        "id",
+        "object",
+        "created",
+        "owned_by",
+        "root",
+        "parent",
+    }
+)
 
 
 class ServiceDiscoveryType(enum.Enum):
@@ -43,17 +53,6 @@ class ServiceDiscoveryType(enum.Enum):
 @dataclass
 class ModelInfo:
     """Information about a model including its relationships and metadata."""
-
-    _KNOWN_FIELDS = frozenset(
-        {
-            "id",
-            "object",
-            "created",
-            "owned_by",
-            "root",
-            "parent",
-        }
-    )
 
     id: str
     object: str
@@ -75,7 +74,9 @@ class ModelInfo:
             root=data.get("root", None),
             parent=data.get("parent", None),
             is_adapter=data.get("parent") is not None,
-            extra_fields={k: v for k, v in data.items() if k not in cls._KNOWN_FIELDS},
+            extra_fields={
+                k: v for k, v in data.items() if k not in _MODEL_INFO_KNOWN_FIELDS
+            },
         )
 
     def to_dict(self) -> Dict:

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -20,7 +20,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 import aiohttp
 import requests
@@ -44,6 +44,17 @@ class ServiceDiscoveryType(enum.Enum):
 class ModelInfo:
     """Information about a model including its relationships and metadata."""
 
+    _KNOWN_FIELDS = frozenset(
+        {
+            "id",
+            "object",
+            "created",
+            "owned_by",
+            "root",
+            "parent",
+        }
+    )
+
     id: str
     object: str
     created: int = 0
@@ -51,6 +62,7 @@ class ModelInfo:
     root: Optional[str] = None
     parent: Optional[str] = None
     is_adapter: bool = False
+    extra_fields: Dict[str, Any] = None
 
     @classmethod
     def from_dict(cls, data: Dict) -> "ModelInfo":
@@ -63,19 +75,22 @@ class ModelInfo:
             root=data.get("root", None),
             parent=data.get("parent", None),
             is_adapter=data.get("parent") is not None,
+            extra_fields={k: v for k, v in data.items() if k not in cls._KNOWN_FIELDS},
         )
 
     def to_dict(self) -> Dict:
         """Convert the ModelInfo instance to a dictionary."""
-        return {
+        data = {
             "id": self.id,
             "object": self.object,
             "created": self.created,
             "owned_by": self.owned_by,
             "root": self.root,
             "parent": self.parent,
-            "is_adapter": self.is_adapter,
         }
+        if self.extra_fields:
+            data.update(self.extra_fields)
+        return data
 
 
 @dataclass


### PR DESCRIPTION
## Summary
This fixes #892 by preserving extra fields returned by backend `/v1/models` responses instead of rebuilding a minimal router-only model card.

The change stores unknown backend model fields in `ModelInfo.extra_fields` and serializes them back out from the router's `/v1/models` endpoint. That keeps metadata such as `max_model_len` and `permission` available to clients.

## Validation
- `uv run --group test python -m pytest -q src/tests/test_main_router_models.py`
- `uv run --group test python -m pytest -q src/tests`
- Live check against a real Dockerized vLLM backend (`vllm/vllm-openai-cpu:latest-arm64`):
  - backend `/v1/models` included `max_model_len` and `permission`
  - `fork/main` router output dropped those fields
  - this branch preserved them (`base_missing=['max_model_len', 'permission']`, `fix_missing=[]`)