### PR TITLE
[Bugfix][Router] service_discovery: add has_ever_seen_model to K8sServiceNameServiceDiscovery

### DIFF
--- a/src/tests/test_k8s_service_name_service_discovery.py
+++ b/src/tests/test_k8s_service_name_service_discovery.py
@@ -1,0 +1,89 @@
+import threading
+from unittest.mock import MagicMock
+
+from vllm_router.service_discovery import K8sServiceNameServiceDiscovery
+
+
+def _make_discovery() -> K8sServiceNameServiceDiscovery:
+    """Build an instance without running __init__ (which starts a k8s watcher)."""
+    instance = K8sServiceNameServiceDiscovery.__new__(K8sServiceNameServiceDiscovery)
+    instance.namespace = "default"
+    instance.known_models = set()
+    instance.known_models_lock = threading.Lock()
+    instance._service_to_model = {}
+    instance.k8s_api = MagicMock()
+    return instance
+
+
+def test_track_known_model_records_model_from_added_event():
+    discovery = _make_discovery()
+
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+
+    assert discovery.has_ever_seen_model("llama3") is True
+    assert discovery.has_ever_seen_model("unknown") is False
+
+
+def test_track_known_model_reads_selector_when_label_missing():
+    discovery = _make_discovery()
+    svc = MagicMock()
+    svc.spec.selector = {"model": "llama3"}
+    discovery.k8s_api.read_namespaced_service.return_value = svc
+
+    discovery._track_known_model("svc-a", "ADDED", None)
+
+    discovery.k8s_api.read_namespaced_service.assert_called_once_with(
+        "svc-a", "default"
+    )
+    assert discovery.has_ever_seen_model("llama3") is True
+
+
+def test_track_known_model_ignores_service_without_model_selector():
+    discovery = _make_discovery()
+    svc = MagicMock()
+    svc.spec.selector = {"app": "vllm"}
+    discovery.k8s_api.read_namespaced_service.return_value = svc
+
+    discovery._track_known_model("svc-a", "ADDED", None)
+
+    assert discovery.known_models == set()
+
+
+def test_track_known_model_ignores_k8s_api_failure():
+    discovery = _make_discovery()
+    discovery.k8s_api.read_namespaced_service.side_effect = RuntimeError("boom")
+
+    discovery._track_known_model("svc-a", "ADDED", None)
+
+    assert discovery.known_models == set()
+
+
+def test_track_known_model_deleted_event_drops_last_reference():
+    discovery = _make_discovery()
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "DELETED", None)
+
+    assert discovery.has_ever_seen_model("llama3") is False
+    assert discovery._service_to_model == {}
+
+
+def test_track_known_model_deleted_event_keeps_label_while_other_service_references_it():
+    discovery = _make_discovery()
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+    discovery._track_known_model("svc-b", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "DELETED", None)
+
+    assert discovery.has_ever_seen_model("llama3") is True
+    assert discovery._service_to_model == {"svc-b": "llama3"}
+
+
+def test_track_known_model_modified_event_updates_mapping():
+    discovery = _make_discovery()
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "MODIFIED", "llama3-v2")
+
+    assert discovery.has_ever_seen_model("llama3-v2") is True
+    assert discovery._service_to_model == {"svc-a": "llama3-v2"}

--- a/src/tests/test_k8s_service_name_service_discovery.py
+++ b/src/tests/test_k8s_service_name_service_discovery.py
@@ -82,6 +82,27 @@ def test_track_known_model_relabel_keeps_old_label_when_another_service_referenc
     assert discovery._service_to_model == {"svc-a": "llama3-v2", "svc-b": "llama3"}
 
 
+def test_track_known_model_modified_event_removing_label_drops_stale(discovery):
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "MODIFIED", None)
+
+    assert discovery.has_ever_seen_model("llama3") is False
+    assert discovery._service_to_model == {}
+
+
+def test_track_known_model_modified_event_removing_label_keeps_other_references(
+    discovery,
+):
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+    discovery._track_known_model("svc-b", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "MODIFIED", None)
+
+    assert discovery.has_ever_seen_model("llama3") is True
+    assert discovery._service_to_model == {"svc-b": "llama3"}
+
+
 def test_track_known_model_modified_event_with_same_label_is_noop(discovery):
     discovery._track_known_model("svc-a", "ADDED", "llama3")
 

