### PR TITLE
[Bugfix]: Fix streaming "connection closed" before body consumed in orchestrated disaggregated routing

### DIFF
--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -844,51 +844,53 @@ async def route_orchestrated_disaggregated_request(
             },
             timeout=aiohttp.ClientTimeout(total=600),
         )
-        if decode_resp.status != 200:
-            error_text = await decode_resp.text()
+        try:
+            if decode_resp.status != 200:
+                error_text = await decode_resp.text()
+                logger.error(
+                    f"[{request_id}] Decode failed with status {decode_resp.status}: {error_text}"
+                )
+                return JSONResponse(
+                    status_code=decode_resp.status,
+                    content={"error": f"Decode failed: {error_text}"},
+                    headers={"X-Request-Id": request_id},
+                )
+
+            if is_streaming:
+                # For streaming, yield chunks as they arrive (true streaming)
+                async def generate_stream():
+                    try:
+                        async for chunk in decode_resp.content.iter_any():
+                            if chunk:
+                                yield chunk
+                    finally:
+                        decode_resp.release()
+                        curr_time = time.time()
+                        logger.info(
+                            f"[{request_id}] Orchestrated streaming request completed, total time = {curr_time - in_router_time:.4f}s"
+                        )
+
+                return StreamingResponse(
+                    generate_stream(),
+                    media_type="text/event-stream",
+                    headers={"X-Request-Id": request_id},
+                )
+            else:
+                # For non-streaming, read full response
+                response_data = await decode_resp.read()
+
+                curr_time = time.time()
+                logger.info(
+                    f"[{request_id}] Orchestrated request completed, total time = {curr_time - in_router_time:.4f}s"
+                )
+
+                return JSONResponse(
+                    content=json.loads(response_data),
+                    headers={"X-Request-Id": request_id},
+                )
+        except Exception as e:
             decode_resp.release()
