### PR TITLE
[Bugfix][Helm] skip lmcache dashboard when cache server is disabled

### DIFF
--- a/helm/templates/dashboards.yaml
+++ b/helm/templates/dashboards.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.grafanaDashboards.enabled }}
 {{- range $path, $bytes := .Files.Glob "dashboards/*.json" }}
+{{- $filename := base $path }}
+{{- if and (eq $filename "lmcache-dashboard.json") (not $.Values.cacheserverSpec.enabled) }}
+{{- continue }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/tests/dashboards_test.yaml
+++ b/helm/tests/dashboards_test.yaml
@@ -10,7 +10,7 @@ tests:
     - hasDocuments:
         count: 0
 
-  - it: should render dashboards when grafanaDashboards is enabled
+  - it: should render all dashboards when grafanaDashboards and cacheserver are enabled
     release:
       name: vllm
     set:
@@ -18,9 +18,11 @@ tests:
         enabled: true
         annotations:
           app: grafana
+      cacheserverSpec:
+        enabled: true
     asserts:
     - hasDocuments:
-        count: 2
+        count: 3
     - documentIndex: 0
       equal:
         path: metadata.name
@@ -50,3 +52,35 @@ tests:
         path: metadata.labels
         value:
           grafana_dashboard: "1"
+    - documentIndex: 2
+      equal:
+        path: metadata.name
+        value: vllm-grafana-vllm-model-metrics-dashboard
+    - documentIndex: 2
+      exists:
+        path: data["vllm-model-metrics-dashboard.json"]
+    - documentIndex: 2
+      equal:
+        path: metadata.labels
+        value:
+          grafana_dashboard: "1"
+
+  - it: should exclude lmcache-dashboard when cacheserver is disabled
+    release:
+      name: vllm
+    set:
+      grafanaDashboards:
+        enabled: true
+      cacheserverSpec:
+        enabled: false
+    asserts:
+    - hasDocuments:
+        count: 2
+    - documentIndex: 0
+      equal:
+        path: metadata.name
+        value: vllm-grafana-vllm-dashboard
+    - documentIndex: 1
+      equal:
+        path: metadata.name
+        value: vllm-grafana-vllm-model-metrics-dashboard


### PR DESCRIPTION
- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

When `grafanaDashboards.enabled` is true, the chart renders a `ConfigMap` for every JSON file in `dashboards/*.json`, including `lmcache-dashboard.json`. This happened regardless of whether the cache server was actually deployed, so clusters running with `cacheserverSpec.enabled: false` ended up with an LMCache Grafana dashboard for a component that isn't running  and it showes panels with no-data.

This PR makes the dashboard rendering conditional: `lmcache-dashboard.json` is now skipped when `cacheserverSpec.enabled` is `false`. All other dashboards continue to render as before.