### PR TITLE
feat(helm/raycluster): pass through annotations and podAnnotations (#962)

### DIFF
--- a/helm/templates/ray-cluster.yaml
+++ b/helm/templates/ray-cluster.yaml
@@ -9,6 +9,10 @@ kind: RayCluster
 metadata:
   name: "{{ .Release.Name }}-{{$modelSpec.name}}-raycluster"
   namespace: {{ .Release.Namespace }}
+  {{- with $modelSpec.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     model: {{ $modelSpec.name }}
     helm-release-name: {{ .Release.Name }}
@@ -20,6 +24,10 @@ spec:
       dashboard-host: "0.0.0.0"
     template:
       metadata:
+        {{- with $modelSpec.podAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         labels:
           model: {{ $modelSpec.name }}
           helm-release-name: {{ .Release.Name }}
@@ -275,6 +283,10 @@ spec:
       groupName: ray
       template:
         metadata:
+          {{- with $modelSpec.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           labels:
             model: {{ $modelSpec.name }}
             helm-release-name: {{ .Release.Name }}

--- a/helm/tests/ray-cluster_test.yaml
+++ b/helm/tests/ray-cluster_test.yaml
@@ -175,6 +175,50 @@ tests:
         path: spec.workerGroupSpecs[0].template.spec.containers[0].image
         value: "vllm/vllm-openai:latest"
 
+  - it: should render annotations and podAnnotations on the RayCluster
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            imagePullSecret: "model-secret"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            annotations:
+              example.com/owner: team-a
+            podAnnotations:
+              k8s.v1.cni.cncf.io/networks: macvlan-conf
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      equal:
+        path: metadata.annotations.["example.com/owner"]
+        value: team-a
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.metadata.annotations.["k8s.v1.cni.cncf.io/networks"]
+        value: macvlan-conf
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.metadata.annotations.["k8s.v1.cni.cncf.io/networks"]
+        value: macvlan-conf
+
   - it: should not render VLLM_API_KEY
     release:
       name: vllm


### PR DESCRIPTION
## Summary

`modelSpec.annotations` and `modelSpec.podAnnotations` already exist and are honored for the standard (non-Ray) vLLM `Deployment` (`deployment-vllm-multi.yaml`), but the **RayCluster** template never consumed them. Users running engines through KubeRay (`raySpec.enabled: true`) therefore had no way to attach pod-level annotations — e.g. Multus `k8s.v1.cni.cncf.io/networks` — or object-level annotations to their head/worker pods. As #962 notes, the values appear to exist but were simply never wired into the kuberay path.

## Changes

`helm/templates/ray-cluster.yaml`, mirroring the existing `Deployment` pattern:

- `modelSpec.annotations` → `RayCluster` object `metadata.annotations`
- `modelSpec.podAnnotations` → head pod template `metadata.annotations`
- `modelSpec.podAnnotations` → worker pod template `metadata.annotations`

No new values are introduced — this only completes the existing passthrough for the KubeRay path. Both blocks are guarded with `{{- with ... }}`, so output is unchanged when the values are empty (the default).

## Test

Adds a `helm-unittest` case to `helm/tests/ray-cluster_test.yaml` asserting that both `annotations` (object) and `podAnnotations` (head + worker) render on the RayCluster.

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
