### PR TITLE
feat(helm/raySpec): allow customizing the Ray head node readiness probe (#742)

### DIFF
--- a/helm/templates/ray-cluster.yaml
+++ b/helm/templates/ray-cluster.yaml
@@ -167,11 +167,15 @@ spec:
               - name: {{ include "chart.container-port-name" . }}
                 containerPort: {{ include "chart.container-port" . }}
             readinessProbe:
+              {{- if $modelSpec.raySpec.headNode.readinessProbe }}
+              {{- toYaml $modelSpec.raySpec.headNode.readinessProbe | nindent 14 }}
+              {{- else }}
               httpGet:
                 path: /health
                 port: {{ include "chart.container-port" . }}
               failureThreshold: 1
               periodSeconds: 10
+              {{- end }}
             livenessProbe:
               exec:
                 command: ["/bin/bash", "-c", "echo TBD"]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -275,6 +275,18 @@ servingEngineSpec:
         requestMemory: "1Gi"
         # -- GPU request for the head node
         requestGPU: 1
+        # Readiness probe for the Ray head node (raySpec.headNode.readinessProbe).
+        # If unset, defaults to an httpGet /health probe with failureThreshold 1
+        # and periodSeconds 10. Override it to relax the probe when the model
+        # takes a long time to come up on a multi-node setup, otherwise the head
+        # pod may be marked unready and never receive traffic. Accepts a standard
+        # Kubernetes probe spec, e.g.:
+        # readinessProbe:
+        #   httpGet:
+        #     path: /health
+        #     port: 8000
+        #   failureThreshold: 10
+        #   periodSeconds: 30
 
   # -- Container port
   containerPort: 8000


### PR DESCRIPTION
## Summary

Fixes #742.

The multi-node Ray head pod hard-codes its readiness probe in `helm/templates/ray-cluster.yaml`:

```yaml
readinessProbe:
  httpGet:
    path: /health
    port: {{ include "chart.container-port" . }}
  failureThreshold: 1
  periodSeconds: 10
```

With `failureThreshold: 1` and `periodSeconds: 10`, a single failed probe marks the head pod unready. On large multi-node deployments the head serving process can take longer than one 10s period to begin answering `/health`, so the pod flips to unready and never receives traffic (`Readiness probe failed: ... connect: connection refused`). As reported in #742, there was no way to relax it — setting `readinessProbe` under `servingEngineSpec`, `modelSpec`, or `raySpec.headNode` had no effect on the head node.

## Change

Honor `raySpec.headNode.readinessProbe` when set, rendered verbatim via `toYaml`, and fall back to the existing default otherwise:

```yaml
readinessProbe:
  {{- if $modelSpec.raySpec.headNode.readinessProbe }}
  {{- toYaml $modelSpec.raySpec.headNode.readinessProbe | nindent 14 }}
  {{- else }}
  httpGet:
    path: /health
    port: {{ include "chart.container-port" . }}
  failureThreshold: 1
  periodSeconds: 10
  {{- end }}
```

- **Backward compatible**: with the field unset the rendered output is byte-identical to before.
- Documents the field with an example in `values.yaml`.
- No `values.schema.json` change: `raySpec.headNode` is an open object in the schema (no `additionalProperties: false`), and the schema is generated from `values.yaml` in CI, so hand-editing it would just be reverted by the generator.

### Example

```yaml
raySpec:
  headNode:
    requestCPU: 16
    requestMemory: "32Gi"
    requestGPU: 2
    readinessProbe:
      httpGet:
        path: /health
        port: 8000
      failureThreshold: 10
      periodSeconds: 30
```

## Notes

I don't have a multi-node GPU cluster to reproduce end-to-end, so I verified the template logic and the values change by inspection. `helm template` with the field set renders the overriding probe; with it unset it renders the original default unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
