### PR TITLE
[Bugfix][Router] Seed the prefix trie on the below-threshold QPS fallback path

### DIFF
--- a/src/tests/test_prefixaware_router.py
+++ b/src/tests/test_prefixaware_router.py
@@ -38,6 +38,11 @@ async def test_route_falls_back_to_qps_when_match_below_threshold():
     When the longest prefix match is shorter than prefix_min_match_length,
     the request should NOT use the matched endpoint. It should fall back to
     QPS-based routing and pick the engine with the lowest QPS.
+
+    The prompt must still be inserted into the trie, attributed to the
+    QPS-selected endpoint. Otherwise a router that starts with an empty trie
+    never seeds it (every request matches below the threshold), and prefix
+    affinity never activates.
     """
 
     endpoints = [
@@ -66,7 +71,57 @@ async def test_route_falls_back_to_qps_when_match_below_threshold():
 
     assert url == "http://engine2.com"
 
-    fake_hashtrie.insert.assert_not_awaited()
+    fake_hashtrie.insert.assert_awaited_once_with(
+        "some prompt text", "http://engine2.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_seeding_enables_later_pinning():
+    """
+    Regression test for the trie never seeding when
+    prefix_min_match_length > 0.
+
+    Uses the real HashTrie. The first request has no prefix match, so it is
+    routed by QPS — but it must seed the trie. A follow-up request extending
+    the same prompt then matches above the threshold and must pin to the
+    endpoint that served the first request, even when QPS stats would prefer
+    the other endpoint.
+    """
+
+    endpoints = [
+        EndpointInfo(url="http://engine1.com"),
+        EndpointInfo(url="http://engine2.com"),
+    ]
+    request = Request(headers={})
+
+    # 128 = one HashTrie chunk; the first chunk of both prompts is identical.
+    router = PrefixAwareRouter(prefix_min_match_length=128)
+
+    first_prompt = "x" * 128 + "y" * 72
+    followup_prompt = first_prompt + "z" * 40
+
+    # First request: cold trie, match below threshold -> QPS picks engine1.
+    request_stats = {
+        "http://engine1.com": RequestStats(qps=5),
+        "http://engine2.com": RequestStats(qps=10),
+    }
+    url = await router.route_request(
+        endpoints, None, request_stats, request, {"prompt": first_prompt}
+    )
+    assert url == "http://engine1.com"
+
+    # Follow-up: shares the first 128-char chunk, so it matches at the
+    # threshold and must pin to engine1 even though engine2 now has the
+    # lower QPS.
+    request_stats = {
+        "http://engine1.com": RequestStats(qps=10),
+        "http://engine2.com": RequestStats(qps=5),
+    }
+    url = await router.route_request(
+        endpoints, None, request_stats, request, {"prompt": followup_prompt}
+    )
+    assert url == "http://engine1.com"
 
 
 @pytest.mark.asyncio

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -505,7 +505,14 @@ class PrefixAwareRouter(RoutingInterface):
         )
 
         if match_length < self.prefix_min_match_length:
-            return self._qps_routing(endpoints, request_stats)
+            # Fall back to QPS routing, but still record the prompt in the
+            # trie. Without this, a router configured with
+            # prefix_min_match_length > 0 starts with an empty trie, every
+            # request matches below the threshold, nothing is ever inserted,
+            # and prefix affinity never activates.
+            selected_endpoint = self._qps_routing(endpoints, request_stats)
+            await self.hashtrie.insert(prompt, selected_endpoint)
+            return selected_endpoint
 
         selected_endpoint = random.choice(list(matched_endpoint))
 

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -511,7 +511,8 @@ class PrefixAwareRouter(RoutingInterface):
             # request matches below the threshold, nothing is ever inserted,
             # and prefix affinity never activates.
             selected_endpoint = self._qps_routing(endpoints, request_stats)
-            await self.hashtrie.insert(prompt, selected_endpoint)
+            if selected_endpoint is not None:
+                await self.hashtrie.insert(prompt, selected_endpoint)
             return selected_endpoint
 
         selected_endpoint = random.choice(list(matched_endpoint))


### PR DESCRIPTION
## Bug

With `--prefix-min-match-length` set to any value > 0 (added in #959), `PrefixAwareRouter` never activates prefix affinity:

1. The router starts with an empty `HashTrie`.
2. Every incoming request therefore gets `match_length = 0 < prefix_min_match_length`.
3. The below-threshold branch returns `self._qps_routing(...)` **without inserting the prompt into the trie**.
4. The trie stays empty forever, so every subsequent request also takes the fallback branch.

Net effect: setting the flag silently turns the prefix-aware router into a pure QPS router. We hit this in production (two vLLM backends behind the router): with `--prefix-min-match-length 4096` the trie never seeded and no request ever pinned; with `0` affinity works but shared prompt prefixes (system prompts / shared project context) create a self-reinforcing single-backend monopoly — the exact problem the threshold was designed to solve.

## Fix

On the below-threshold path, still insert the prompt into the trie, attributed to the QPS-selected endpoint:

- Short or brand-new prefixes keep load-balancing by QPS (unchanged intent of #959).
- Once a conversation's prefix history exceeds the threshold, it matches the seeded entries and pins to the endpoint that already holds its KV cache.

Verified in production with two vLLM backends and `--prefix-min-match-length 100000`: identical sub-threshold prompts QPS-balance across both backends, distinct conversations sharing a 40k-char prefix spread across both backends, and a >100k-char conversation pins to a single backend across turns.

## Tests

- Updated `test_route_falls_back_to_qps_when_match_below_threshold`: the fallback path must insert the prompt attributed to the QPS-selected endpoint (previously asserted no insert, which encoded the bug).
- Added `test_below_threshold_seeding_enables_later_pinning`: regression test using the real `HashTrie` — a cold-trie request routes by QPS and seeds the trie; a follow-up request extending the same prompt matches above the threshold and pins to the seeding endpoint even when QPS stats prefer the other one.

All 4 tests in `src/tests/test_prefixaware_router.py` pass.
