### PR TITLE
fix(utils): make install-kubectl.sh work on macOS

### DIFF
--- a/utils/install-kubectl.sh
+++ b/utils/install-kubectl.sh
@@ -5,11 +5,30 @@ set -e
 KUBECTL_DIR="$HOME/.local/bin"
 KUBECTL_PATH="$KUBECTL_DIR/kubectl"
 
+# Detect host OS and architecture so we download the matching kubectl build.
+# Without this the script always pulled the linux/amd64 binary, which on macOS
+# installs an unexecutable Linux ELF (exec format error on later kubectl calls).
+OS_KERNEL="$(uname -s)"
+case "$OS_KERNEL" in
+  Linux)  HOST_OS=linux ;;
+  Darwin) HOST_OS=darwin ;;
+  *)      echo "ERROR: unsupported OS: $OS_KERNEL" >&2; exit 1 ;;
+esac
+
+OS_ARCH="$(uname -m)"
+case "$OS_ARCH" in
+  x86_64 | amd64)   HOST_ARCH=amd64 ;;
+  arm64 | aarch64)  HOST_ARCH=arm64 ;;
+  *)                echo "ERROR: unsupported architecture: $OS_ARCH" >&2; exit 1 ;;
+esac
+
+# A kubectl on PATH only counts as installed if it actually runs on this host
+# (a stale Linux binary on macOS is on PATH but cannot execute).
 kubectl_exists() {
-    command -v kubectl >/dev/null 2>&1
+    command -v kubectl >/dev/null 2>&1 && kubectl version --client >/dev/null 2>&1
 }
 
-# If kubectl is already installed, exit
+# If a working kubectl is already installed, exit
 if kubectl_exists; then
     echo "kubectl is already installed"
     exit 0
@@ -18,8 +37,9 @@ fi
 # Ensure the target directory exists
 mkdir -p "$KUBECTL_DIR"
 
-# Install kubectl
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+# Install kubectl for the detected platform. -f makes curl fail on HTTP errors
+# instead of saving an error page as the binary.
+curl -fLO "https://dl.k8s.io/release/$(curl -fL -s https://dl.k8s.io/release/stable.txt)/bin/${HOST_OS}/${HOST_ARCH}/kubectl"
 chmod +x kubectl
 mv kubectl "$KUBECTL_PATH"
 


### PR DESCRIPTION
## Summary

Follow-up to the review on #970 (and same macOS root cause as #931): `utils/install-kubectl.sh` always downloaded the `linux/amd64` kubectl, so on macOS it installs an unexecutable Linux ELF and later `kubectl` calls fail with an exec-format error. #970 fixed `install-minikube-cluster.sh`, which calls this script — so without this change the end-to-end flow still breaks on macOS at the kubectl step.

## Changes

- Detect OS (`uname -s` → linux/darwin) and arch (`uname -m` → amd64/arm64) and download the matching `bin/{linux,darwin}/{amd64,arm64}/kubectl`, mirroring the detection added to `install-minikube-cluster.sh` in #970.
- Treat an existing kubectl as installed only if it actually runs (`kubectl version --client`), so a stale Linux binary left on `PATH` on macOS is replaced instead of skipped (this was the exact `#931` failure mode).
- Use `curl -f` so an HTTP error aborts the script (via `set -e`) instead of saving an error page as the binary.

Linux behavior is unchanged: `HOST_OS`/`HOST_ARCH` resolve to `linux`/`amd64` on a normal x86_64 Linux host, giving the same URL as before.

## Test plan

- `bash -n utils/install-kubectl.sh` — passes (shellcheck runs in CI).
- On Linux x86_64: resolves to `bin/linux/amd64/kubectl` (identical to the previous hardcoded URL).
- On macOS arm64: resolves to `bin/darwin/arm64/kubectl`; a previously-installed Linux binary on `PATH` no longer short-circuits the install.

AI assistance was used; I have reviewed, run, and can defend every change.