--- a/src/tests/test_k8s_service_name_service_discovery.py
+++ b/src/tests/test_k8s_service_name_service_discovery.py
@@ -1,65 +1,37 @@
 import threading
-from unittest.mock import MagicMock
+
+import pytest
 
 from vllm_router.service_discovery import K8sServiceNameServiceDiscovery
 
 
-def _make_discovery() -> K8sServiceNameServiceDiscovery:
+@pytest.fixture
+def discovery() -> K8sServiceNameServiceDiscovery:
     """Build an instance without running __init__ (which starts a k8s watcher)."""
     instance = K8sServiceNameServiceDiscovery.__new__(K8sServiceNameServiceDiscovery)
     instance.namespace = "default"
     instance.known_models = set()
     instance.known_models_lock = threading.Lock()
     instance._service_to_model = {}
-    instance.k8s_api = MagicMock()
     return instance
 
 
-def test_track_known_model_records_model_from_added_event():
-    discovery = _make_discovery()
-
+def test_track_known_model_records_model_from_added_event(discovery):
     discovery._track_known_model("svc-a", "ADDED", "llama3")
 
     assert discovery.has_ever_seen_model("llama3") is True
     assert discovery.has_ever_seen_model("unknown") is False
 
 
-def test_track_known_model_reads_selector_when_label_missing():
-    discovery = _make_discovery()
-    svc = MagicMock()
-    svc.spec.selector = {"model": "llama3"}
-    discovery.k8s_api.read_namespaced_service.return_value = svc
-
+def test_track_known_model_ignores_event_without_model_label(discovery):
     discovery._track_known_model("svc-a", "ADDED", None)
-
-    discovery.k8s_api.read_namespaced_service.assert_called_once_with(
-        "svc-a", "default"
-    )
-    assert discovery.has_ever_seen_model("llama3") is True
-
-
-def test_track_known_model_ignores_service_without_model_selector():
-    discovery = _make_discovery()
-    svc = MagicMock()
-    svc.spec.selector = {"app": "vllm"}
-    discovery.k8s_api.read_namespaced_service.return_value = svc
-
-    discovery._track_known_model("svc-a", "ADDED", None)
+    discovery._track_known_model("svc-b", "ADDED", "")
 
     assert discovery.known_models == set()
+    assert discovery._service_to_model == {}
 
 
-def test_track_known_model_ignores_k8s_api_failure():
-    discovery = _make_discovery()
-    discovery.k8s_api.read_namespaced_service.side_effect = RuntimeError("boom")
-
-    discovery._track_known_model("svc-a", "ADDED", None)
-
-    assert discovery.known_models == set()
-
-
-def test_track_known_model_deleted_event_drops_last_reference():
-    discovery = _make_discovery()
+def test_track_known_model_deleted_event_drops_last_reference(discovery):
     discovery._track_known_model("svc-a", "ADDED", "llama3")
 
     discovery._track_known_model("svc-a", "DELETED", None)
@@ -68,8 +40,9 @@ def test_track_known_model_deleted_event_drops_last_reference():
     assert discovery._service_to_model == {}
 
 
-def test_track_known_model_deleted_event_keeps_label_while_other_service_references_it():
-    discovery = _make_discovery()
+def test_track_known_model_deleted_event_keeps_label_while_other_service_references_it(
+    discovery,
+):
     discovery._track_known_model("svc-a", "ADDED", "llama3")
     discovery._track_known_model("svc-b", "ADDED", "llama3")
 
@@ -79,11 +52,49 @@ def test_track_known_model_deleted_event_keeps_label_while_other_service_referen
     assert discovery._service_to_model == {"svc-b": "llama3"}
 
 
-def test_track_known_model_modified_event_updates_mapping():
-    discovery = _make_discovery()
+def test_track_known_model_deleted_event_for_unknown_service_is_noop(discovery):
+    discovery._track_known_model("svc-ghost", "DELETED", None)
+
+    assert discovery.known_models == set()
+    assert discovery._service_to_model == {}
+
+
+def test_track_known_model_relabel_drops_stale_label(discovery):
     discovery._track_known_model("svc-a", "ADDED", "llama3")
 
     discovery._track_known_model("svc-a", "MODIFIED", "llama3-v2")
 
     assert discovery.has_ever_seen_model("llama3-v2") is True
