### PR TITLE
feat(helm): support externally-managed PVC via pvcExistingClaimName (#938)

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -471,7 +471,7 @@ spec:
             {{- toYaml $modelSpec.pvcStorage.emptyDir | nindent 12 }}
         {{- else if kindIs "string" $modelSpec.pvcStorage }}
           persistentVolumeClaim:
-            claimName: "{{ .Release.Name }}-{{$modelSpec.name}}-storage-claim"
+            claimName: {{ $modelSpec.pvcExistingClaimName | default (printf "%s-%s-storage-claim" .Release.Name $modelSpec.name) | quote }}
         {{- end }}
         {{- end }}
         {{- if $.Values.sharedPvcStorage.enabled }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.servingEngineSpec.enableEngine -}}
 {{- range $modelSpec := .Values.servingEngineSpec.modelSpec }}
 {{- with $ -}}
-{{- if and (hasKey $modelSpec "pvcStorage") (not (empty $modelSpec.pvcStorage)) (kindIs "string" $modelSpec.pvcStorage) }}
+{{- if and (hasKey $modelSpec "pvcStorage") (not (empty $modelSpec.pvcStorage)) (kindIs "string" $modelSpec.pvcStorage) (empty $modelSpec.pvcExistingClaimName) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/tests/pvc_test.yaml
+++ b/helm/tests/pvc_test.yaml
@@ -66,3 +66,16 @@ tests:
           path: spec.selector.matchLabels
           value:
             model: "mistral"
+
+  - it: should not render a PVC when an existing claim is provided
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            pvcStorage: "50Gi"
+            pvcExistingClaimName: "my-existing-claim"
+    asserts:
+      - template: pvc.yaml
+        hasDocuments:
+          count: 0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -94,6 +94,11 @@ servingEngineSpec:
     pvcLabels: {}
     # -- The annotations to add to the PVC
     pvcAnnotations: {}
+    # Use an externally-managed PersistentVolumeClaim instead of one created by
+    # this chart. When set, the chart skips rendering the PVC and mounts the
+    # named claim directly (useful for GitOps setups where PVCs are managed
+    # outside the chart). Leave unset to have the chart create the PVC.
+    # pvcExistingClaimName: "my-existing-claim"
     # -- Additional volumes to add to the pod, in Kubernetes volume format
     extraVolumes: []
       # - name: tmp-volume


### PR DESCRIPTION
## Summary

Fixes #938.

Adds an optional per-model `pvcExistingClaimName` to `servingEngineSpec.modelSpec[]`, so operators can mount a `PersistentVolumeClaim` that is managed **outside** the chart instead of one the chart creates. This is useful for GitOps environments where PVC policy requires claims to be provisioned separately and brought in via `existingClaim`.

## Behavior

- **`pvcExistingClaimName` set** → the chart skips rendering the model PVC (`pvc.yaml`) and the serving-engine deployment mounts the named claim directly.
- **`pvcExistingClaimName` unset (default)** → unchanged: the chart creates and mounts `<release>-<model>-storage-claim`.

## Changes

- `helm/templates/pvc.yaml` — guard PVC creation with `(empty $modelSpec.pvcExistingClaimName)`.
- `helm/templates/deployment-vllm-multi.yaml` — use `pvcExistingClaimName` for the volume `claimName` when set, falling back to the generated name.
- `helm/values.yaml` — document the option as a commented example. Kept as a plain comment (not a `# --` helm-docs key) so the generated `values.schema.json` is unaffected; since `modelSpec` items do not set `additionalProperties: false`, the new key still validates.
- `helm/tests/pvc_test.yaml` — add a case asserting no PVC document is rendered when `pvcExistingClaimName` is set.

Scope is limited to the per-model storage claim referenced by the serving-engine deployment; the separate `sharedPvcStorage` path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
