### PR TITLE
[Bugfix] Fix /v1/audio/transcriptions endpoint when not using roundrobin

### DIFF
--- a/src/tests/test_request_auth_headers.py
+++ b/src/tests/test_request_auth_headers.py
@@ -32,7 +32,7 @@ def _build_request(headers=None):
     state.callbacks = None
     state.request_stats_monitor.get_request_stats.return_value = {}
     state.engine_stats_scraper.get_engine_stats.return_value = {}
-    state.router.route_request.return_value = "http://whisper-engine"
+    state.router.route_request = AsyncMock(return_value="http://whisper-engine")
 
     request = MagicMock()
     request.headers = headers or {}

--- a/src/tests/test_roundrobin_router.py
+++ b/src/tests/test_roundrobin_router.py
@@ -75,7 +75,9 @@ def test_roundrobin_logic(
         route_counts = Counter()
         for _ in range(num_requests):
             request = generate_request()
-            url = router.route_request(endpoints, engine_stats, request_stats, request)
+            url = await router.route_request(
+                endpoints, engine_stats, request_stats, request
+            )
             route_counts[url] += 1
 
         assert_even_distribution(route_counts)
@@ -97,9 +99,13 @@ def test_roundrobin_keeps_state_per_endpoint_set():
     route_counts_b = Counter()
 
     for _ in range(100):
-        url_a = router.route_request(endpoints_a, engine_stats, request_stats, request)
+        url_a = await router.route_request(
+            endpoints_a, engine_stats, request_stats, request
+        )
         route_counts_a[url_a] += 1
-        url_b = router.route_request(endpoints_b, engine_stats, request_stats, request)
+        url_b = await router.route_request(
+            endpoints_b, engine_stats, request_stats, request
+        )
         route_counts_b[url_b] += 1
 
     assert_even_distribution(route_counts_a)
@@ -115,10 +121,11 @@ def test_roundrobin_keeps_state_when_endpoint_order_changes():
     endpoints_a_reordered = [EndpointInfo(url="a1"), EndpointInfo(url="a0")]
 
     assert (
-        router.route_request(endpoints_a, engine_stats, request_stats, request) == "a0"
+        await router.route_request(endpoints_a, engine_stats, request_stats, request)
+        == "a0"
     )
     assert (
-        router.route_request(
+        await router.route_request(
             endpoints_a_reordered,
             engine_stats,
             request_stats,
@@ -132,4 +139,4 @@ def test_roundrobin_rejects_empty_endpoint_list():
     router = RoundRobinRouter()
 
     with pytest.raises(ValueError, match="at least one endpoint"):
-        router.route_request([], {}, {}, generate_request())
+        await router.route_request([], {}, {}, generate_request())

--- a/src/tests/test_roundrobin_router.py
+++ b/src/tests/test_roundrobin_router.py
@@ -62,7 +62,8 @@ def assert_even_distribution(route_counts: Counter):
     assert max(counts) - min(counts) <= 1
 
 
-def test_roundrobin_logic(
+@pytest.mark.asyncio
+async def test_roundrobin_logic(
     dynamic_discoveries: int = 10, max_endpoints: int = 1000, max_requests: int = 10000
 ):
     """
@@ -70,7 +71,7 @@ def test_roundrobin_logic(
     """
     router = RoundRobinRouter()
 
-    def assert_router_stays_balanced(num_endpoints: int, num_requests: int):
+    async def assert_router_stays_balanced(num_endpoints: int, num_requests: int):
         endpoints, engine_stats, request_stats = generate_request_args(num_endpoints)
         route_counts = Counter()
         for _ in range(num_requests):
@@ -85,10 +86,11 @@ def test_roundrobin_logic(
     for _ in range(dynamic_discoveries):
         num_endpoints = random.randint(1, max_endpoints)
         num_requests = random.randint(1, max_requests)
-        assert_router_stays_balanced(num_endpoints, num_requests)
+        await assert_router_stays_balanced(num_endpoints, num_requests)
 
 
-def test_roundrobin_keeps_state_per_endpoint_set():
+@pytest.mark.asyncio
+async def test_roundrobin_keeps_state_per_endpoint_set():
     router = RoundRobinRouter()
     request = generate_request()
     engine_stats = {}
@@ -112,7 +114,8 @@ def test_roundrobin_keeps_state_per_endpoint_set():
     assert_even_distribution(route_counts_b)
 
 
-def test_roundrobin_keeps_state_when_endpoint_order_changes():
+@pytest.mark.asyncio
+async def test_roundrobin_keeps_state_when_endpoint_order_changes():
     router = RoundRobinRouter()
     request = generate_request()
     engine_stats = {}
@@ -135,7 +138,8 @@ def test_roundrobin_keeps_state_when_endpoint_order_changes():
     )
 
 
-def test_roundrobin_rejects_empty_endpoint_list():
+@pytest.mark.asyncio
+async def test_roundrobin_rejects_empty_endpoint_list():
     router = RoundRobinRouter()
 
     with pytest.raises(ValueError, match="at least one endpoint"):

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -115,12 +115,13 @@ class RoutingInterface(metaclass=SingletonABCMeta):
         return val if val is not None else request_json.get(session_key, None)
 
     @abc.abstractmethod
-    def route_request(
+    async def route_request(
         self,
         endpoints: List[EndpointInfo],
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
+        request_json: Dict = {},
     ) -> str:
         """
         Route the request to the appropriate engine URL
@@ -132,6 +133,7 @@ class RoutingInterface(metaclass=SingletonABCMeta):
             request_stats (Dict[str, RequestStats]): The request stats
                 indicating the request-level performance of each engine
             request (Request): The incoming request
+            request_json (Dict): The request body
         """
         raise NotImplementedError
 
@@ -165,12 +167,13 @@ class RoundRobinRouter(RoutingInterface):
             self._sorted_cache[urls] = key
         return key
 
-    def route_request(
+    async def route_request(
         self,
         endpoints: List[EndpointInfo],
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
+        request_json: Dict = {},
     ) -> str:
         """
         Route the request to the appropriate engine URL using a simple
@@ -183,6 +186,7 @@ class RoundRobinRouter(RoutingInterface):
             request_stats (Dict[str, RequestStats]): The request stats
                 indicating the request-level performance of each engine
             request (Request): The incoming request
+            request_json (Dict): Unused for RoundRobinRouter
         """
         endpoint_urls = self._endpoint_key(endpoints)
         idx = self._next_index.get(endpoint_urls, 0)
@@ -518,7 +522,7 @@ class DisaggregatedPrefillRouter(RoutingInterface):
         self.decode_model_labels = decode_model_labels
         self.request_cache = {}  # Cache to store prefill results
 
-    def route_request(
+    async def route_request(
         self,
         endpoints: List[EndpointInfo],
         engine_stats: Dict[str, EngineStats],

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -493,7 +493,7 @@ class PrefixAwareRouter(RoutingInterface):
                 prompt = ""
         else:
             # Handle regular completions
-            prompt = request_json["prompt"]
+            prompt = request_json.get("prompt", "")
 
         available_endpoints = set(endpoint.url for endpoint in endpoints)
         _, matched_endpoint = await self.hashtrie.longest_prefix_match(

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1110,6 +1110,7 @@ async def route_general_transcriptions(
         )
         language: Optional[str] = form.get("language", "en")
         stream: bool = form.get("stream", "false").lower() == "true"
+        session_id: Optional[str] = form.get("session_id", None)
     except KeyError as e:
         return JSONResponse(
             status_code=400,
@@ -1119,13 +1120,14 @@ async def route_general_transcriptions(
     logger.debug("==== Enter audio_transcriptions ====")
     logger.debug("Received upload: %s (%s)", file.filename, file.content_type)
     logger.debug(
-        "Params: model=%s prompt=%r response_format=%r temperature=%r language=%s stream=%s",
+        "Params: model=%s prompt=%r response_format=%r temperature=%r language=%s stream=%s session_id=%s",
         model,
         prompt,
         response_format,
         temperature,
         language,
         stream,
+        session_id,
     )
 
     payload_bytes = await file.read()
@@ -1145,6 +1147,9 @@ async def route_general_transcriptions(
     if stream:
         data["stream"] = "true"
 
+    if session_id:
+        data["session_id"] = str(session_id)
+
     form_data = aiohttp.FormData()
 
     for key, (filename, content, content_type) in files.items():
@@ -1154,7 +1159,7 @@ async def route_general_transcriptions(
         form_data.add_field(key, value)
 
     return await proxy_multipart_request(
-        form_data, model, endpoint, request, stream=stream
+        form_data, model, endpoint, request, data, stream=stream
     )
 
 
@@ -1185,6 +1190,7 @@ async def proxy_multipart_request(
     model: str,
     endpoint: str,
     request: Request,
+    request_json: dict,
     *,
     stream: bool = False,
 ):
@@ -1218,9 +1224,20 @@ async def proxy_multipart_request(
     request_stats = request_stats_monitor.get_request_stats(time.time())
 
     # pick one using the router's configured logic (roundrobin, least-loaded, etc.)
-    if isinstance(router, (KvawareRouter, PrefixAwareRouter, SessionRouter)):
-        request_json = {}
+    if isinstance(
+        router,
+        (
+            KvawareRouter,
+            PrefixAwareRouter,
+            SessionRouter,
+            DisaggregatedPrefillOrchestratedRouter,
+        ),
+    ):
         chosen_url = await router.route_request(
+            endpoints, engine_stats, request_stats, request, request_json
+        )
+    elif isinstance(router, DisaggregatedPrefillRouter):
+        chosen_url = router.route_request(
             endpoints, engine_stats, request_stats, request, request_json
         )
     else:

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -30,9 +30,6 @@ from vllm_router.log import init_logger
 from vllm_router.routers.routing_logic import (
     DisaggregatedPrefillOrchestratedRouter,
     DisaggregatedPrefillRouter,
-    KvawareRouter,
-    PrefixAwareRouter,
-    SessionRouter,
 )
 from vllm_router.service_discovery import get_service_discovery
 from vllm_router.services.request_service.rewriter import (

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1176,7 +1176,7 @@ async def proxy_multipart_request(
     model: str,
     endpoint: str,
     request: Request,
-    request_json: dict,
+    request_json: dict = {},
     *,
     stream: bool = False,
 ):

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1218,12 +1218,15 @@ async def proxy_multipart_request(
     request_stats = request_stats_monitor.get_request_stats(time.time())
 
     # pick one using the router's configured logic (roundrobin, least-loaded, etc.)
-    chosen_url = router.route_request(
-        endpoints,
-        engine_stats,
-        request_stats,
-        request,
-    )
+    if isinstance(router, (KvawareRouter, PrefixAwareRouter, SessionRouter)):
+        request_json = {}
+        chosen_url = await router.route_request(
+            endpoints, engine_stats, request_stats, request, request_json
+        )
+    else:
+        chosen_url = router.route_request(
+            endpoints, engine_stats, request_stats, request
+        )
     logger.info(
         "Proxying multi-part form request for model %s to %s", model, chosen_url
     )

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -554,16 +554,9 @@ async def route_general_request(
         logger.debug(
             f"Routing request {request_id} to engine with Id: {endpoints[0].Id}"
         )
-
-    elif isinstance(
-        request.app.state.router, (KvawareRouter, PrefixAwareRouter, SessionRouter)
-    ):
+    else:
         server_url = await request.app.state.router.route_request(
             endpoints, engine_stats, request_stats, request, request_json
-        )
-    else:
-        server_url = request.app.state.router.route_request(
-            endpoints, engine_stats, request_stats, request
         )
 
     curr_time = time.time()
@@ -602,16 +595,9 @@ async def route_general_request(
                 break
             if request_endpoint:
                 server_url = remaining[0].url
-            elif isinstance(
-                request.app.state.router,
-                (KvawareRouter, PrefixAwareRouter, SessionRouter),
-            ):
+            else:
                 server_url = await request.app.state.router.route_request(
                     remaining, engine_stats, request_stats, request, request_json
-                )
-            else:
-                server_url = request.app.state.router.route_request(
-                    remaining, engine_stats, request_stats, request
                 )
             logger.info(
                 f"Routing request {request_id} to {server_url} "
@@ -1224,26 +1210,9 @@ async def proxy_multipart_request(
     request_stats = request_stats_monitor.get_request_stats(time.time())
 
     # pick one using the router's configured logic (roundrobin, least-loaded, etc.)
-    if isinstance(
-        router,
-        (
-            KvawareRouter,
-            PrefixAwareRouter,
-            SessionRouter,
-            DisaggregatedPrefillOrchestratedRouter,
-        ),
-    ):
-        chosen_url = await router.route_request(
-            endpoints, engine_stats, request_stats, request, request_json
-        )
-    elif isinstance(router, DisaggregatedPrefillRouter):
-        chosen_url = router.route_request(
-            endpoints, engine_stats, request_stats, request, request_json
-        )
-    else:
-        chosen_url = router.route_request(
-            endpoints, engine_stats, request_stats, request
-        )
+    chosen_url = await router.route_request(
+        endpoints, engine_stats, request_stats, request, request_json
+    )
     logger.info(
         "Proxying multi-part form request for model %s to %s", model, chosen_url
     )


### PR DESCRIPTION
The /v1/audio/transcriptions endpoint was failing with an error due to missing a `request_json` argument when set to any routing logic besides `roundrobin`.
```TypeError: KvawareRouter.route_request() missing 1 required positional argument: 'request_json'```

This is due to `route_request` requiring different parameters depending on routing logic.

This change copies the logic from `route_general_request` to match the required parameters [here](https://github.com/vllm-project/production-stack/blob/main/src/vllm_router/services/request_service/request.py#L558).

After the change, it successfully routes the traffic:
```
[2026-05-12 13:59:15,723] DEBUG: ==== Enter audio_transcriptions ==== (request.py:1119:vllm_router.services.request_service.request)
[2026-05-12 13:59:15,723] DEBUG: Received upload: example.wav (application/octet-stream) (request.py:1120:vllm_router.services.request_service.request)
[2026-05-12 13:59:15,723] DEBUG: Params: model=qwen3-asr prompt=None response_format='json' temperature=None language=en stream=False (request.py:1121:vllm_router.services.request_service.request)
[2026-05-12 13:59:15,731] DEBUG: Lookup return message: LookupRetMsg(event_id='Lookupf7fe41f7-7b6e-4dfc-a5cd-a5e2ad4dd12c', layout_info={}) (routing_logic.py:382:vllm_router.routers.routing_logic)
[2026-05-12 13:59:15,731] DEBUG: Fallback to using session id: None (routing_logic.py:395:vllm_router.routers.routing_logic)
[2026-05-12 13:59:15,731] INFO: Proxying multi-part form request for model qwen3-asr to http://10.244.6.164:8000 (request.py:1232:vllm_router.services.request_service.request)
INFO:     10.244.6.84:34549 - "POST /v1/audio/transcriptions HTTP/1.1" 200 OK
```