+    assert discovery.has_ever_seen_model("llama3") is False
     assert discovery._service_to_model == {"svc-a": "llama3-v2"}
+
+
+def test_track_known_model_relabel_keeps_old_label_when_another_service_references_it(
+    discovery,
+):
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+    discovery._track_known_model("svc-b", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "MODIFIED", "llama3-v2")
+
+    assert discovery.has_ever_seen_model("llama3") is True
+    assert discovery.has_ever_seen_model("llama3-v2") is True
+    assert discovery._service_to_model == {"svc-a": "llama3-v2", "svc-b": "llama3"}
+
+
+def test_track_known_model_modified_event_with_same_label_is_noop(discovery):
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+
+    discovery._track_known_model("svc-a", "MODIFIED", "llama3")
+
+    assert discovery._service_to_model == {"svc-a": "llama3"}
+    assert discovery.known_models == {"llama3"}
+
+
+def test_get_known_models_returns_snapshot_copy(discovery):
+    discovery._track_known_model("svc-a", "ADDED", "llama3")
+
+    snapshot = discovery.get_known_models()
+    snapshot.add("injected")
+
+    assert discovery.known_models == {"llama3"}

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -1294,17 +1294,14 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
         """
         with self.known_models_lock:
             old_label = self._service_to_model.get(engine_name)
-            if event == "DELETED":
-                if old_label is None:
-                    return
-                del self._service_to_model[engine_name]
-                if old_label not in self._service_to_model.values():
-                    self.known_models.discard(old_label)
+            new_label = model_label if event != "DELETED" else None
+            if old_label == new_label:
                 return
-            if not model_label or old_label == model_label:
-                return
-            self._service_to_model[engine_name] = model_label
-            self.known_models.add(model_label)
+            if new_label:
+                self._service_to_model[engine_name] = new_label
+                self.known_models.add(new_label)
+            else:
+                self._service_to_model.pop(engine_name, None)
             if (
                 old_label is not None
                 and old_label not in self._service_to_model.values()

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -1175,20 +1175,20 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
                 ):
                     service = event["object"]
                     event_type = event["type"]
-                    if event_type == "DELETED":
-                        if service.metadata.name in self.available_engines:
-                            self._delete_engine(service.metadata.name)
-                        continue
                     service_name = service.metadata.name
+                    if event_type == "DELETED":
+                        self._track_known_model(service_name, "DELETED", None)
+                        if service_name in self.available_engines:
+                            self._delete_engine(service_name)
+                        continue
+                    model_label = self._get_model_label(service)
                     is_service_ready = self._check_service_ready(
                         service_name, self.namespace
                     )
                     if is_service_ready:
                         model_names = self._get_model_names(service_name)
-                        model_label = self._get_model_label(service)
                     else:
                         model_names = []
-                        model_label = None
                     self._on_engine_update(
                         service_name,
                         event_type,
@@ -1288,32 +1288,38 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
         Ensures has_ever_seen_model() returns True even when the backing
         Deployment is scaled to zero (no Ready pod -> no /v1/models probe
         -> never registered by _on_engine_update without this hook).
+        Maintains a per-service refcount so the label is only dropped from
+        known_models once the last Service referencing it is gone or
+        relabelled.
         """
-        if event == "DELETED":
-            with self.known_models_lock:
-                label = self._service_to_model.pop(engine_name, None)
-                if label is None:
-                    return
-                if not any(v == label for v in self._service_to_model.values()):
-                    self.known_models.discard(label)
-            return
-        label = model_label
-        if label is None:
-            try:
-                svc = self.k8s_api.read_namespaced_service(engine_name, self.namespace)
-                label = svc.spec.selector.get("model") if svc.spec.selector else None
-            except Exception:
-                label = None
-        if not label:
-            return
         with self.known_models_lock:
