### PR TITLE
[Feat] Add extraVolumes/extraVolumeMounts to routerSpec for readOnlyRootFilesystem

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -240,6 +240,8 @@ This table documents all available configuration values for the Production Stack
 | `routerSpec.routingLogic` | string | `"roundrobin"` | Routing logic: `"roundrobin"`, `"session"`, `"prefixaware"`, or `"kvaware"` |
 | `routerSpec.sessionKey` | string | `""` | Session key if using "session" routing logic |
 | `routerSpec.extraArgs` | list | `[]` | Extra command line arguments to pass to the router |
+| `routerSpec.extraVolumes` | list | `[]` | Additional volumes to add to the router pod, in Kubernetes volume format |
+| `routerSpec.extraVolumeMounts` | list | `[]` | Additional volume mounts to add to the router container, in Kubernetes volumeMount format |
 | `routerSpec.engineScrapeInterval` | integer | `15` | Interval in seconds to scrape metrics from the serving engine |
 | `routerSpec.requestStatsWindow` | integer | `60` | Window size in seconds for calculating request statistics |
 | `routerSpec.strategy` | map | `{}` | Deployment strategy for the router pods |

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -177,4 +177,12 @@ spec:
         readinessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.routerSpec.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.routerSpec.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -503,6 +503,14 @@
                     "description": "extra service ports",
                     "type": "array"
                 },
+                "extraVolumeMounts": {
+                    "description": "Additional volume mounts to add to the router container, in Kubernetes volumeMount format",
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "description": "Additional volumes to add to the router pod, in Kubernetes volume format",
+                    "type": "array"
+                },
                 "hf_token": {
                     "description": "Hugging Face token configuration",
                     "type": "string"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -437,6 +437,19 @@ routerSpec:
   # -- Container-level security context configuration. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core
   containerSecurityContext: {}
 
+  # -- Additional volumes to add to the router pod, in Kubernetes volume format
+  extraVolumes: []
+    # - name: tmp-volume
+    #   emptyDir: {}
+    # - name: home-volume
+    #   emptyDir: {}
+  # -- Additional volume mounts to add to the router container, in Kubernetes volumeMount format
+  extraVolumeMounts: []
+    # - name: tmp-volume
+    #   mountPath: /tmp
+    # - name: home-volume
+    #   mountPath: /home
+
   # -- Image pull secrets for private container registries
   # Example:
   # imagePullSecrets:


### PR DESCRIPTION
## Summary

Adds `extraVolumes` and `extraVolumeMounts` to `routerSpec` so the router pod can run with 
`readOnlyRootFilesystem: true`.

Model containers already support writable mounts via `servingEngineSpec.modelSpec[].extraVolumes` / `extraVolumeMounts`, but the router deployment had no equivalent. Only `containerSecurityContext` was configurable. Without writable mounts for paths like `/tmp` and `/home`, enabling a read-only root filesystem on the router would fail at runtime.

FIX #966

## Changes

- Add `routerSpec.extraVolumes` and `routerSpec.extraVolumeMounts` to `values.yaml` (default `[]`)
- Render volume mounts and volumes in `deployment-router.yaml`
- Update `values.schema.json` and `helm/README.md`

## Example

```yaml
routerSpec:
  containerSecurityContext:
    readOnlyRootFilesystem: true
  extraVolumes:
    - name: tmp-volume
      emptyDir: {}
    - name: home-volume
      emptyDir: {}
  extraVolumeMounts:
    - name: tmp-volume
      mountPath: /tmp
    - name: home-volume
      mountPath: /home
```

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
