### PR TITLE
fix(router): forward extra /sleep query params (level, mode) to upstream

### DIFF
--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -517,9 +517,11 @@ async def route_general_request(
     else:
         endpoints = list(
             filter(
-                lambda x: requested_model in x.model_names
-                and x.Id == request_endpoint
-                and not x.sleep,
+                lambda x: (
+                    requested_model in x.model_names
+                    and x.Id == request_endpoint
+                    and not x.sleep
+                ),
                 endpoints,
             )
         )
@@ -1059,9 +1061,16 @@ async def route_sleep_wakeup_request(
 
     url = server_url + endpoint
 
+    # Forward any additional query parameters (e.g. /sleep `level` and `mode`,
+    # /wake_up `tags`) to the upstream engine. `id` is router-only and is
+    # consumed above to pick the target engine.
+    upstream_params = {k: v for k, v in request.query_params.items() if k != "id"}
+
     async with aiohttp.ClientSession() as client:
         if endpoint == "/is_sleeping":
-            async with client.get(url, headers=headers) as response:
+            async with client.get(
+                url, headers=headers, params=upstream_params
+            ) as response:
                 response.raise_for_status()
                 return await response.json()
         else:
@@ -1069,11 +1078,15 @@ async def route_sleep_wakeup_request(
             response_status = None
             if request_body:
                 req_data = json.loads(request_body)
-                async with client.post(url, json=req_data, headers=headers) as response:
+                async with client.post(
+                    url, json=req_data, headers=headers, params=upstream_params
+                ) as response:
                     response.raise_for_status()
                     response_status = response.status
             else:
-                async with client.post(url, headers=headers) as response:
+                async with client.post(
+                    url, headers=headers, params=upstream_params
+                ) as response:
                     response.raise_for_status()
                     response_status = response.status
 


### PR DESCRIPTION
Fixes #953.

### Summary

\`route_sleep_wakeup_request\` consumed only the router-internal \`id\` query parameter and dropped everything else, so \`POST /sleep?id=X&level=2\` silently degraded to \`level=1\` because vLLM never saw \`level=2\`. Same defect for \`mode\` on \`/sleep\` and \`tags\` on \`/wake_up\`.

This PR builds a dict of all query params minus \`id\` (router-only — consumed above to pick the target engine) and passes it as the aiohttp \`params=\` argument to each upstream call (\`is_sleeping\` GET, sleep/wake_up POST with body, sleep/wake_up POST without body).

### Reproduction (per issue #953)

Before:
\`\`\`
POST /sleep?id=X&level=2
-> upstream /sleep (no params)
-> vLLM falls back to level=1
\`\`\`

After:
\`\`\`
POST /sleep?id=X&level=2
-> upstream /sleep?level=2
-> vLLM honors level=2
\`\`\`

### Out of scope (follow-up)

The issue also mentions that \`/collective_rpc\` and \`/reset_prefix_cache\` are needed for \`level=2\` workflows but aren't registered through the router. That's a separate change (registers new endpoints, decides label-management semantics, may want auth/rate-limit considerations) and is best handled as a follow-up PR so this minimal forwarding fix can land without those design questions.

### Test plan

- \`ruff check\` / \`ruff format --check\` clean.
- Manual trace: with the change, \`request.query_params\` for \`/sleep?id=X&level=2&mode=offload\` yields \`{'id': 'X', 'level': '2', 'mode': 'offload'}\` -> \`upstream_params == {'level': '2', 'mode': 'offload'}\` -> aiohttp emits \`/sleep?level=2&mode=offload\` on the upstream URL.
- Existing single-param call \`/sleep?id=X\` continues to work (\`upstream_params == {}\` -> aiohttp omits the query string).

Diff is small and contained — only the four upstream HTTP calls in \`route_sleep_wakeup_request\` are touched.