### PR TITLE
[Feat] Add per-model custom labels and podLabels to modelSpec

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -82,6 +82,8 @@ This table documents all available configuration values for the Production Stack
 |-------|------|---------|-------------|
 | `servingEngineSpec.modelSpec[].annotations` | map | `{}` | (Optional) Annotations to add to the deployment, e.g., {model: "opt125m"} |
 | `servingEngineSpec.modelSpec[].podAnnotations` | map | `{}` | (Optional) Annotations to add to the pod, e.g., {model: "opt125m"} |
+| `servingEngineSpec.modelSpec[].labels` | map | `{}` | (Optional) Additional labels to add to the deployment |
+| `servingEngineSpec.modelSpec[].podLabels` | map | `{}` | (Optional) Additional labels to add to the pods |
 | `servingEngineSpec.modelSpec[].name` | string | `""` | The name of the model, e.g., "example-model" |
 | `servingEngineSpec.modelSpec[].repository` | string | `""` | The repository of the model, e.g., "vllm/vllm-openai" |
 | `servingEngineSpec.modelSpec[].tag` | string | `""` | The tag of the model, e.g., "latest" |

--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -26,6 +26,9 @@ metadata:
     helm-release-name: {{ .Release.Name }}
   {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 4 }}
   {{- include "chart.engineLabels" . | nindent 4 }}
+  {{- with $modelSpec.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if not (and $modelSpec.keda $modelSpec.keda.enabled) }}
   replicas: {{ $modelSpec.replicaCount }}
@@ -49,6 +52,9 @@ spec:
         helm-release-name: {{ .Release.Name }}
       {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 8 }}
       {{- include "chart.engineLabels" . | nindent 8 }}
+      {{- with $modelSpec.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if $modelSpec.priorityClassName }}
       priorityClassName: {{ $modelSpec.priorityClassName | quote }}

--- a/helm/tests/deployment-vllm-multi_test.yaml
+++ b/helm/tests/deployment-vllm-multi_test.yaml
@@ -176,6 +176,53 @@ tests:
               fieldRef:
                 fieldPath: status.podIP
 
+  - it: should render per-model custom labels and podLabels
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+        - name: "test-model"
+          labels:
+            gpu-size: large
+            team: ml-platform
+          podLabels:
+            cost-center: ml-infra
+            gpu-type: a100
+          repository: "vllm/vllm-openai"
+          tag: "latest"
+          modelURL: "facebook/opt-125m"
+          replicaCount: 1
+          requestCPU: 1
+          requestMemory: "1Gi"
+          requestGPU: 1
+    asserts:
+    - hasDocuments:
+        count: 1
+    - documentIndex: 0
+      isSubset:
+        path: metadata.labels
+        content:
+          gpu-size: large
+          team: ml-platform
+    - documentIndex: 0
+      isSubset:
+        path: spec.template.metadata.labels
+        content:
+          cost-center: ml-infra
+          gpu-type: a100
+    - documentIndex: 0
+      isNotSubset:
+        path: spec.selector.matchLabels
+        content:
+          gpu-size: large
+    - documentIndex: 0
+      isNotSubset:
+        path: spec.selector.matchLabels
+        content:
+          cost-center: ml-infra
+
   - it: should render two models, one with chat templates
     release:
       name: vllm

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1089,6 +1089,10 @@
                                 "description": "The annotations to add to the deployment",
                                 "type": "object"
                             },
+                            "labels": {
+                                "description": "Additional labels to add to the deployment",
+                                "type": "object"
+                            },
                             "enableLoRA": {
                                 "description": "Whether to enable LoRA",
                                 "type": "boolean"
@@ -1374,6 +1378,10 @@
                             },
                             "podAnnotations": {
                                 "description": "The annotations to add to the pods",
+                                "type": "object"
+                            },
+                            "podLabels": {
+                                "description": "Additional labels to add to the pods",
                                 "type": "object"
                             },
                             "priorityClassName": {

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1093,10 +1093,6 @@
                                 "description": "The annotations to add to the deployment",
                                 "type": "object"
                             },
-                            "labels": {
-                                "description": "Additional labels to add to the deployment",
-                                "type": "object"
-                            },
                             "enableLoRA": {
                                 "description": "Whether to enable LoRA",
                                 "type": "boolean"
@@ -1312,6 +1308,10 @@
                                         }
                                     }
                                 }
+                            },
+                            "labels": {
+                                "description": "Additional labels to add to the deployment",
+                                "type": "object"
                             },
                             "limitCPU": {
                                 "description": "The CPU limit for the model. If limitCPU and limitMemory are not specified, only GPU resources will have limits set equal to their requests.",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,10 @@ servingEngineSpec:
     annotations: {}
     # -- The annotations to add to the pods
     podAnnotations: {}
+    # -- Additional labels to add to the deployment
+    labels: {}
+    # -- Additional labels to add to the pods
+    podLabels: {}
     # -- The name of the service account to use for the deployment
     serviceAccountName: ""
     # -- The name of the priority class name for the deployment


### PR DESCRIPTION
Add support for custom `labels` and `podLabels` on a per-model basis via `modelSpec`, similar to the existing `annotations` and `podAnnotations` fields.

`labels` are applied to the Deployment resource metadata, and `podLabels` are applied to the pod template metadata. Neither is added to `selector.matchLabels` since selectors are immutable after creation.

**Use case:** Enables teams to apply custom labels per model for GPU scheduling (e.g., nodeAffinity rules driven by labels) and observability via pod metadata collection.

**Changes:**
- `helm/values.yaml` — Added `labels` and `podLabels` fields to modelSpec
- `helm/values.schema.json` — Added schema definitions for both fields
- `helm/templates/deployment-vllm-multi.yaml` — Render per-model labels on deployment and pod template metadata
- `helm/tests/deployment-vllm-multi_test.yaml` — Added test verifying labels, podLabels, and selector isolation

FIX #934
