### PR TITLE
[Bugfix][Dashboard] Dedup healthy_pods_total across router replicas

### DIFF
--- a/helm/dashboards/vllm-dashboard.json
+++ b/helm/dashboards/vllm-dashboard.json
@@ -90,7 +90,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "count by(endpoint) (vllm:healthy_pods_total)",
+          "expr": "sum(max by (server) (vllm:healthy_pods_total))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,

--- a/tutorials/terraform/coreweave/config/vllm-dashboard.json
+++ b/tutorials/terraform/coreweave/config/vllm-dashboard.json
@@ -90,7 +90,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "count by(endpoint) (vllm:healthy_pods_total)",
+          "expr": "sum(max by (server) (vllm:healthy_pods_total))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,

--- a/tutorials/terraform/eks/config/vllm-dashboard.json
+++ b/tutorials/terraform/eks/config/vllm-dashboard.json
@@ -90,7 +90,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "count by(endpoint) (vllm:healthy_pods_total)",
+          "expr": "sum(max by (server) (vllm:healthy_pods_total))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,

--- a/tutorials/terraform/nebius/config/vllm-dashboard.json
+++ b/tutorials/terraform/nebius/config/vllm-dashboard.json
@@ -90,7 +90,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "count by(endpoint) (vllm:healthy_pods_total)",
+          "expr": "sum(max by (server) (vllm:healthy_pods_total))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,


### PR DESCRIPTION
The "Available vLLM instances" stat panel reads:

```promql
count by(endpoint) (vllm:healthy_pods_total)
```

The metric is emitted by each router replica from its own service-discovery view, so Prometheus stores N time-series per backend (one per scrape target). `count by(endpoint)` then multiplies the result by router replica count.

Fix:

```promql
sum(max by (server) (vllm:healthy_pods_total))
```

`max by (server)` dedups across router replicas before summing. The metric is 0/1, so max is effectively OR across replicas. If any router sees a backend healthy, it counts.

Went with max (optimistic) over min (pessimistic) on purpose. During scale-up or SD propagation lag, routers can briefly disagree about a backend's health. For an availability stat, the useful answer is "is there a router willing to route there", and `min` would under-report during transient lag.

### Verification

promtool tests with synthetic series:

```
$ promtool test rules healthy_pods_test.yml
  SUCCESS
```

1. 3 routers × 2 healthy backends → old query: 6, new query: 2
2. 1 router × 2 healthy backends → new query: 2
3. 3 routers × 1 healthy + 1 unhealthy → new query: 1
4. Router disagreement (1 healthy view, 2 unhealthy) → new query: 1
5. All unhealthy → new query: 0

Fixes #644

---

- [x] Make sure the code changes pass the pre-commit checks.
- [x] Sign-off your commit
- [x] PR title classified [Bugfix]