### PR TITLE
[Feat] Add timeouts to VLLM Router configuration

### DIFF
--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -41,6 +41,10 @@ spec:
     - backendRefs:
         - name: {{ $serviceName }}
           port: {{ $servicePort }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}

--- a/helm/tests/route_test.yaml
+++ b/helm/tests/route_test.yaml
@@ -66,6 +66,8 @@ tests:
             parentRefs:
               - name: gateway
                 namespace: default
+            timeouts:
+              requests: 300s
     asserts:
     - hasDocuments:
         count: 2
@@ -183,3 +185,8 @@ tests:
           - path:
               type: PathPrefix
               value: /
+    - documentIndex: 1
+      equal:
+        path: spec.rules[0].timeouts
+        value:
+          requests: 300s

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -636,6 +636,10 @@ routerSpec:
         #       - name: X-Custom-Header
         #         value: custom-value
 
+      # -- Timeouts applied to the route rule (https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
+      timeouts: {}
+        # requests: 300s
+
       # -- Additional custom rules that can be added to the route
       additionalRules: []
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -638,7 +638,6 @@ routerSpec:
 
       # -- Timeouts applied to the route rule (https://gateway-api.sigs.k8s.io/api-types/httproute/#timeouts-optional)
       timeouts: {}
-        # requests: 300s
 
       # -- Additional custom rules that can be added to the route
       additionalRules: []


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

FIX #706
---
Currently the router configuration for the backend will be created with defaults, for some models and scenarios this means the Gateway is timing out before vLLM responds. This is a quick fix to allow users to create a timeout. Long term a more elegant solution would be appropriate.

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.
