### PR TITLE
[Bugfix] Propagate serviceAccountName to Ray head and worker pods

### DIFF
--- a/helm/templates/ray-cluster.yaml
+++ b/helm/templates/ray-cluster.yaml
@@ -26,7 +26,7 @@ spec:
           {{- include "chart.engineLabels" . | nindent 10 }}
       spec:
         terminationGracePeriodSeconds: 0
-        {{- if hasKey $modelSpec "serviceAccountName" }}
+        {{- if $modelSpec.serviceAccountName }}
         serviceAccountName: {{ $modelSpec.serviceAccountName }}
         {{- end }}
         {{- with .Values.servingEngineSpec.securityContext }}
@@ -283,7 +283,7 @@ spec:
             helm-release-name: {{ .Release.Name }}
             {{- include "chart.engineLabels" . | nindent 12 }}
         spec:
-          {{- if hasKey $modelSpec "serviceAccountName" }}
+          {{- if $modelSpec.serviceAccountName }}
           serviceAccountName: {{ $modelSpec.serviceAccountName }}
           {{- end }}
           {{- with .Values.servingEngineSpec.securityContext }}

--- a/helm/templates/ray-cluster.yaml
+++ b/helm/templates/ray-cluster.yaml
@@ -26,6 +26,9 @@ spec:
           {{- include "chart.engineLabels" . | nindent 10 }}
       spec:
         terminationGracePeriodSeconds: 0
+        {{- if hasKey $modelSpec "serviceAccountName" }}
+        serviceAccountName: {{ $modelSpec.serviceAccountName }}
+        {{- end }}
         {{- with .Values.servingEngineSpec.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -280,6 +283,9 @@ spec:
             helm-release-name: {{ .Release.Name }}
             {{- include "chart.engineLabels" . | nindent 12 }}
         spec:
+          {{- if hasKey $modelSpec "serviceAccountName" }}
+          serviceAccountName: {{ $modelSpec.serviceAccountName }}
+          {{- end }}
           {{- with .Values.servingEngineSpec.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/tests/ray-cluster_test.yaml
+++ b/helm/tests/ray-cluster_test.yaml
@@ -456,3 +456,72 @@ tests:
           name: LMCACHE_REMOTE_SERDE
           value: naive
         any: true
+
+  - it: should set serviceAccountName on head and worker when specified
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            serviceAccountName: "my-custom-sa"
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.serviceAccountName
+        value: my-custom-sa
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.serviceAccountName
+        value: my-custom-sa
+
+  - it: should not set serviceAccountName when not specified
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      isNull:
+        path: spec.headGroupSpec.template.spec.serviceAccountName
+    - documentIndex: 0
+      isNull:
+        path: spec.workerGroupSpecs[0].template.spec.serviceAccountName

--- a/helm/tests/ray-cluster_test.yaml
+++ b/helm/tests/ray-cluster_test.yaml
@@ -525,3 +525,37 @@ tests:
     - documentIndex: 0
       isNull:
         path: spec.workerGroupSpecs[0].template.spec.serviceAccountName
+
+  - it: should not set serviceAccountName when set to empty string
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            serviceAccountName: ""
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      isNull:
+        path: spec.headGroupSpec.template.spec.serviceAccountName
+    - documentIndex: 0
+      isNull:
+        path: spec.workerGroupSpecs[0].template.spec.serviceAccountName


### PR DESCRIPTION
## Summary

This PR fixes an issue where the serviceAccountName configured in modelSpec was not propagated to the Ray head and worker pods generated by **helm/templates/ray-cluster.yaml**.

As a result, during multi-node Ray deployments, both head and worker pods were created with the default Kubernetes service account instead of the user-specified service account. This caused authentication and authorization failures when accessing cloud resources and other Kubernetes-integrated services.

This change ensures that the serviceAccountName defined in modelSpec is applied consistently to both head and worker pod templates.

## Root Cause

The Ray cluster Helm template did not pass the configured serviceAccountName from modelSpec to the generated pod specifications for the Ray head and worker groups.

Because of this, Kubernetes automatically assigned the default service account to the pods.

## Changes

- Apply the configured service account to Ray head pods
- Apply the configured service account to Ray worker pods