### PR TITLE
[Feat][Router] Add per-algorithm routing decisions counter (Refs #474)

### DIFF
--- a/src/tests/test_disaggregated_routing_metrics.py
+++ b/src/tests/test_disaggregated_routing_metrics.py
@@ -1,0 +1,183 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from vllm_router.routers.routing_logic import (
+    DisaggregatedPrefillOrchestratedRouter,
+    DisaggregatedPrefillRouter,
+    cleanup_routing_logic,
+)
+from vllm_router.services.request_service.request import (
+    route_disaggregated_prefill_request,
+    route_orchestrated_disaggregated_request,
+)
+
+
+class AwaitableResponse:
+    def __init__(self, *, json_data=None, body=b"{}"):
+        self.status = 200
+        self._json_data = json_data or {}
+        self._body = body
+        self.content = SimpleNamespace(iter_any=self._iter_any)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def __await__(self):
+        async def resolve():
+            return self
+
+        return resolve().__await__()
+
+    async def json(self):
+        return self._json_data
+
+    async def read(self):
+        return self._body
+
+    async def text(self):
+        return self._body.decode()
+
+    async def _iter_any(self):
+        yield self._body
+
+    def release(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_prefill_and_decode_dispatches_are_each_counted_once():
+    cleanup_routing_logic()
+    router = DisaggregatedPrefillOrchestratedRouter(["prefill"], ["decode"])
+    endpoints = [
+        SimpleNamespace(
+            url="http://prefill.internal:8000",
+            model_label="prefill",
+            Id="prefill-id",
+        ),
+        SimpleNamespace(
+            url="http://decode.internal:8000",
+            model_label="decode",
+            Id="decode-id",
+        ),
+    ]
+    responses = [
+        AwaitableResponse(json_data={"kv_transfer_params": {}}),
+        AwaitableResponse(body=json.dumps({"ok": True}).encode()),
+    ]
+    client = MagicMock()
+    client.post.side_effect = responses
+
+    request = MagicMock()
+    request.headers = {}
+    request.json = AsyncMock(return_value={"model": "test-model", "stream": False})
+    request.app.state.router = router
+    request.app.state.aiohttp_client_wrapper = MagicMock(return_value=client)
+
+    service_discovery = MagicMock()
+    service_discovery.get_endpoint_info.return_value = endpoints
+
+    with (
+        patch(
+            "vllm_router.services.request_service.request.get_service_discovery",
+            return_value=service_discovery,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.record_routing_decision"
+        ) as metric_mock,
+    ):
+        response = await route_orchestrated_disaggregated_request(
+            request, "/v1/chat/completions", MagicMock()
+        )
+
+    assert response.status_code == 200
+    assert metric_mock.call_args_list == [
+        call(
+            algorithm="disaggregated_prefill_orchestrated",
+            decision="primary",
+            reason="prefill",
+        ),
+        call(
+            algorithm="disaggregated_prefill_orchestrated",
+            decision="primary",
+            reason="decode",
+        ),
+    ]
+    assert "http://" not in str(metric_mock.call_args_list)
+    cleanup_routing_logic()
+
+
+@pytest.mark.asyncio
+async def test_fixed_prefill_and_decode_dispatches_are_each_counted_once():
+    cleanup_routing_logic()
+    router = DisaggregatedPrefillRouter(["prefill"], ["decode"])
+    endpoints = [
+        SimpleNamespace(
+            url="http://fixed-prefill.internal:8000",
+            model_label="prefill",
+            Id="fixed-prefill-id",
+        ),
+        SimpleNamespace(
+            url="http://fixed-decode.internal:8000",
+            model_label="decode",
+            Id="fixed-decode-id",
+        ),
+    ]
+    request = MagicMock()
+    request.headers = {}
+    request.json = AsyncMock(return_value={"model": "test-model", "stream": True})
+    request.app.state.router = router
+    request.app.state.prefill_client = SimpleNamespace(
+        _base_url="http://fixed-prefill.internal:8000"
+    )
+    request.app.state.decode_client = SimpleNamespace(
+        _base_url="http://fixed-decode.internal:8000"
+    )
+
+    service_discovery = MagicMock()
+    service_discovery.get_endpoint_info.return_value = endpoints
+
+    async def decode_stream(*_args, **_kwargs):
+        yield b"done"
+
+    with (
+        patch(
+            "vllm_router.services.request_service.request.get_service_discovery",
+            return_value=service_discovery,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.send_request_to_prefiller",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "vllm_router.services.request_service.request.send_request_to_decode",
+            side_effect=decode_stream,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.record_routing_decision"
+        ) as metric_mock,
+    ):
+        response = await route_disaggregated_prefill_request(
+            request, "/v1/chat/completions", MagicMock()
+        )
+        chunks = [chunk async for chunk in response.body_iterator]
+
+    assert chunks == [b"done"]
+    assert metric_mock.call_args_list == [
+        call(
+            algorithm="disaggregated_prefill",
+            decision="primary",
+            reason="prefill",
+        ),
+        call(
+            algorithm="disaggregated_prefill",
+            decision="primary",
+            reason="decode",
+        ),
+    ]
+    cleanup_routing_logic()

--- a/src/tests/test_instance_failover.py
+++ b/src/tests/test_instance_failover.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -26,7 +26,10 @@ def cleanup_singletons():
         del SingletonABCMeta._instances[cls]
 
 
-ENDPOINTS = [EndpointInfo(url="http://engine1"), EndpointInfo(url="http://engine2")]
+ENDPOINTS = [
+    EndpointInfo(url="http://engine1", Id="engine-id-1"),
+    EndpointInfo(url="http://engine2", Id="engine-id-2"),
+]
 
 MOCK_HEADERS = MagicMock()
 MOCK_HEADERS.items.return_value = [("content-type", "text/event-stream")]
@@ -104,15 +107,61 @@ async def test_no_retry_on_success(setup):
         yield MOCK_HEADERS, 200
         yield b"done"
 
-    with patch(
-        "vllm_router.services.request_service.request.process_request", side_effect=ok
-    ) as mock:
+    with (
+        patch(
+            "vllm_router.services.request_service.request.process_request",
+            side_effect=ok,
+        ) as process_mock,
+        patch(
+            "vllm_router.services.request_service.request.record_routing_decision"
+        ) as metric_mock,
+    ):
         from vllm_router.services.request_service.request import route_general_request
 
         resp = await route_general_request(req, "/v1/chat/completions", MagicMock())
 
     assert resp.status_code == 200
-    assert mock.call_count == 1
+    assert process_mock.call_count == 1
+    assert metric_mock.call_args_list == [
+        call(
+            algorithm="roundrobin",
+            decision="primary",
+            reason="round_robin",
+        )
+    ]
+    assert "http://engine1" not in str(metric_mock.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_requested_endpoint_selection_is_counted(setup):
+    req, router = setup
+    router.max_instance_failover_reroute_attempts = 0
+    req.query_params = {"id": "engine-id-2"}
+
+    async def ok(*a, **kw):
+        yield MOCK_HEADERS, 200
+        yield b"done"
+
+    with (
+        patch(
+            "vllm_router.services.request_service.request.process_request",
+            side_effect=ok,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.record_routing_decision"
+        ) as metric_mock,
+    ):
+        from vllm_router.services.request_service.request import route_general_request
+
+        response = await route_general_request(req, "/v1/chat/completions", MagicMock())
+
+    assert response.status_code == 200
+    metric_mock.assert_called_once_with(
+        algorithm="roundrobin",
+        decision="primary",
+        reason="requested_endpoint",
+    )
+    assert "http://engine2" not in str(metric_mock.call_args)
 
 
 @pytest.mark.asyncio
@@ -127,9 +176,14 @@ async def test_retries_on_failure_with_different_url(setup):
         yield MOCK_HEADERS, 200
         yield b"done"
 
-    with patch(
-        "vllm_router.services.request_service.request.process_request",
-        side_effect=fail_then_ok,
+    with (
+        patch(
+            "vllm_router.services.request_service.request.process_request",
+            side_effect=fail_then_ok,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.record_routing_decision"
+        ) as metric_mock,
     ):
         from vllm_router.services.request_service.request import route_general_request
 
@@ -138,6 +192,18 @@ async def test_retries_on_failure_with_different_url(setup):
     assert resp.status_code == 200
     assert len(urls_called) == 2
     assert urls_called[0] != urls_called[1]
+    assert metric_mock.call_args_list == [
+        call(
+            algorithm="roundrobin",
+            decision="primary",
+            reason="round_robin",
+        ),
+        call(
+            algorithm="roundrobin",
+            decision="retry",
+            reason="backend_error",
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_kvaware_router.py
+++ b/src/tests/test_kvaware_router.py
@@ -77,6 +77,11 @@ async def test_kvaware_routes_to_longest_reported_prefix(threshold):
     )
 
     assert selected == url_b
+    assert (selected.algorithm, selected.decision, selected.reason) == (
+        "kvaware",
+        "primary",
+        "cache_hit",
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,3 +168,63 @@ async def test_kvaware_refreshes_unknown_dead_holder_and_uses_live_match():
     )
 
     assert selected == url_b
+
+
+@pytest.mark.parametrize(
+    ("layout_info", "instance_map", "threshold", "expected_reason"),
+    [
+        pytest.param({}, {}, 1000, "no_cache_match", id="no-cache-match"),
+        pytest.param(
+            {"dead-instance": ("LocalCPUBackend", 1000)},
+            {
+                "instance-a": "http://10.0.0.1:8000",
+                "instance-b": "http://10.0.0.2:8000",
+                "dead-instance": "http://10.0.0.9:8000",
+            },
+            1000,
+            "no_live_holder",
+            id="no-live-holder",
+        ),
+        pytest.param(
+            {"instance-a": ("LocalCPUBackend", 100)},
+            {
+                "instance-a": "http://10.0.0.1:8000",
+                "instance-b": "http://10.0.0.2:8000",
+            },
+            0,
+            "below_threshold",
+            id="below-threshold",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_kvaware_fallback_decision_reason(
+    layout_info, instance_map, threshold, expected_reason
+):
+    url_a = "http://10.0.0.1:8000"
+    url_b = "http://10.0.0.2:8000"
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = Tokenizer()
+    router.threshold = threshold
+    router.session_key = "x-session-id"
+    router.hash_ring = routing_logic.HashRing()
+    router.instance_id_to_ip = instance_map
+
+    async def query_manager(_msg):
+        return SimpleNamespace(layout_info=layout_info)
+
+    router.query_manager = query_manager
+    selected = await router.route_request(
+        [EndpointInfo(url_a), EndpointInfo(url_b)],
+        {},
+        {url_a: SimpleNamespace(qps=10), url_b: SimpleNamespace(qps=1)},
+        SimpleNamespace(headers={}),
+        {"prompt": "test"},
+    )
+
+    assert selected == url_b
+    assert (selected.algorithm, selected.decision, selected.reason) == (
+        "kvaware",
+        "fallback",
+        expected_reason,
+    )

--- a/src/tests/test_loadaware_router.py
+++ b/src/tests/test_loadaware_router.py
@@ -74,6 +74,11 @@ class LookupRet:
         self.layout_info = layout_info
 
 
+class InstRet:
+    def __init__(self, instance_id: str):
+        self.instance_id = instance_id
+
+
 def endpoints(*urls):
     return [EndpointInfo(url=url) for url in urls]
 
@@ -311,8 +316,10 @@ async def test_route_request_scores_and_routes_to_the_argmax():
 
     router.tokenizer = Tokenizer()
 
-    async def query_manager(_msg):
-        return LookupRet({INST_A: (LOCAL, PROMPT_TOKENS)})
+    async def query_manager(msg):
+        if hasattr(msg, "tokens"):
+            return LookupRet({INST_A: (LOCAL, PROMPT_TOKENS)})
+        return InstRet(INST_A)
 
     router.query_manager = query_manager
     stats = {URL_A: busy(in_prefill=4, in_decoding=8), URL_B: busy()}
@@ -320,6 +327,11 @@ async def test_route_request_scores_and_routes_to_the_argmax():
         endpoints(URL_A, URL_B), {}, stats, None, {"prompt": "x"}
     )
     assert url == URL_B
+    assert (url.algorithm, url.decision, url.reason) == (
+        "loadaware",
+        "primary",
+        "load_aware",
+    )
 
 
 @pytest.mark.asyncio
@@ -351,6 +363,132 @@ async def test_no_cached_prefix_anywhere_falls_back_to_qps():
         endpoints(URL_A, URL_B), {}, stats, Request(), {"prompt": "x"}
     )
     assert url == URL_B
+    assert (url.algorithm, url.decision, url.reason) == (
+        "loadaware",
+        "fallback",
+        "no_cache_match",
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_url_restart_does_not_credit_the_old_instance_id():
+    """A restart can retain its URL while changing LMCache identity. Even when
+    the old holder is already known, routing must validate the endpoint's live
+    identity before awarding cache credit."""
+    from uhashring import HashRing
+
+    router = make_router()
+
+    class Tokenizer:
+        def encode(self, _prompt):
+            return list(range(PROMPT_TOKENS))
+
+    router.tokenizer = Tokenizer()
+    queried_ips = []
+
+    async def query_manager(msg):
+        if hasattr(msg, "tokens"):
+            return LookupRet({INST_A: (LOCAL, PROMPT_TOKENS)})
+        queried_ips.append(msg.ip)
+        return InstRet(RESTARTED_A)
+
+    router.query_manager = query_manager
+    router.session_key = "x-user-id"
+    router.hash_ring = HashRing()
+
+    class Request:
+        headers: Dict[str, str] = {}
+
+    stats = {URL_A: busy(qps=5.0), URL_B: busy(qps=1.0)}
+    url = await router.route_request(
+        endpoints(URL_A, URL_B), {}, stats, Request(), {"prompt": "x"}
+    )
+
+    assert queried_ips == ["10.0.0.1"]
+    assert url == URL_B
+    assert (url.algorithm, url.decision, url.reason) == (
+        "loadaware",
+        "fallback",
+        "no_live_holder",
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_unavailable_cache_holders_fall_back_to_qps():
+    from uhashring import HashRing
+
+    router = make_router(mapped=False)
+    router.instance_id_to_ip = {
+        INST_A: URL_A,
+        RESTARTED_A: URL_A,
+        INST_B: URL_B,
+    }
+
+    class Tokenizer:
+        def encode(self, _prompt):
+            return list(range(PROMPT_TOKENS))
+
+    router.tokenizer = Tokenizer()
+
+    async def query_manager(msg):
+        if hasattr(msg, "tokens"):
+            return LookupRet({INST_A: (LOCAL, PROMPT_TOKENS)})
+        return InstRet(RESTARTED_A)
+
+    router.query_manager = query_manager
+    router.session_key = "x-user-id"
+    router.hash_ring = HashRing()
+
+    class Request:
+        headers: Dict[str, str] = {}
+
+    stats = {URL_A: busy(qps=5.0), URL_B: busy(qps=1.0)}
+    url = await router.route_request(
+        endpoints(URL_A, URL_B), {}, stats, Request(), {"prompt": "x"}
+    )
+
+    assert url == URL_B
+    assert (url.algorithm, url.decision, url.reason) == (
+        "loadaware",
+        "fallback",
+        "no_live_holder",
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_stale_holder_url_outside_current_endpoints_falls_back_to_qps():
+    from uhashring import HashRing
+
+    router = make_router()
+    router.instance_id_to_ip["instance-c"] = URL_C
+
+    class Tokenizer:
+        def encode(self, _prompt):
+            return list(range(PROMPT_TOKENS))
+
+    router.tokenizer = Tokenizer()
+
+    async def query_manager(_msg):
+        return LookupRet({"instance-c": (LOCAL, PROMPT_TOKENS)})
+
+    router.query_manager = query_manager
+    router.session_key = "x-user-id"
+    router.hash_ring = HashRing()
+
+    class Request:
+        headers: Dict[str, str] = {}
+
+    stats = {URL_A: busy(qps=5.0), URL_B: busy(qps=1.0)}
+    url = await router.route_request(
+        endpoints(URL_A, URL_B), {}, stats, Request(), {"prompt": "x"}
+    )
+
+    assert url == URL_B
+    assert (url.algorithm, url.decision, url.reason) == (
+        "loadaware",
+        "fallback",
+        "no_live_holder",
+    )
 
 
 @pytest.mark.asyncio
@@ -372,10 +510,6 @@ async def test_instance_map_refresh_queries_endpoints_concurrently():
     router = make_router(mapped=False)
     in_flight = 0
     max_in_flight = 0
-
-    class InstRet:
-        def __init__(self, instance_id):
-            self.instance_id = instance_id
 
     async def query_manager(msg):
         nonlocal in_flight, max_in_flight

--- a/src/tests/test_metrics.py
+++ b/src/tests/test_metrics.py
@@ -1,4 +1,12 @@
-from vllm_router.services.metrics_service import request_latency_seconds
+from types import SimpleNamespace
+
+from vllm_router.routers.routing_logic import RoutingDecision
+from vllm_router.services.metrics_service import (
+    record_routing_decision,
+    request_latency_seconds,
+    routing_decisions_total,
+)
+from vllm_router.services.request_service.request import _record_backend_selection
 
 
 def test_records_both_status_labels():
@@ -18,3 +26,63 @@ def test_records_both_status_labels():
     }
 
     assert {"success", "error"} <= statuses_seen
+
+
+def test_routing_counter_uses_bounded_labels_without_raw_url_or_model():
+    raw_url = "http://secret-backend.internal:8000"
+
+    record_routing_decision(
+        algorithm="user-supplied-algorithm",
+        decision="user-supplied-decision",
+        reason=raw_url,
+    )
+
+    samples = [
+        sample
+        for metric in routing_decisions_total.collect()
+        for sample in metric.samples
+        if sample.name == "vllm:routing_decisions_total"
+        and sample.labels.get("algorithm") == "unknown"
+        and sample.labels.get("decision") == "unknown"
+        and sample.labels.get("reason") == "unknown"
+    ]
+    assert len(samples) == 1
+    assert samples[0].labels == {
+        "algorithm": "unknown",
+        "decision": "unknown",
+        "reason": "unknown",
+    }
+    assert raw_url not in str(samples[0].labels)
+    assert "model" not in samples[0].labels
+
+
+def test_arbitrary_endpoint_ids_do_not_create_routing_metric_series():
+    for index in range(10_000):
+        url = f"http://backend-{index}.internal:8000"
+        selection = RoutingDecision(
+            url,
+            algorithm="disaggregated_prefill_orchestrated",
+            decision="retry",
+            reason="missing_session",
+        )
+        _record_backend_selection(
+            selection,
+            [SimpleNamespace(url=url, Id=f"discovered-id-{index}")],
+        )
+
+    samples = [
+        sample
+        for metric in routing_decisions_total.collect()
+        for sample in metric.samples
+        if sample.name == "vllm:routing_decisions_total"
+        and sample.labels.get("algorithm") == "disaggregated_prefill_orchestrated"
+        and sample.labels.get("decision") == "retry"
+        and sample.labels.get("reason") == "missing_session"
+    ]
+
+    assert len(samples) == 1
+    assert samples[0].labels == {
+        "algorithm": "disaggregated_prefill_orchestrated",
+        "decision": "retry",
+        "reason": "missing_session",
+    }

--- a/src/tests/test_prefixaware_router.py
+++ b/src/tests/test_prefixaware_router.py
@@ -70,6 +70,11 @@ async def test_route_falls_back_to_qps_when_match_below_threshold():
     )
 
     assert url == "http://engine2.com"
+    assert (url.algorithm, url.decision, url.reason) == (
+        "prefixaware",
+        "fallback",
+        "below_threshold",
+    )
 
     fake_hashtrie.insert.assert_awaited_once_with(
         "some prompt text", "http://engine2.com"
@@ -153,7 +158,11 @@ async def test_route_uses_matched_endpoint_when_match_above_threshold():
     )
 
     assert url == "http://engine1.com"
-
+    assert (url.algorithm, url.decision, url.reason) == (
+        "prefixaware",
+        "primary",
+        "prefix_match",
+    )
     fake_hashtrie.insert.assert_awaited_once()
 
 

--- a/src/tests/test_priority_router.py
+++ b/src/tests/test_priority_router.py
@@ -90,6 +90,11 @@ async def test_high_priority_request_selects_least_loaded_engine():
     )
 
     assert url == "http://engine2.com"
+    assert (url.algorithm, url.decision, url.reason) == (
+        "priority",
+        "primary",
+        "priority",
+    )
     # Priority must be injected back into the forwarded body.
     assert request_json["priority"] == -1
 
@@ -124,6 +129,11 @@ async def test_default_priority_is_not_treated_as_high_priority():
     )
 
     assert url == "http://engine1.com"
+    assert (url.algorithm, url.decision, url.reason) == (
+        "priority",
+        "fallback",
+        "round_robin",
+    )
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_request_auth_headers.py
+++ b/src/tests/test_request_auth_headers.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from vllm_router.routers.routing_logic import PriorityRouter, RoutingDecision
 from vllm_router.services.request_service.request import (
     process_request,
     proxy_multipart_request,
@@ -12,10 +13,11 @@ from vllm_router.utils import SingletonABCMeta
 
 
 class EndpointInfo:
-    def __init__(self, url, model_names=None, sleep=False):
+    def __init__(self, url, model_names=None, sleep=False, Id=None):
         self.url = url
         self.model_names = model_names or ["whisper-model"]
         self.sleep = sleep
+        self.Id = Id
 
 
 @pytest.fixture(autouse=True)
@@ -109,6 +111,12 @@ async def test_proxy_multipart_request_preserves_client_auth_without_stale_bound
             "x-custom-header": "keep-me",
         }
     )
+    request.app.state.router.route_request.return_value = RoutingDecision(
+        "http://engine",
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
     backend_response = MagicMock()
     backend_response.status = 200
     backend_response.headers.items.return_value = [("content-type", "application/json")]
@@ -119,15 +127,22 @@ async def test_proxy_multipart_request_preserves_client_auth_without_stale_bound
     request.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
 
     service_discovery = MagicMock()
-    service_discovery.get_endpoint_info.return_value = [EndpointInfo("http://engine")]
+    service_discovery.get_endpoint_info.return_value = [
+        EndpointInfo("http://engine", Id="multipart-engine-id")
+    ]
 
     form_data = aiohttp.FormData()
     form_data.add_field("file", b"audio-bytes", filename="sample.wav")
     form_data.add_field("model", "whisper-model")
 
-    with patch(
-        "vllm_router.services.request_service.request.get_service_discovery",
-        return_value=service_discovery,
+    with (
+        patch(
+            "vllm_router.services.request_service.request.get_service_discovery",
+            return_value=service_discovery,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.record_routing_decision"
+        ) as metric_mock,
     ):
         response = await proxy_multipart_request(
             form_data,
@@ -145,3 +160,48 @@ async def test_proxy_multipart_request_preserves_client_auth_without_stale_bound
     assert "x-request-id" not in forwarded_headers
     assert forwarded_headers["x-custom-header"] == "keep-me"
     assert "content-type" not in lowered_headers
+    metric_mock.assert_called_once_with(
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxy_multipart_request_awaits_priority_router_with_request_body():
+    request = _build_request()
+    request.app.state.router = PriorityRouter(priority_default=0, priority_threshold=0)
+
+    backend_response = MagicMock()
+    backend_response.status = 200
+    backend_response.headers.items.return_value = [("content-type", "application/json")]
+    backend_response.json = AsyncMock(return_value={"ok": True})
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=backend_response)
+    request.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    service_discovery = MagicMock()
+    service_discovery.get_endpoint_info.return_value = [
+        EndpointInfo("http://engine", Id="priority-engine-id")
+    ]
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", b"audio-bytes", filename="sample.wav")
+    form_data.add_field("model", "whisper-model")
+
+    with patch(
+        "vllm_router.services.request_service.request.get_service_discovery",
+        return_value=service_discovery,
+    ):
+        response = await proxy_multipart_request(
+            form_data,
+            "whisper-model",
+            "/v1/audio/transcriptions",
+            request,
+        )
+
+    assert response.status_code == 200
+    assert mock_client.post.await_args.args[0] == (
+        "http://engine/v1/audio/transcriptions"
+    )

--- a/src/tests/test_roundrobin_router.py
+++ b/src/tests/test_roundrobin_router.py
@@ -128,6 +128,18 @@ def test_roundrobin_keeps_state_when_endpoint_order_changes():
     )
 
 
+def test_roundrobin_decision_metadata_preserves_string_behavior():
+    router = RoundRobinRouter()
+    selected = router.route_request(
+        [EndpointInfo(url="http://engine1.com")], {}, {}, generate_request()
+    )
+
+    assert selected == "http://engine1.com"
+    assert selected.algorithm == "roundrobin"
+    assert selected.decision == "primary"
+    assert selected.reason == "round_robin"
+
+
 def test_roundrobin_rejects_empty_endpoint_list():
     router = RoundRobinRouter()
 

--- a/src/tests/test_routing_decisions.py
+++ b/src/tests/test_routing_decisions.py
@@ -1,0 +1,185 @@
+"""Routing decision metadata stays compatible with existing URL-string callers."""
+
+import copy
+import pickle
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_router.routers.routing_logic import (
+    DisaggregatedPrefillOrchestratedRouter,
+    DisaggregatedPrefillRouter,
+    RoutingDecision,
+    cleanup_routing_logic,
+)
+from vllm_router.services.request_service.request import _record_backend_selection
+
+
+def test_routing_decision_is_a_string_with_bounded_metadata():
+    decision = RoutingDecision(
+        "http://backend.internal:8000",
+        algorithm="unbounded-algorithm",
+        decision="unbounded-decision",
+        reason="exception: secret request data",
+    )
+
+    assert isinstance(decision, str)
+    assert decision == "http://backend.internal:8000"
+    assert decision.algorithm == "unknown"
+    assert decision.decision == "unknown"
+    assert decision.reason == "unknown"
+
+
+def test_routing_decision_has_no_mutable_instance_dictionary():
+    decision = RoutingDecision(
+        "http://backend.internal:8000",
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+
+    assert not hasattr(decision, "__dict__")
+    with pytest.raises(AttributeError, match="immutable"):
+        decision.algorithm = "priority"
+
+
+@pytest.mark.parametrize("attribute", ["algorithm", "decision", "reason"])
+def test_routing_decision_metadata_cannot_be_deleted(attribute):
+    decision = RoutingDecision(
+        "http://backend.internal:8000",
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+    original_metadata = (decision.algorithm, decision.decision, decision.reason)
+
+    with pytest.raises(AttributeError, match="immutable"):
+        delattr(decision, attribute)
+
+    assert (decision.algorithm, decision.decision, decision.reason) == original_metadata
+
+
+@pytest.mark.parametrize("attribute", ["algorithm", "decision", "reason"])
+def test_routing_decision_metadata_resists_object_setattr(attribute):
+    decision = RoutingDecision(
+        "http://backend.internal:8000",
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+    original_metadata = (decision.algorithm, decision.decision, decision.reason)
+
+    with pytest.raises(AttributeError):
+        object.__setattr__(decision, attribute, "unknown")
+
+    assert (decision.algorithm, decision.decision, decision.reason) == original_metadata
+
+
+@pytest.mark.parametrize("attribute", ["algorithm", "decision", "reason"])
+def test_routing_decision_metadata_resists_object_delattr(attribute):
+    decision = RoutingDecision(
+        "http://backend.internal:8000",
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+    original_metadata = (decision.algorithm, decision.decision, decision.reason)
+
+    with pytest.raises(AttributeError):
+        object.__delattr__(decision, attribute)
+
+    assert (decision.algorithm, decision.decision, decision.reason) == original_metadata
+
+
+@pytest.mark.parametrize(
+    "round_trip",
+    [copy.copy, copy.deepcopy, lambda value: pickle.loads(pickle.dumps(value))],
+    ids=["copy", "deepcopy", "pickle"],
+)
+def test_routing_decision_round_trips_value_and_metadata(round_trip):
+    decision = RoutingDecision(
+        "http://backend.internal:8000",
+        algorithm="loadaware",
+        decision="fallback",
+        reason="no_live_holder",
+    )
+
+    restored = round_trip(decision)
+
+    assert type(restored) is RoutingDecision
+    assert restored == decision
+    assert (restored.algorithm, restored.decision, restored.reason) == (
+        "loadaware",
+        "fallback",
+        "no_live_holder",
+    )
+
+
+def test_backend_selection_records_only_bounded_decision_dimensions():
+    selection = RoutingDecision(
+        "http://unidentified.internal:8000",
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+    endpoint = SimpleNamespace(url=str(selection), Id=None)
+
+    with patch(
+        "vllm_router.services.request_service.request.record_routing_decision"
+    ) as metric_mock:
+        _record_backend_selection(selection, [endpoint])
+
+    metric_mock.assert_called_once_with(
+        algorithm="roundrobin",
+        decision="primary",
+        reason="round_robin",
+    )
+
+
+def test_disaggregated_prefill_router_labels_prefill_and_decode():
+    cleanup_routing_logic()
+    router = DisaggregatedPrefillRouter(["prefill"], ["decode"])
+    endpoints = [
+        SimpleNamespace(url="http://prefill", model_label="prefill"),
+        SimpleNamespace(url="http://decode", model_label="decode"),
+    ]
+
+    prefill = router.route_request(endpoints, {}, {}, None, {"max_tokens": 1})
+    decode = router.route_request(endpoints, {}, {}, None, {"max_tokens": 2})
+
+    assert (prefill.algorithm, prefill.decision, prefill.reason) == (
+        "disaggregated_prefill",
+        "primary",
+        "prefill",
+    )
+    assert (decode.algorithm, decode.decision, decode.reason) == (
+        "disaggregated_prefill",
+        "primary",
+        "decode",
+    )
+    cleanup_routing_logic()
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_router_route_request_has_prefill_metadata():
+    cleanup_routing_logic()
+    router = DisaggregatedPrefillOrchestratedRouter(["prefill"], ["decode"])
+    selected = await router.route_request(
+        [
+            SimpleNamespace(url="http://prefill", model_label="prefill"),
+            SimpleNamespace(url="http://decode", model_label="decode"),
+        ],
+        {},
+        {},
+        None,
+        {},
+    )
+
+    assert selected == "http://prefill"
+    assert (selected.algorithm, selected.decision, selected.reason) == (
+        "disaggregated_prefill_orchestrated",
+        "primary",
+        "prefill",
+    )
+    cleanup_routing_logic()

--- a/src/tests/test_routing_metrics.py
+++ b/src/tests/test_routing_metrics.py
@@ -1,0 +1,217 @@
+import importlib.util
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vllm_router.routers.routing_logic import (
+    DisaggregatedPrefillOrchestratedRouter,
+    KvawareRouter,
+    RoundRobinRouter,
+    SessionRouter,
+    cleanup_routing_logic,
+)
+from vllm_router.services.metrics_service import routing_decisions_total
+
+_LMCACHE_AVAILABLE = importlib.util.find_spec("lmcache") is not None
+requires_lmcache = pytest.mark.skipif(
+    not _LMCACHE_AVAILABLE, reason="lmcache not installed"
+)
+
+
+class EndpointInfo:
+    def __init__(
+        self,
+        url: str,
+        model_label: str = "",
+        model_names: List[str] | None = None,
+    ):
+        self.url = url
+        self.model_label = model_label
+        self.model_names = model_names or ["test-model"]
+
+
+class RequestStats:
+    def __init__(self, qps: float):
+        self.qps = qps
+
+
+class Request:
+    def __init__(self, headers: Dict[str, str], body: Dict[str, Any] = None):
+        self.headers = headers
+        self.body = body
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_router_singletons():
+    cleanup_routing_logic()
+    yield
+    cleanup_routing_logic()
+
+
+def _counter_value(server: str, model: str, algorithm: str, outcome: str) -> float:
+    """Return the current value of the routing decisions counter for the given labels."""
+    for metric in routing_decisions_total.collect():
+        for sample in metric.samples:
+            if not sample.name.endswith("_total"):
+                continue
+            labels = sample.labels
+            if (
+                labels.get("server") == server
+                and labels.get("model") == model
+                and labels.get("algorithm") == algorithm
+                and labels.get("outcome") == outcome
+            ):
+                return sample.value
+    return 0.0
+
+
+def test_roundrobin_records_success_outcome_with_model():
+    router = RoundRobinRouter()
+    endpoints = [EndpointInfo(url="http://engine1.com", model_names=["llama-3"])]
+    request = Request(headers={})
+
+    before = _counter_value("http://engine1.com", "llama-3", "roundrobin", "success")
+    router.route_request(endpoints, {}, {}, request)
+    after = _counter_value("http://engine1.com", "llama-3", "roundrobin", "success")
+
+    assert after - before == 1
+
+
+@pytest.mark.asyncio
+async def test_session_router_records_fallback_when_no_session_id():
+    router = SessionRouter(session_key="session_id")
+    endpoints = [
+        EndpointInfo(url="http://engine1.com"),
+        EndpointInfo(url="http://engine2.com"),
+    ]
+    request_stats = {
+        "http://engine1.com": RequestStats(qps=10),
+        "http://engine2.com": RequestStats(qps=5),
+    }
+    request = Request(headers={})
+    request_json = {"model": "llama-3"}
+
+    before = _counter_value("http://engine2.com", "llama-3", "session", "fallback")
+    url = await router.route_request(
+        endpoints, None, request_stats, request, request_json
+    )
+    after = _counter_value("http://engine2.com", "llama-3", "session", "fallback")
+
+    assert url == "http://engine2.com"
+    assert after - before == 1
+
+
+@pytest.mark.asyncio
+async def test_session_router_records_success_with_session_id():
+    router = SessionRouter(session_key="session_id")
+    endpoints = [
+        EndpointInfo(url="http://engine1.com"),
+        EndpointInfo(url="http://engine2.com"),
+    ]
+    request_stats = {
+        "http://engine1.com": RequestStats(qps=10),
+        "http://engine2.com": RequestStats(qps=5),
+    }
+    request = Request(headers={"session_id": "abc123"})
+    request_json = {"model": "llama-3"}
+
+    before = {
+        ep.url: _counter_value(ep.url, "llama-3", "session", "success")
+        for ep in endpoints
+    }
+    url = await router.route_request(
+        endpoints, None, request_stats, request, request_json
+    )
+    after = _counter_value(url, "llama-3", "session", "success")
+
+    assert after - before[url] == 1
+
+
+@requires_lmcache
+@pytest.mark.asyncio
+async def test_kvaware_router_records_success_for_session_hashring_on_kv_miss():
+    # __new__ + manual field setup bypasses the lmcache controller in __init__.
+    router = KvawareRouter.__new__(KvawareRouter)
+    router._initialized = True
+    router.session_key = "session_id"
+    router.threshold = 2000
+    router.tokenizer = MagicMock()
+    router.tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+    router.instance_id_to_ip = {}
+    from uhashring import HashRing
+
+    router.hash_ring = HashRing()
+    empty_layout = MagicMock()
+    empty_layout.layout_info = {}
+    router.query_manager = AsyncMock(return_value=empty_layout)
+
+    endpoints = [
+        EndpointInfo(url="http://engine1.com"),
+        EndpointInfo(url="http://engine2.com"),
+    ]
+    request_stats = {
+        "http://engine1.com": RequestStats(qps=10),
+        "http://engine2.com": RequestStats(qps=5),
+    }
+    request = Request(headers={"session_id": "abc123"})
+    request_json = {"model": "llama-3", "prompt": "hi"}
+
+    before = {
+        ep.url: _counter_value(ep.url, "llama-3", "kvaware", "success")
+        for ep in endpoints
+    }
+    url = await router.route_request(
+        endpoints, None, request_stats, request, request_json
+    )
+    after = _counter_value(url, "llama-3", "kvaware", "success")
+
+    assert after - before[url] == 1
+
+
+def test_disaggregated_prefill_orchestrated_records_two_decisions_per_request():
+    router = DisaggregatedPrefillOrchestratedRouter(
+        prefill_model_labels=["prefill"],
+        decode_model_labels=["decode"],
+    )
+    prefill_endpoints = [EndpointInfo(url="http://prefill1.com", model_label="prefill")]
+    decode_endpoints = [EndpointInfo(url="http://decode1.com", model_label="decode")]
+
+    before_prefill = _counter_value(
+        "http://prefill1.com",
+        "llama-3",
+        "disaggregated_prefill_orchestrated",
+        "success",
+    )
+    before_decode = _counter_value(
+        "http://decode1.com",
+        "llama-3",
+        "disaggregated_prefill_orchestrated",
+        "success",
+    )
+
+    router.select_prefill_endpoint(prefill_endpoints, "llama-3")
+    router.select_decode_endpoint(decode_endpoints, "llama-3")
+
+    after_prefill = _counter_value(
+        "http://prefill1.com",
+        "llama-3",
+        "disaggregated_prefill_orchestrated",
+        "success",
+    )
+    after_decode = _counter_value(
+        "http://decode1.com",
+        "llama-3",
+        "disaggregated_prefill_orchestrated",
+        "success",
+    )
+
+    assert after_prefill - before_prefill == 1
+    assert after_decode - before_decode == 1
+
+
+def test_record_decision_handles_missing_model_label():
+    router = RoundRobinRouter()
+    router._record_decision(server_url="", model="")
+    value = _counter_value("unknown", "unknown", "roundrobin", "success")
+    assert value >= 1

--- a/src/tests/test_routing_metrics.py
+++ b/src/tests/test_routing_metrics.py
@@ -130,7 +130,7 @@ async def test_session_router_records_success_with_session_id():
 
 @requires_lmcache
 @pytest.mark.asyncio
-async def test_kvaware_router_records_success_for_session_hashring_on_kv_miss():
+async def test_kvaware_router_records_fallback_on_kv_miss():
     # __new__ + manual field setup bypasses the lmcache controller in __init__.
     router = KvawareRouter.__new__(KvawareRouter)
     router._initialized = True
@@ -158,13 +158,13 @@ async def test_kvaware_router_records_success_for_session_hashring_on_kv_miss():
     request_json = {"model": "llama-3", "prompt": "hi"}
 
     before = {
-        ep.url: _counter_value(ep.url, "llama-3", "kvaware", "success")
+        ep.url: _counter_value(ep.url, "llama-3", "kvaware", "fallback")
         for ep in endpoints
     }
     url = await router.route_request(
         endpoints, None, request_stats, request, request_json
     )
-    after = _counter_value(url, "llama-3", "kvaware", "success")
+    after = _counter_value(url, "llama-3", "kvaware", "fallback")
 
     assert after - before[url] == 1
 

--- a/src/tests/test_session_router.py
+++ b/src/tests/test_session_router.py
@@ -49,6 +49,41 @@ async def test_route_request_with_session_id():
 
 
 @pytest.mark.asyncio
+async def test_session_decision_metadata_distinguishes_affinity_and_fallback():
+    endpoints = [
+        EndpointInfo(url="http://engine1.com"),
+        EndpointInfo(url="http://engine2.com"),
+    ]
+    request_stats = {
+        "http://engine1.com": RequestStats(qps=10),
+        "http://engine2.com": RequestStats(qps=5),
+    }
+    router = SessionRouter(session_key="session_id")
+
+    affinity = await router.route_request(
+        endpoints,
+        None,
+        request_stats,
+        Request(headers={"session_id": "abc123"}),
+        {},
+    )
+    fallback = await router.route_request(
+        endpoints, None, request_stats, Request(headers={}), {}
+    )
+
+    assert (affinity.algorithm, affinity.decision, affinity.reason) == (
+        "session",
+        "primary",
+        "session_affinity",
+    )
+    assert (fallback.algorithm, fallback.decision, fallback.reason) == (
+        "session",
+        "fallback",
+        "missing_session",
+    )
+
+
+@pytest.mark.asyncio
 async def test_route_request_without_session_id():
     """
     Test routing when no session ID is present in the request headers.

--- a/src/vllm_router/README.md
+++ b/src/vllm_router/README.md
@@ -43,6 +43,29 @@ The router can be configured using command-line arguments. Below are the availab
 - `--engine-stats-interval`: The interval in seconds to scrape engine statistics. Default is `30`.
 - `--request-stats-window`: The sliding window seconds to compute request statistics. Default is `60`.
 
+### Routing decision metric
+
+`vllm:routing_decisions_total` counts each backend selection at the point where the
+request is dispatched. Its labels are:
+
+- `algorithm`: `roundrobin`, `session`, `kvaware`, `loadaware`, `prefixaware`,
+  `priority`, `disaggregated_prefill`, `disaggregated_prefill_orchestrated`, or
+  `unknown`.
+- `decision`: `primary`, `fallback`, `retry`, or `unknown`.
+- `reason`: `round_robin`, `session_affinity`, `missing_session`, `cache_hit`,
+  `no_cache_match`, `no_live_holder`, `below_threshold`, `load_aware`,
+  `prefix_match`, `priority`, `prefill`, `decode`, `requested_endpoint`,
+  `backend_error`, or `unknown`.
+
+All three labels use closed allowlists; unexpected values are normalized to
+`unknown`. The metric deliberately excludes backend IDs, models, request IDs,
+prompts, URLs, and error details. `EndpointInfo.Id` is discovery-provided and may
+be arbitrary, so it is not a label. The current per-process cardinality contract
+is at most 9 algorithms x 4 decisions x 15 reasons = 540 time series, independent
+of the number or churn of discovered backends and independent of request volume.
+Adding an allowlisted label value increases that bound and requires an explicit
+cardinality review.
+
 ### Logging Options
 
 - `--log-stats`: Log statistics periodically.

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -42,6 +42,7 @@ from uhashring import HashRing
 
 from vllm_router.log import init_logger
 from vllm_router.service_discovery import EndpointInfo
+from vllm_router.services.metrics_service import routing_decisions_total
 from vllm_router.stats.engine_stats import EngineStats
 from vllm_router.stats.request_stats import RequestStats
 from vllm_router.utils import SingletonABCMeta
@@ -59,6 +60,18 @@ class RoutingLogic(str, enum.Enum):
 
 
 class RoutingInterface(metaclass=SingletonABCMeta):
+    ALGORITHM_NAME: str = "unknown"
+
+    def _record_decision(
+        self, server_url: str, model: str, outcome: str = "success"
+    ) -> None:
+        routing_decisions_total.labels(
+            server=server_url or "unknown",
+            model=model or "unknown",
+            algorithm=self.ALGORITHM_NAME,
+            outcome=outcome,
+        ).inc()
+
     def _qps_routing(
         self, endpoints: List[EndpointInfo], request_stats: Dict[str, RequestStats]
     ) -> str:
@@ -140,6 +153,8 @@ class RoundRobinRouter(RoutingInterface):
     # TODO (ApostaC): when available engines in the endpoints changes, the
     # algorithm may not be "perfectly" round-robin.
 
+    ALGORITHM_NAME = "roundrobin"
+
     # Upper bound on cached endpoint-set entries to prevent unbounded memory
     # growth when endpoints change dynamically (add / remove / update).
     _MAX_CACHE_SIZE = 1024
@@ -192,7 +207,12 @@ class RoundRobinRouter(RoutingInterface):
         ):
             self._next_index.clear()
         self._next_index[endpoint_urls] = idx + 1
-        return endpoint_urls[idx % len(endpoint_urls)]
+        url = endpoint_urls[idx % len(endpoint_urls)]
+        selected = next((e for e in endpoints if e.url == url), endpoints[0])
+        model_names = getattr(selected, "model_names", None) or []
+        model = model_names[0] if model_names else "unknown"
+        self._record_decision(url, model)
+        return url
 
 
 class SessionRouter(RoutingInterface):
@@ -200,6 +220,8 @@ class SessionRouter(RoutingInterface):
     Route the request to the appropriate engine URL based on the session key
     in the request headers
     """
+
+    ALGORITHM_NAME = "session"
 
     def __init__(self, session_key: str = None):
         if hasattr(self, "_initialized"):
@@ -239,12 +261,15 @@ class SessionRouter(RoutingInterface):
         # Update the hash ring with the current list of endpoints
         self._update_hash_ring(endpoints)
 
+        model = request_json.get("model", "unknown") if request_json else "unknown"
         if session_id is None:
             # Route based on QPS if no session ID is present
             url = self._qps_routing(endpoints, request_stats)
+            self._record_decision(url, model, outcome="fallback")
         else:
             # Use the hash ring to get the endpoint for the session ID
             url = self.hash_ring.get_node(session_id)
+            self._record_decision(url, model)
 
         return url
 
@@ -254,6 +279,8 @@ class KvawareRouter(RoutingInterface):
     Route the request to the appropriate engine URL by where the KV cache
     of the longest prefix match is found.
     """
+
+    ALGORITHM_NAME = "kvaware"
 
     def __init__(
         self,
@@ -386,6 +413,7 @@ class KvawareRouter(RoutingInterface):
             ]  # Get the first key
             matched_tokens = instance_id.layout_info[matched_instance_id][1]
 
+        model = request_json.get("model", "unknown") if request_json else "unknown"
         if (
             instance_id is None
             or len(instance_id.layout_info) == 0
@@ -395,12 +423,13 @@ class KvawareRouter(RoutingInterface):
             logger.debug(f"Fallback to using session id: {session_id}")
             # Update the hash ring with the current list of endpoints
             self._update_hash_ring(endpoints)
+            # outcome mirrors SessionRouter: QPS=fallback, hash-ring=success.
             if session_id is None:
-                # Route based on QPS if no session ID is present
                 url = self._qps_routing(endpoints, request_stats)
+                self._record_decision(url, model, outcome="fallback")
             else:
-                # Use the hash ring to get the endpoint for the session ID
                 url = self.hash_ring.get_node(session_id)
+                self._record_decision(url, model)
             return url
         else:
             queried_instance_ids = [info for info in instance_id.layout_info]
@@ -425,7 +454,9 @@ class KvawareRouter(RoutingInterface):
             logger.info(
                 f"Routing request to {queried_instance_ids[0]} found by kvaware router"
             )
-            return self.instance_id_to_ip[queried_instance_ids[0]]
+            url = self.instance_id_to_ip[queried_instance_ids[0]]
+            self._record_decision(url, model)
+            return url
 
 
 class PrefixAwareRouter(RoutingInterface):
@@ -435,6 +466,8 @@ class PrefixAwareRouter(RoutingInterface):
 
     In this class, we assume that there is no eviction of prefix cache.
     """
+
+    ALGORITHM_NAME = "prefixaware"
 
     def __init__(self: int):
         if hasattr(self, "_initialized"):
@@ -504,6 +537,8 @@ class PrefixAwareRouter(RoutingInterface):
 
         await self.hashtrie.insert(prompt, selected_endpoint)
 
+        model = request_json.get("model", "unknown") if request_json else "unknown"
+        self._record_decision(selected_endpoint, model)
         return selected_endpoint
 
 
@@ -512,6 +547,8 @@ class DisaggregatedPrefillRouter(RoutingInterface):
     Route the request to the appropriate engine URL by handling prefill and decode operations sequentially.
     First request goes to prefill endpoint, then second request goes to decode endpoint.
     """
+
+    ALGORITHM_NAME = "disaggregated_prefill"
 
     def __init__(self, prefill_model_labels: List[str], decode_model_labels: List[str]):
         self.prefill_model_labels = prefill_model_labels
@@ -565,6 +602,8 @@ class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
     Load balancing: Uses round-robin across available prefill and decode pods.
     """
 
+    ALGORITHM_NAME = "disaggregated_prefill_orchestrated"
+
     def __init__(self, prefill_model_labels: List[str], decode_model_labels: List[str]):
         if hasattr(self, "_initialized"):
             return
@@ -617,7 +656,9 @@ class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
         return prefiller_endpoints, decoder_endpoints
 
     def select_prefill_endpoint(
-        self, prefiller_endpoints: List[EndpointInfo]
+        self,
+        prefiller_endpoints: List[EndpointInfo],
+        model: str = "unknown",
     ) -> EndpointInfo:
         """Select prefill endpoint using round-robin load balancing."""
         if not prefiller_endpoints:
@@ -626,10 +667,13 @@ class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
         sorted_endpoints = sorted(prefiller_endpoints, key=lambda e: e.url)
         selected = sorted_endpoints[self.prefill_idx % len(sorted_endpoints)]
         self.prefill_idx += 1
+        self._record_decision(selected.url, model)
         return selected
 
     def select_decode_endpoint(
-        self, decoder_endpoints: List[EndpointInfo]
+        self,
+        decoder_endpoints: List[EndpointInfo],
+        model: str = "unknown",
     ) -> EndpointInfo:
         """Select decode endpoint using round-robin load balancing."""
         if not decoder_endpoints:
@@ -638,6 +682,7 @@ class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
         sorted_endpoints = sorted(decoder_endpoints, key=lambda e: e.url)
         selected = sorted_endpoints[self.decode_idx % len(sorted_endpoints)]
         self.decode_idx += 1
+        self._record_decision(selected.url, model)
         return selected
 
     async def route_request(

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -423,13 +423,11 @@ class KvawareRouter(RoutingInterface):
             logger.debug(f"Fallback to using session id: {session_id}")
             # Update the hash ring with the current list of endpoints
             self._update_hash_ring(endpoints)
-            # outcome mirrors SessionRouter: QPS=fallback, hash-ring=success.
             if session_id is None:
                 url = self._qps_routing(endpoints, request_stats)
-                self._record_decision(url, model, outcome="fallback")
             else:
                 url = self.hash_ring.get_node(session_id)
-                self._record_decision(url, model)
+            self._record_decision(url, model, outcome="fallback")
             return url
         else:
             queried_instance_ids = [info for info in instance_id.layout_info]

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -21,7 +21,8 @@ import os
 import random
 import threading
 import uuid
-from typing import Dict, List, Optional
+import weakref
+from typing import Dict, List, Optional, Self
 from urllib.parse import urlparse
 
 import requests
@@ -60,6 +61,93 @@ class RoutingLogic(str, enum.Enum):
     DISAGGREGATED_PREFILL = "disaggregated_prefill"
     DISAGGREGATED_PREFILL_ORCHESTRATED = "disaggregated_prefill_orchestrated"
     PRIORITY = "priority"
+
+
+ROUTING_DECISION_KINDS = frozenset({"primary", "fallback", "retry", "unknown"})
+ROUTING_DECISION_REASONS = frozenset(
+    {
+        "round_robin",
+        "session_affinity",
+        "missing_session",
+        "cache_hit",
+        "no_cache_match",
+        "no_live_holder",
+        "below_threshold",
+        "load_aware",
+        "prefix_match",
+        "priority",
+        "prefill",
+        "decode",
+        "requested_endpoint",
+        "backend_error",
+        "unknown",
+    }
+)
+ROUTING_ALGORITHMS = frozenset({logic.value for logic in RoutingLogic} | {"unknown"})
+
+_ROUTING_DECISION_METADATA = {}
+
+
+class RoutingDecision(str):
+    """A URL string carrying immutable, bounded routing metadata."""
+
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, value: str, *, algorithm: str, decision: str, reason: str) -> Self:
+        instance = super().__new__(cls, value)
+        metadata = (
+            algorithm if algorithm in ROUTING_ALGORITHMS else "unknown",
+            decision if decision in ROUTING_DECISION_KINDS else "unknown",
+            reason if reason in ROUTING_DECISION_REASONS else "unknown",
+        )
+
+        identity = id(instance)
+
+        def discard_metadata(reference, *, identity=identity):
+            entry = _ROUTING_DECISION_METADATA.get(identity)
+            if entry is not None and entry[0] is reference:
+                del _ROUTING_DECISION_METADATA[identity]
+
+        reference = weakref.ref(instance, discard_metadata)
+        _ROUTING_DECISION_METADATA[identity] = (reference, metadata)
+        return instance
+
+    @property
+    def _metadata(self):
+        reference, metadata = _ROUTING_DECISION_METADATA[id(self)]
+        if reference() is not self:
+            raise RuntimeError("RoutingDecision metadata identity mismatch")
+        return metadata
+
+    @property
+    def algorithm(self):
+        return self._metadata[0]
+
+    @property
+    def decision(self):
+        return self._metadata[1]
+
+    @property
+    def reason(self):
+        return self._metadata[2]
+
+    def __setattr__(self, name, value):
+        raise AttributeError("RoutingDecision is immutable")
+
+    def __delattr__(self, name):
+        raise AttributeError("RoutingDecision is immutable")
+
+    def __reduce__(self):
+        return (
+            _rebuild_routing_decision,
+            (str(self), self.algorithm, self.decision, self.reason),
+        )
+
+
+def _rebuild_routing_decision(
+    value: str, algorithm: str, decision: str, reason: str
+) -> RoutingDecision:
+    return RoutingDecision(value, algorithm=algorithm, decision=decision, reason=reason)
 
 
 # The single tunable of the `loadaware` routing logic. beta = 1.0 reads as: an
@@ -224,7 +312,12 @@ class RoundRobinRouter(RoutingInterface):
         ):
             self._next_index.clear()
         self._next_index[endpoint_urls] = idx + 1
-        return endpoint_urls[idx % len(endpoint_urls)]
+        return RoutingDecision(
+            endpoint_urls[idx % len(endpoint_urls)],
+            algorithm=RoutingLogic.ROUND_ROBIN.value,
+            decision="primary",
+            reason="round_robin",
+        )
 
 
 class SessionRouter(RoutingInterface):
@@ -274,11 +367,20 @@ class SessionRouter(RoutingInterface):
         if session_id is None:
             # Route based on QPS if no session ID is present
             url = self._qps_routing(endpoints, request_stats)
+            decision = "fallback"
+            reason = "missing_session"
         else:
             # Use the hash ring to get the endpoint for the session ID
             url = self.hash_ring.get_node(session_id)
+            decision = "primary"
+            reason = "session_affinity"
 
-        return url
+        return RoutingDecision(
+            url,
+            algorithm=RoutingLogic.SESSION_BASED.value,
+            decision=decision,
+            reason=reason,
+        )
 
 
 class KvawareRouter(RoutingInterface):
@@ -413,7 +515,7 @@ class KvawareRouter(RoutingInterface):
         matched_tokens = math.inf
         matched_instance_id = None
         logger.debug(f"Lookup return message: {instance_id}")
-        layout_info = instance_id.layout_info
+        layout_info = getattr(instance_id, "layout_info", None) or {}
         if layout_info:
             mapped_urls = set(self.instance_id_to_ip.values())
             if any(endpoint.url not in mapped_urls for endpoint in endpoints) or any(
@@ -454,12 +556,15 @@ class KvawareRouter(RoutingInterface):
             matched_instance_id = max(live_holders, key=lambda key: layout_info[key][1])
             matched_tokens = layout_info[matched_instance_id][1]
 
-        if (
-            instance_id is None
-            or len(instance_id.layout_info) == 0
-            or matched_instance_id is None
-            or matched_tokens < max(len(token_ids) - self.threshold, 0)
-        ):
+        fallback_reason = None
+        if not layout_info:
+            fallback_reason = "no_cache_match"
+        elif matched_instance_id is None:
+            fallback_reason = "no_live_holder"
+        elif matched_tokens < max(len(token_ids) - self.threshold, 0):
+            fallback_reason = "below_threshold"
+
+        if fallback_reason is not None:
             session_id = self.extract_session_id(request, request_json)
             logger.debug(f"Fallback to using session id: {session_id}")
             # Update the hash ring with the current list of endpoints
@@ -470,9 +575,19 @@ class KvawareRouter(RoutingInterface):
             else:
                 # Use the hash ring to get the endpoint for the session ID
                 url = self.hash_ring.get_node(session_id)
-            return url
+            return RoutingDecision(
+                url,
+                algorithm=RoutingLogic.KVAWARE.value,
+                decision="fallback",
+                reason=fallback_reason,
+            )
         logger.info(f"Routing request to {matched_instance_id} found by kvaware router")
-        return self.instance_id_to_ip[matched_instance_id]
+        return RoutingDecision(
+            self.instance_id_to_ip[matched_instance_id],
+            algorithm=RoutingLogic.KVAWARE.value,
+            decision="primary",
+            reason="cache_hit",
+        )
 
 
 class LoadAwareRouter(KvawareRouter):
@@ -565,17 +680,25 @@ class LoadAwareRouter(KvawareRouter):
         benefit = min(matched_tokens, prompt_tokens) / max(prompt_tokens, 1)
         return benefit - self.beta * relative_load
 
-    def matched_tokens_by_url(self, layout_info: Dict) -> Dict[str, int]:
+    def matched_tokens_by_url(
+        self,
+        layout_info: Dict,
+        current_instance_ids: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, int]:
         """Re-key the controller's answer from instance_id to engine URL.
 
         A restarted engine registers under a fresh id while its dead id
         lingers in the controller's `kv_pool`, so `lookup()` can name the
         dead id as a holder whose match is phantom (the restart emptied the
-        cache). Inverting the bridge credits only the live id: dicts preserve
-        insertion order, so the last id `refresh_instance_map` wrote for a
-        URL wins.
+        cache). A request-local ``current_instance_ids`` snapshot is
+        authoritative when supplied. Direct callers without one use the last
+        identity written for each URL in the historical bridge.
         """
-        url_to_instance = {url: iid for iid, url in self.instance_id_to_ip.items()}
+        url_to_instance = (
+            current_instance_ids
+            if current_instance_ids is not None
+            else {url: iid for iid, url in self.instance_id_to_ip.items()}
+        )
         matched = {}
         for url, instance_id in url_to_instance.items():
             info = layout_info.get(instance_id)
@@ -589,15 +712,18 @@ class LoadAwareRouter(KvawareRouter):
         request_stats: Dict[str, RequestStats],
         layout_info: Dict,
         prompt_tokens: int,
+        current_instance_ids: Optional[Dict[str, str]] = None,
     ) -> Optional[str]:
         """The placement decision. Pure: no I/O, no awaits.
 
-        Requires `self.instance_id_to_ip` to be populated for every endpoint
-        (`refresh_instance_map`) since it bridges `layout_info`'s instance_id
-        keys to `request_stats`' URL keys. Ties break by lexicographic URL
-        for reproducibility; returns None if there is nothing to route to.
+        ``current_instance_ids`` bridges `layout_info`'s instance_id keys to
+        `request_stats`' URL keys. Without a snapshot, direct callers use
+        ``self.instance_id_to_ip``. Ties break by lexicographic URL for
+        reproducibility; returns None if there is nothing to route to.
         """
-        matched_by_url = self.matched_tokens_by_url(layout_info)
+        matched_by_url = self.matched_tokens_by_url(
+            layout_info, current_instance_ids=current_instance_ids
+        )
         relative = self.relative_loads(request_stats, endpoints)
         best_url = None
         best_score = -math.inf
@@ -618,12 +744,12 @@ class LoadAwareRouter(KvawareRouter):
     def instance_map_is_stale(
         self, endpoints: List[EndpointInfo], layout_info: Dict
     ) -> bool:
-        """Does the instance_id -> URL bridge still cover what we must score?
+        """Does the instance_id -> URL bridge structurally cover this lookup?
 
         Stale means an endpoint URL the bridge cannot score, or an
         instance_id in `layout_info` the bridge has never seen (an engine
-        restart). Missing the latter silently degenerates placement to
-        least-loaded for the life of the router.
+        restart). A same-URL restart is not structurally visible here;
+        ``refresh_instance_map`` separately validates known holder identities.
         """
         mapped_urls = set(self.instance_id_to_ip.values())
         if any(endpoint.url not in mapped_urls for endpoint in endpoints):
@@ -634,18 +760,34 @@ class LoadAwareRouter(KvawareRouter):
 
     async def refresh_instance_map(
         self, endpoints: List[EndpointInfo], layout_info: Dict
-    ) -> None:
-        """Populate instance_id -> URL for every endpoint, on demand.
+    ) -> Dict[str, str]:
+        """Return the live instance identity for each cache-relevant URL.
 
-        Scoring needs the whole bridge, not just the one instance
-        `KvawareRouter` translates lazily. A rebuild costs one controller
-        round-trip per endpoint, so the `instance_map_is_stale` gate keeps it
-        a once-per-fleet-change cost rather than a per-request one.
+        The cached bridge cannot reveal a restart that keeps the same URL, so
+        every known holder URL in a non-empty lookup costs one ``QueryInst``.
+        Unknown holders or unmapped endpoints require a concurrent fleet-wide
+        refresh. This is the smallest set of queries that can safely award
+        cache credit; results are returned as a request-local snapshot so
+        concurrent refreshes cannot change the identities used for scoring.
         """
-        if not self.instance_map_is_stale(endpoints, layout_info):
-            return
+        if self.instance_map_is_stale(endpoints, layout_info):
+            refresh_urls = {endpoint.url for endpoint in endpoints}
+        else:
+            endpoint_urls = {endpoint.url for endpoint in endpoints}
+            refresh_urls = {
+                url
+                for instance_id in layout_info
+                if (url := self.instance_id_to_ip.get(instance_id)) in endpoint_urls
+            }
 
-        async def query_endpoint(endpoint: EndpointInfo) -> None:
+        seen_urls = set()
+        refresh_endpoints = []
+        for endpoint in endpoints:
+            if endpoint.url in refresh_urls and endpoint.url not in seen_urls:
+                seen_urls.add(endpoint.url)
+                refresh_endpoints.append(endpoint)
+
+        async def query_endpoint(endpoint: EndpointInfo) -> tuple[str, str]:
             event_id = "QueryInst" + str(uuid.uuid4())
             url = endpoint.url if "//" in endpoint.url else "//" + endpoint.url
             query_ip = urlparse(url).hostname or ""
@@ -654,10 +796,20 @@ class LoadAwareRouter(KvawareRouter):
             logger.debug(
                 f"Query ip: {query_ip}, return instance id: {endpoint_instance_id}"
             )
-            self.instance_id_to_ip[endpoint_instance_id.instance_id] = endpoint.url
+            return endpoint.url, endpoint_instance_id.instance_id
 
-        await asyncio.gather(*(query_endpoint(e) for e in endpoints))
-        logger.info(f"Instance id to ip mapping: {self.instance_id_to_ip}")
+        refreshed = await asyncio.gather(
+            *(query_endpoint(endpoint) for endpoint in refresh_endpoints)
+        )
+        current_instance_ids = {}
+        for url, instance_id in refreshed:
+            # Reinsert an already-known identity so it remains the winning
+            # entry when historical and current IDs share one URL.
+            self.instance_id_to_ip.pop(instance_id, None)
+            self.instance_id_to_ip[instance_id] = url
+            current_instance_ids[url] = instance_id
+        logger.debug(f"Instance id to ip mapping: {self.instance_id_to_ip}")
+        return current_instance_ids
 
     async def tokenize_prompt(
         self, endpoints: List[EndpointInfo], request_json: Dict
@@ -746,14 +898,50 @@ class LoadAwareRouter(KvawareRouter):
 
         if not layout_info:
             # Nothing cached anywhere - no benefit term to weigh.
-            return self.fallback_url(endpoints, request_stats, request, request_json)
+            return RoutingDecision(
+                self.fallback_url(endpoints, request_stats, request, request_json),
+                algorithm=RoutingLogic.LOADAWARE.value,
+                decision="fallback",
+                reason="no_cache_match",
+            )
 
-        await self.refresh_instance_map(endpoints, layout_info)
-        url = self.select_url(endpoints, request_stats, layout_info, len(token_ids))
+        current_instance_ids = await self.refresh_instance_map(endpoints, layout_info)
+        endpoint_urls = {endpoint.url for endpoint in endpoints}
+        live_matches = {
+            url: matched_tokens
+            for url, matched_tokens in self.matched_tokens_by_url(
+                layout_info, current_instance_ids=current_instance_ids
+            ).items()
+            if url in endpoint_urls
+        }
+        if not live_matches:
+            return RoutingDecision(
+                self.fallback_url(endpoints, request_stats, request, request_json),
+                algorithm=RoutingLogic.LOADAWARE.value,
+                decision="fallback",
+                reason="no_live_holder",
+            )
+        url = self.select_url(
+            endpoints,
+            request_stats,
+            layout_info,
+            len(token_ids),
+            current_instance_ids=current_instance_ids,
+        )
         if url is None:
-            return self.fallback_url(endpoints, request_stats, request, request_json)
+            return RoutingDecision(
+                self.fallback_url(endpoints, request_stats, request, request_json),
+                algorithm=RoutingLogic.LOADAWARE.value,
+                decision="fallback",
+                reason="no_live_holder",
+            )
         logger.info(f"Routing request to {url} found by loadaware router")
-        return url
+        return RoutingDecision(
+            url,
+            algorithm=RoutingLogic.LOADAWARE.value,
+            decision="primary",
+            reason="load_aware",
+        )
 
 
 class PrefixAwareRouter(RoutingInterface):
@@ -841,13 +1029,23 @@ class PrefixAwareRouter(RoutingInterface):
             selected_endpoint = self._qps_routing(endpoints, request_stats)
             if selected_endpoint is not None:
                 await self.hashtrie.insert(prompt, selected_endpoint)
-            return selected_endpoint
+            return RoutingDecision(
+                selected_endpoint,
+                algorithm=RoutingLogic.PREFIXAWARE.value,
+                decision="fallback",
+                reason="below_threshold",
+            )
 
         selected_endpoint = random.choice(list(matched_endpoint))
 
         await self.hashtrie.insert(prompt, selected_endpoint)
 
-        return selected_endpoint
+        return RoutingDecision(
+            selected_endpoint,
+            algorithm=RoutingLogic.PREFIXAWARE.value,
+            decision="primary",
+            reason="prefix_match",
+        )
 
 
 class PriorityRouter(RoutingInterface):
@@ -954,14 +1152,24 @@ class PriorityRouter(RoutingInterface):
         endpoint_urls = tuple(sorted(endpoint.url for endpoint in endpoints))
 
         if priority < self.priority_threshold:
-            return min(
-                endpoint_urls,
-                key=lambda url: self._engine_load(url, request_stats),
+            return RoutingDecision(
+                min(
+                    endpoint_urls,
+                    key=lambda url: self._engine_load(url, request_stats),
+                ),
+                algorithm=RoutingLogic.PRIORITY.value,
+                decision="primary",
+                reason="priority",
             )
 
         idx = self._next_index.get(endpoint_urls, 0)
         self._next_index[endpoint_urls] = idx + 1
-        return endpoint_urls[idx % len(endpoint_urls)]
+        return RoutingDecision(
+            endpoint_urls[idx % len(endpoint_urls)],
+            algorithm=RoutingLogic.PRIORITY.value,
+            decision="fallback",
+            reason="round_robin",
+        )
 
 
 class DisaggregatedPrefillRouter(RoutingInterface):
@@ -1002,9 +1210,19 @@ class DisaggregatedPrefillRouter(RoutingInterface):
             e for e in endpoints if e.model_label in self.decode_model_labels
         ]
         if is_prefill:
-            return prefiller_endpoints[0].url
+            return RoutingDecision(
+                prefiller_endpoints[0].url,
+                algorithm=RoutingLogic.DISAGGREGATED_PREFILL.value,
+                decision="primary",
+                reason="prefill",
+            )
         else:
-            return decoder_endpoints[0].url
+            return RoutingDecision(
+                decoder_endpoints[0].url,
+                algorithm=RoutingLogic.DISAGGREGATED_PREFILL.value,
+                decision="primary",
+                reason="decode",
+            )
 
 
 class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
@@ -1112,7 +1330,12 @@ class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
         """
         prefiller_endpoints, _ = self._find_endpoints(endpoints)
         # Return prefill URL - actual orchestration is done in request.py
-        return prefiller_endpoints[0].url
+        return RoutingDecision(
+            prefiller_endpoints[0].url,
+            algorithm=RoutingLogic.DISAGGREGATED_PREFILL_ORCHESTRATED.value,
+            decision="primary",
+            reason="prefill",
+        )
 
 
 # Instead of managing a global _global_router, we can define the initialization functions as:

--- a/src/vllm_router/services/metrics_service/__init__.py
+++ b/src/vllm_router/services/metrics_service/__init__.py
@@ -69,3 +69,10 @@ request_latency_seconds = Histogram(
     ["server", "model", "status"],
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0),
 )
+
+# --- Routing-level metrics ---
+routing_decisions_total = Counter(
+    "vllm:routing_decisions_total",
+    "Total routing decisions made by the router.",
+    ["server", "model", "algorithm", "outcome"],
+)

--- a/src/vllm_router/services/metrics_service/__init__.py
+++ b/src/vllm_router/services/metrics_service/__init__.py
@@ -1,5 +1,11 @@
 from prometheus_client import Counter, Gauge, Histogram
 
+from vllm_router.routers.routing_logic import (
+    ROUTING_ALGORITHMS,
+    ROUTING_DECISION_KINDS,
+    ROUTING_DECISION_REASONS,
+)
+
 # --- Prometheus Gauges ---
 # Existing metrics
 num_requests_running = Gauge(
@@ -38,6 +44,21 @@ num_incoming_requests_total = Counter(
     "Total valid incoming requests to router (including when no backends available).",
     ["model"],
 )
+routing_decisions_total = Counter(
+    "vllm:routing_decisions_total",
+    "Total routing selections made by the router.",
+    ["algorithm", "decision", "reason"],
+)
+
+
+def record_routing_decision(*, algorithm: str, decision: str, reason: str) -> None:
+    """Increment a routing decision after normalizing bounded labels."""
+    routing_decisions_total.labels(
+        algorithm=algorithm if algorithm in ROUTING_ALGORITHMS else "unknown",
+        decision=decision if decision in ROUTING_DECISION_KINDS else "unknown",
+        reason=reason if reason in ROUTING_DECISION_REASONS else "unknown",
+    ).inc()
+
 
 # New metrics per dashboard update
 healthy_pods_total = Gauge(

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -748,8 +748,11 @@ async def route_orchestrated_disaggregated_request(
         )
 
     # Use round-robin load balancing to select prefill and decode endpoints
-    prefill_endpoint = router.select_prefill_endpoint(prefiller_endpoints)
-    decode_endpoint = router.select_decode_endpoint(decoder_endpoints)
+    requested_model = request_json.get("model", "unknown")
+    prefill_endpoint = router.select_prefill_endpoint(
+        prefiller_endpoints, requested_model
+    )
+    decode_endpoint = router.select_decode_endpoint(decoder_endpoints, requested_model)
     prefill_url = prefill_endpoint.url
     decode_url = decode_endpoint.url
 
@@ -917,6 +920,7 @@ async def route_disaggregated_prefill_request(
     # Same as vllm, Get request_id from X-Request-Id header if available
     request_id = request.headers.get("X-Request-Id") or str(uuid.uuid4())
     request_json = await request.json()
+    requested_model = request_json.get("model", "unknown")
 
     # Save original request for decode phase
     orig_request_json = request_json.copy()
@@ -928,6 +932,8 @@ async def route_disaggregated_prefill_request(
     request_json.pop("max_completion_tokens", None)
 
     st = time.time()
+    # str() — _base_url is a yarl.URL, not a plain string.
+    prefill_url = str(request.app.state.prefill_client._base_url)
     try:
         await send_request_to_prefiller(
             request.app.state.prefill_client, endpoint, request_json, request_id
@@ -935,8 +941,9 @@ async def route_disaggregated_prefill_request(
         et = time.time()
         logger.info(f"{request_id} prefill time (TTFT): {et - st:.4f}")
         logger.info(
-            f"Routing request {request_id} with session id None to {request.app.state.prefill_client._base_url} at {et}, process time = {et - in_router_time:.4f}"
+            f"Routing request {request_id} with session id None to {prefill_url} at {et}, process time = {et - in_router_time:.4f}"
         )
+        request.app.state.router._record_decision(prefill_url, requested_model)
         # Use original request for decode phase
         request_json = orig_request_json
     except aiohttp.ClientResponseError as e:
@@ -1000,9 +1007,11 @@ async def route_disaggregated_prefill_request(
             yield json.dumps(error_response).encode("utf-8")
 
     curr_time = time.time()
+    decode_url = str(request.app.state.decode_client._base_url)
     logger.info(
-        f"Routing request {request_id} with session id None to {request.app.state.decode_client._base_url} at {curr_time}, process time = {curr_time - et:.4f}"
+        f"Routing request {request_id} with session id None to {decode_url} at {curr_time}, process time = {curr_time - et:.4f}"
     )
+    request.app.state.router._record_decision(decode_url, requested_model)
 
     return StreamingResponse(
         generate_stream(),

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -31,8 +31,12 @@ from vllm_router.routers.routing_logic import (
     DisaggregatedPrefillOrchestratedRouter,
     DisaggregatedPrefillRouter,
     KvawareRouter,
+    LoadAwareRouter,
     PrefixAwareRouter,
     PriorityRouter,
+    RoundRobinRouter,
+    RoutingDecision,
+    RoutingLogic,
     SessionRouter,
 )
 from vllm_router.service_discovery import get_service_discovery
@@ -74,6 +78,7 @@ from vllm_router.services.metrics_service import (
     input_tokens_total,
     num_incoming_requests_total,
     output_tokens_total,
+    record_routing_decision,
     request_errors_total,
     request_latency_seconds,
 )
@@ -104,6 +109,45 @@ _HEADERS_TO_STRIP_FROM_RESPONSE = {
 def _is_json_media_type(content_type: str) -> bool:
     media_type = content_type.partition(";")[0].strip().lower()
     return media_type == "application/json" or media_type.endswith("+json")
+
+
+def _configured_routing_algorithm(router) -> str:
+    router_algorithms = (
+        (LoadAwareRouter, RoutingLogic.LOADAWARE.value),
+        (KvawareRouter, RoutingLogic.KVAWARE.value),
+        (PrefixAwareRouter, RoutingLogic.PREFIXAWARE.value),
+        (PriorityRouter, RoutingLogic.PRIORITY.value),
+        (SessionRouter, RoutingLogic.SESSION_BASED.value),
+        (RoundRobinRouter, RoutingLogic.ROUND_ROBIN.value),
+        (
+            DisaggregatedPrefillOrchestratedRouter,
+            RoutingLogic.DISAGGREGATED_PREFILL_ORCHESTRATED.value,
+        ),
+        (DisaggregatedPrefillRouter, RoutingLogic.DISAGGREGATED_PREFILL.value),
+    )
+    return next(
+        (
+            algorithm
+            for router_type, algorithm in router_algorithms
+            if isinstance(router, router_type)
+        ),
+        "unknown",
+    )
+
+
+def _record_backend_selection(
+    selection: str,
+    endpoints,
+    *,
+    decision: str | None = None,
+    reason: str | None = None,
+) -> None:
+    """Count one selection using only bounded routing dimensions."""
+    record_routing_decision(
+        algorithm=getattr(selection, "algorithm", "unknown"),
+        decision=decision or getattr(selection, "decision", "unknown"),
+        reason=reason or getattr(selection, "reason", "unknown"),
+    )
 
 
 async def process_external_provider_request(
@@ -573,7 +617,12 @@ async def route_general_request(
 
     logger.debug(f"Routing request {request_id} for model: {requested_model}")
     if request_endpoint:
-        server_url = endpoints[0].url
+        server_url = RoutingDecision(
+            endpoints[0].url,
+            algorithm=_configured_routing_algorithm(request.app.state.router),
+            decision="primary",
+            reason="requested_endpoint",
+        )
         logger.debug(
             f"Routing request {request_id} to engine with Id: {endpoints[0].Id}"
         )
@@ -652,6 +701,15 @@ async def route_general_request(
 
         media_type = "text/event-stream"
         try:
+            if attempt == 0:
+                _record_backend_selection(server_url, endpoints)
+            else:
+                _record_backend_selection(
+                    server_url,
+                    endpoints,
+                    decision="retry",
+                    reason="backend_error",
+                )
             stream_generator = process_request(
                 request,
                 request_body,
@@ -824,6 +882,15 @@ async def route_orchestrated_disaggregated_request(
         client: aiohttp.ClientSession = request.app.state.aiohttp_client_wrapper()
 
         # Send to Prefill
+        _record_backend_selection(
+            RoutingDecision(
+                prefill_url,
+                algorithm=RoutingLogic.DISAGGREGATED_PREFILL_ORCHESTRATED.value,
+                decision="primary",
+                reason="prefill",
+            ),
+            endpoints,
+        )
         async with client.post(
             prefill_api_url,
             json=prefill_request_json,
@@ -870,6 +937,15 @@ async def route_orchestrated_disaggregated_request(
         decode_api_url = f"{decode_url}{endpoint}"
         logger.info(f"[{request_id}] Sending decode request to {decode_api_url}")
 
+        _record_backend_selection(
+            RoutingDecision(
+                decode_url,
+                algorithm=RoutingLogic.DISAGGREGATED_PREFILL_ORCHESTRATED.value,
+                decision="primary",
+                reason="decode",
+            ),
+            endpoints,
+        )
         decode_resp = await client.post(
             decode_api_url,
             json=decode_request,
@@ -957,6 +1033,7 @@ async def route_disaggregated_prefill_request(
     # Same as vllm, Get request_id from X-Request-Id header if available
     request_id = request.headers.get("X-Request-Id") or str(uuid.uuid4())
     request_json = await request.json()
+    endpoints = get_service_discovery().get_endpoint_info()
 
     # Save original request for decode phase
     orig_request_json = request_json.copy()
@@ -969,6 +1046,15 @@ async def route_disaggregated_prefill_request(
 
     st = time.time()
     try:
+        _record_backend_selection(
+            RoutingDecision(
+                str(request.app.state.prefill_client._base_url).rstrip("/"),
+                algorithm=RoutingLogic.DISAGGREGATED_PREFILL.value,
+                decision="primary",
+                reason="prefill",
+            ),
+            endpoints,
+        )
         await send_request_to_prefiller(
             request.app.state.prefill_client, endpoint, request_json, request_id
         )
@@ -1008,6 +1094,15 @@ async def route_disaggregated_prefill_request(
 
     async def generate_stream():
         try:
+            _record_backend_selection(
+                RoutingDecision(
+                    str(request.app.state.decode_client._base_url).rstrip("/"),
+                    algorithm=RoutingLogic.DISAGGREGATED_PREFILL.value,
+                    decision="primary",
+                    reason="decode",
+                ),
+                endpoints,
+            )
             async for chunk in send_request_to_decode(
                 request.app.state.decode_client, endpoint, request_json, request_id
             ):
@@ -1284,6 +1379,7 @@ async def proxy_multipart_request(
             KvawareRouter,
             PrefixAwareRouter,
             SessionRouter,
+            PriorityRouter,
             DisaggregatedPrefillOrchestratedRouter,
         ),
     ):
@@ -1324,6 +1420,7 @@ async def proxy_multipart_request(
         request_stats_monitor.on_new_request(chosen_url, request_id, time.time())
 
         try:
+            _record_backend_selection(chosen_url, endpoints)
             backend_response = await client.post(
                 f"{chosen_url}{endpoint}",
                 data=form_data,


### PR DESCRIPTION
## What this changes

The request counter shows request volume, but it cannot explain which routing path selected a backend. This redesign adds a routing-decision counter for primary choices, fallbacks, retries, and prefill/decode selections.

- Routing methods still return URL-compatible strings. Selection metadata is carried by an immutable `RoutingDecision` string subtype.
- The counter records only `algorithm`, `decision`, and `reason`.
- Load-aware routing validates the current LMCache instance identity before crediting a cached prefix, including same-URL restarts and unavailable holders.
- Multipart dispatch awaits async routing methods instead of calling them synchronously.

## Cardinality

All three labels use explicit allowlists: 9 algorithms × 6 decisions × 10 reasons, for at most 540 label combinations per registry. Backend IDs, URLs, model names, and request metadata are not labels.

## Tests

- 58 focused routing-decision, KV-aware, and load-aware tests pass.
- The full router suite reports 256 passed with the same 3 Windows-only parser expectation failures as clean `main`.
- Pre-commit passes on every changed file.

Closes #474