-            self._service_to_model[engine_name] = label
-            self.known_models.add(label)
+            old_label = self._service_to_model.get(engine_name)
+            if event == "DELETED":
+                if old_label is None:
+                    return
+                del self._service_to_model[engine_name]
+                if old_label not in self._service_to_model.values():
+                    self.known_models.discard(old_label)
+                return
+            if not model_label or old_label == model_label:
+                return
+            self._service_to_model[engine_name] = model_label
+            self.known_models.add(model_label)
+            if (
+                old_label is not None
+                and old_label not in self._service_to_model.values()
+            ):
+                self.known_models.discard(old_label)
 
     def has_ever_seen_model(self, model_name: str) -> bool:
         """Check if we've ever seen this model, even if currently scaled to zero."""
         with self.known_models_lock:
             return model_name in self.known_models
+
+    def get_known_models(self) -> Set[str]:
+        """Get all models that have ever been discovered."""
+        with self.known_models_lock:
+            return self.known_models.copy()
 
     def get_endpoint_info(self) -> List[EndpointInfo]:
         """

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -955,6 +955,9 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
         self.available_engines: Dict[str, EndpointInfo] = {}
         self.available_engines_lock = threading.Lock()
         self.label_selector = label_selector
+        self.known_models: Set[str] = set()
+        self.known_models_lock = threading.Lock()
+        self._service_to_model: Dict[str, str] = {}
         self.watcher_timeout_seconds = watcher_timeout_seconds
         self.health_check_timeout_seconds = health_check_timeout_seconds
 
@@ -1241,6 +1244,7 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
         model_names: List[str],
         model_label: Optional[str],
     ) -> None:
+        self._track_known_model(engine_name, event, model_label)
         if event == "ADDED":
             if not engine_name:
                 return
@@ -1272,6 +1276,44 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
             ) and engine_name in self.available_engines:
                 self._delete_engine(engine_name)
                 return
+
+    def _track_known_model(
+        self,
+        engine_name: str,
+        event: str,
+        model_label: Optional[str],
+    ) -> None:
+        """Record every model observed via Service spec.selector["model"].
+
+        Ensures has_ever_seen_model() returns True even when the backing
+        Deployment is scaled to zero (no Ready pod -> no /v1/models probe
+        -> never registered by _on_engine_update without this hook).
+        """
+        if event == "DELETED":
+            with self.known_models_lock:
+                label = self._service_to_model.pop(engine_name, None)
+                if label is None:
+                    return
+                if not any(v == label for v in self._service_to_model.values()):
+                    self.known_models.discard(label)
+            return
+        label = model_label
+        if label is None:
+            try:
+                svc = self.k8s_api.read_namespaced_service(engine_name, self.namespace)
+                label = svc.spec.selector.get("model") if svc.spec.selector else None
+            except Exception:
+                label = None
+        if not label:
+            return
+        with self.known_models_lock:
+            self._service_to_model[engine_name] = label
+            self.known_models.add(label)
+
+    def has_ever_seen_model(self, model_name: str) -> bool:
+        """Check if we've ever seen this model, even if currently scaled to zero."""
+        with self.known_models_lock:
+            return model_name in self.known_models
 
     def get_endpoint_info(self) -> List[EndpointInfo]:
         """


### PR DESCRIPTION
## Summary
- Adds `has_ever_seen_model` hook to `K8sServiceNameServiceDiscovery`, tracked from each Service's `spec.selector["model"]` label at watch time — independent of pod readiness.
- Lets `request.py` distinguish a configured-but-scaled-to-zero model (503, retriable) from a bogus model name (404, terminal).
- Mirrors the hook already implemented on `StaticServiceDiscovery` (#889) and `K8sPodIPServiceDiscovery`.

## Motivation
When KEDA scales a Deployment to zero on idle, the Service remains but no pod ever answers a `/v1/models` probe, so the router never registers the model. Any client request for that model hits `request.py`'s 404 branch, and the OpenAI SDK treats 404 as terminal (no retry) — masking KEDA's scale-from-zero. The `has_ever_seen_model` hook (already consumed by `request.py`) converts the response to 503, and clients retry normally.

## Test plan
- [ ] Unit test: service ADDED with `selector.model=X` → `has_ever_seen_model("X") == True` even with no Ready pod.
- [ ] Unit test: service DELETED → `has_ever_seen_model` returns False only after the last Service referencing that label is removed.
- [ ] E2E: scale backing Deployment to zero with KEDA; request to `/v1/chat/completions` for that model returns 503 (not 404).

Related: #889