### PR TITLE
[CI/Build] Anchor Chart.yaml version grep to start of line

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -70,7 +70,7 @@ jobs:
         id: chart-version
         run: |
           set -euo pipefail
-          CHART_VERSION=$(grep -oP 'version: \K[0-9]+\.[0-9]+\.[0-9]+' helm/Chart.yaml)
+          CHART_VERSION=$(grep -oP '^version: \K[0-9]+\.[0-9]+\.[0-9]+' helm/Chart.yaml)
           echo "version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Chart version: ${CHART_VERSION}"
 

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -61,7 +61,7 @@ jobs:
         id: bump-version
         run: |
           # Get current version from Chart.yaml
-          CURRENT_VERSION=$(grep -oP 'version: \K[0-9]+\.[0-9]+\.[0-9]+' helm/Chart.yaml)
+          CURRENT_VERSION=$(grep -oP '^version: \K[0-9]+\.[0-9]+\.[0-9]+' helm/Chart.yaml)
 
           # Calculate new version based on bump type
           BUMP_TYPE="${{ steps.bump-type.outputs.bump_type }}"


### PR DESCRIPTION
## Summary

The `release-docker` job was failing with `Invalid format '82.4.3'` when writing to `\$GITHUB_OUTPUT`. Example failure: https://github.com/vllm-project/production-stack/actions/runs/25514259997/job/74881416401

## Root cause

`helm/Chart.yaml` contains three `version:` keys: the chart's own version plus two dependencies (`kube-prometheus-stack: 82.4.3`, `prometheus-adapter: 5.3.0`). The current grep matches all three, producing a multi-line value. When written as `version=0.1.11\n82.4.3\n5.3.0` to `\$GITHUB_OUTPUT`, GHA parses subsequent lines as fresh `key=value` pairs, hence the `Invalid format '82.4.3'` error.

## Fix

Anchor the regex to the start of line (`^version:`). The chart's top-level `version:` key is at column 0; dependency versions are indented under list items, so the anchor narrows the match to the chart's own version.

Same fix applied to `scheduled-release.yml` which has the identical pattern.

## Test plan

- [ ] Confirm release workflow no longer errors on `\$GITHUB_OUTPUT` parsing.
- [x] Local: `grep -oP '^version: ...' helm/Chart.yaml` returns only the chart version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)