-            logger.error(
-                f"[{request_id}] Decode failed with status {decode_resp.status}: {error_text}"
-            )
-            return JSONResponse(
-                status_code=decode_resp.status,
-                content={"error": f"Decode failed: {error_text}"},
-                headers={"X-Request-Id": request_id},
-            )
-
-        if is_streaming:
-            # For streaming, yield chunks as they arrive (true streaming)
-            async def generate_stream():
-                try:
-                    async for chunk in decode_resp.content.iter_any():
-                        if chunk:
-                            yield chunk
-                finally:
-                    decode_resp.release()
-                    curr_time = time.time()
-                    logger.info(
-                        f"[{request_id}] Orchestrated streaming request completed, total time = {curr_time - in_router_time:.4f}s"
-                    )
-
-            return StreamingResponse(
-                generate_stream(),
-                media_type="text/event-stream",
-                headers={"X-Request-Id": request_id},
-            )
-        else:
-            # For non-streaming, read full response
-            response_data = await decode_resp.read()
-            decode_resp.release()
-
-            curr_time = time.time()
-            logger.info(
-                f"[{request_id}] Orchestrated request completed, total time = {curr_time - in_router_time:.4f}s"
-            )
-
-            return JSONResponse(
-                content=json.loads(response_data),
-                headers={"X-Request-Id": request_id},
-            )
+            raise
 
     except aiohttp.ClientError as e:
         logger.error(

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -888,7 +888,7 @@ async def route_orchestrated_disaggregated_request(
                     content=json.loads(response_data),
                     headers={"X-Request-Id": request_id},
                 )
-        except Exception as e:
+        except Exception:
             decode_resp.release()
             raise
 

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -786,7 +786,7 @@ async def route_orchestrated_disaggregated_request(
 
     try:
         # Use the shared aiohttp client from app state
-        client = request.app.state.aiohttp_client_wrapper()
+        client: aiohttp.ClientSession = request.app.state.aiohttp_client_wrapper()
 
         # Send to Prefill
         async with client.post(
@@ -835,7 +835,7 @@ async def route_orchestrated_disaggregated_request(
         decode_api_url = f"{decode_url}{endpoint}"
         logger.info(f"[{request_id}] Sending decode request to {decode_api_url}")
 
-        async with client.post(
+        decode_resp = await client.post(
             decode_api_url,
             json=decode_request,
             headers={
@@ -843,49 +843,52 @@ async def route_orchestrated_disaggregated_request(
                 "X-Request-Id": request_id,
             },
             timeout=aiohttp.ClientTimeout(total=600),
-        ) as decode_resp:
-            if decode_resp.status != 200:
-                error_text = await decode_resp.text()
-                logger.error(
-                    f"[{request_id}] Decode failed with status {decode_resp.status}: {error_text}"
-                )
-                return JSONResponse(
-                    status_code=decode_resp.status,
-                    content={"error": f"Decode failed: {error_text}"},
-                    headers={"X-Request-Id": request_id},
-                )
+        )
+        if decode_resp.status != 200:
+            error_text = await decode_resp.text()
+            decode_resp.release()
+            logger.error(
+                f"[{request_id}] Decode failed with status {decode_resp.status}: {error_text}"
+            )
+            return JSONResponse(
+                status_code=decode_resp.status,
+                content={"error": f"Decode failed: {error_text}"},
+                headers={"X-Request-Id": request_id},
+            )
 
-            if is_streaming:
-                # For streaming, yield chunks as they arrive (true streaming)
-                async def generate_stream():
-                    try:
-                        async for chunk in decode_resp.content.iter_any():
-                            if chunk:
-                                yield chunk
-                    finally:
-                        curr_time = time.time()
-                        logger.info(
-                            f"[{request_id}] Orchestrated streaming request completed, total time = {curr_time - in_router_time:.4f}s"
-                        )
+        if is_streaming:
+            # For streaming, yield chunks as they arrive (true streaming)
+            async def generate_stream():
+                try:
+                    async for chunk in decode_resp.content.iter_any():
+                        if chunk:
+                            yield chunk
+                finally:
+                    decode_resp.release()
+                    curr_time = time.time()
+                    logger.info(
+                        f"[{request_id}] Orchestrated streaming request completed, total time = {curr_time - in_router_time:.4f}s"
+                    )
 
-                return StreamingResponse(
-                    generate_stream(),
-                    media_type="text/event-stream",
-                    headers={"X-Request-Id": request_id},
-                )
-            else:
-                # For non-streaming, read full response
-                response_data = await decode_resp.read()
+            return StreamingResponse(
+                generate_stream(),
+                media_type="text/event-stream",
+                headers={"X-Request-Id": request_id},
+            )
+        else:
+            # For non-streaming, read full response
+            response_data = await decode_resp.read()
+            decode_resp.release()
 
-                curr_time = time.time()
-                logger.info(
-                    f"[{request_id}] Orchestrated request completed, total time = {curr_time - in_router_time:.4f}s"
-                )
+            curr_time = time.time()
+            logger.info(
+                f"[{request_id}] Orchestrated request completed, total time = {curr_time - in_router_time:.4f}s"
+            )
 
-                return JSONResponse(
-                    content=json.loads(response_data),
-                    headers={"X-Request-Id": request_id},
-                )
+            return JSONResponse(
+                content=json.loads(response_data),
+                headers={"X-Request-Id": request_id},
+            )
 
     except aiohttp.ClientError as e:
         logger.error(


### PR DESCRIPTION
FIX [#952](https://github.com/vllm-project/production-stack/issues/952)

In [#777](https://github.com/vllm-project/production-stack/pull/777), disaggregated prefill/decode that is orchestrated by the router was added. In a stage of this orchestration, after the router receives a response from prefill, the router makes a request to decode and it honors the client's `stream` property in the request by streaming decode tokens back to the client.

The bug is in the `route_orchestrated_disaggregated_request` function where the response from decode was opened with a context manager `async with client.post(...) as decode_resp`. The context manager exits as soon as `return StreamingResponse(generate_stream())` is reached, and that causes the underlying `aiohttp` connection (to decode) to close prematurely before the entire stream was consumed.

On the server side, one will see the log line `aiohttp.client_exceptions.ClientConnectionError: Connection closed`. On the client side, one will see `transfer closed with outstanding read data remaining`. Non-streaming requests were not affected because the entire response from decode is consumed before the context manager exits.

When port-forwarding the router's Kubernetes Service, this request could reproduce the bugfix:
```
$ curl http://localhost:8000/v1/chat/completions  \
-H "Content-Type: application/json" \
-d '{"model":"opt-125m","messages":[{"role":"user","content":"Hello"}],"max_tokens":20,"stream":true}'
```

Router log lines showing the "Connection closed" streaming bug:
[router-5d7dcbf4df-wl95c.log](https://github.com/user-attachments/files/28199364/router-5d7dcbf4df-wl95c.log)

Given that same HTTP request and the router bugfix, the router's logs are visible here:
[router-7967bcb78-9ml7f.log](https://github.com/user-attachments/files/28199363/router-7967bcb78-9ml7f.log)

This was reproduced with: k3s, `lmcache/lmstack-router:v0.1.11`, `facebook/opt-125m`, and VLLM's CPU image. Since this bug deals with how the router handles HTTP streaming requests, a more sophisticated setup is not required. As called out in the issue, this StackOverflow post has an example of improperly bucket-brigading a stream using FastAPI and AIOHTTP: https://stackoverflow.com/questions/77795766/aiohttp-connection-closing-before-fastapi-streaming-response.

This fix would be to not use the context manager for the AIOHTTP request to decode so the side-effect of `return StreamingResponse(...)` closing that context manager does not happen. One benefit of the context manager is that it calls [`release()`](https://docs.aiohttp.org/en/v3.13.3/client_reference.html#aiohttp.ClientResponse) under the hood, so that must be done explicitly now.
> After exiting from async with block response object will be released (see [release()](https://docs.aiohttp.org/en/v3.13.3/client_reference.html#aiohttp.ClientResponse.release) method).

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.