### PR TITLE
[CI] Bump memory for k8s discovery e2e tests

### DIFF
--- a/.github/values-06-session-routing.yaml
+++ b/.github/values-06-session-routing.yaml
@@ -12,7 +12,7 @@ servingEngineSpec:
         enabled: true
         minAvailable: 1
       requestCPU: 6
-      requestMemory: "30Gi"
+      requestMemory: "40Gi"
       requestGPU: 1
       pvcStorage: "50Gi"
       vllmConfig:
@@ -48,10 +48,10 @@ routerSpec:
   resources:
     requests:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
     limits:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
   lmcacheControllerPort: 9000
   sessionKey: "x-user-id"
   extraArgs:

--- a/.github/values-07-prefix-routing.yaml
+++ b/.github/values-07-prefix-routing.yaml
@@ -9,7 +9,7 @@ servingEngineSpec:
       modelURL: "facebook/opt-125m"
       replicaCount: 2
       requestCPU: 6
-      requestMemory: "30Gi"
+      requestMemory: "40Gi"
       requestGPU: 1
       pvcStorage: "50Gi"
       vllmConfig:
@@ -43,10 +43,10 @@ routerSpec:
   resources:
     requests:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
     limits:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
   enableRouter: true
   routingLogic: "prefixaware"
   extraArgs:

--- a/.github/values-08-roundrobin-routing.yaml
+++ b/.github/values-08-roundrobin-routing.yaml
@@ -9,7 +9,7 @@ servingEngineSpec:
       modelURL: "facebook/opt-125m"
       replicaCount: 2
       requestCPU: 6
-      requestMemory: "30Gi"
+      requestMemory: "40Gi"
       requestGPU: 1
       pvcStorage: "50Gi"
       vllmConfig:
@@ -48,10 +48,10 @@ routerSpec:
   resources:
     requests:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
     limits:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
   lmcacheControllerPort: 9000
   startupProbe:
     initialDelaySeconds: 20

--- a/.github/values-09-kvaware-routing.yaml
+++ b/.github/values-09-kvaware-routing.yaml
@@ -9,7 +9,7 @@ servingEngineSpec:
       modelURL: "facebook/opt-125m"
       replicaCount: 2
       requestCPU: 6
-      requestMemory: "30Gi"
+      requestMemory: "40Gi"
       requestGPU: 1
       pvcStorage: "50Gi"
       vllmConfig:
@@ -45,10 +45,10 @@ routerSpec:
   resources:
     requests:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
     limits:
       cpu: "1"
-      memory: "2G"
+      memory: "4G"
   startupProbe:
     initialDelaySeconds: 20
     periodSeconds: 5

--- a/.github/values-10-disagg-prefill.yaml
+++ b/.github/values-10-disagg-prefill.yaml
@@ -13,7 +13,7 @@ servingEngineSpec:
       modelURL: "facebook/opt-125m"
       replicaCount: 1
       requestCPU: 8
-      requestMemory: "30Gi"
+      requestMemory: "40Gi"
       # requestGPU: 1
       pvcStorage: "50Gi"
       vllmConfig:
@@ -47,7 +47,7 @@ servingEngineSpec:
       modelURL: "facebook/opt-125m"
       replicaCount: 1
       requestCPU: 8
-      requestMemory: "30Gi"
+      requestMemory: "40Gi"
       # requestGPU: 1
       pvcStorage: "50Gi"
       vllmConfig:


### PR DESCRIPTION
Router resources 2G→4G; engine `requestMemory` 30Gi→40Gi across e2e values files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)