### PR TITLE
[Feat][Helm] Support customizable resources and init containers for RayCluster

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 maintainers:
   - name: apostac

--- a/helm/README.md
+++ b/helm/README.md
@@ -203,6 +203,28 @@ This table documents all available configuration values for the Production Stack
 | `servingEngineSpec.modelSpec[].keda.advanced.scalingModifiers.metricType` | string | `"AverageValue"` | Metric type (AverageValue or Value) |
 | `servingEngineSpec.modelSpec[].keda.advanced.scalingModifiers.formula` | string | - | Formula to compose metrics together |
 
+#### Ray Cluster Configuration
+
+Set `servingEngineSpec.modelSpec[].raySpec.enabled: true` to deploy the model as a multi-node `RayCluster` (via KubeRay) instead of a standard `Deployment`. Worker resources and the worker init container are taken from the top-level `modelSpec` (`requestCPU`/`requestMemory`/`requestGPU` or `resources`, and `initContainer`), while head-node resources and the head-node init container are configured under `raySpec.headNode`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `servingEngineSpec.modelSpec[].raySpec.enabled` | boolean | `false` | Deploy the model as a `RayCluster` instead of a `Deployment` |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.requestCPU` | integer | `1` | CPU request for the Ray head node container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.requestMemory` | string | `"1Gi"` | Memory request for the Ray head node container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.requestGPU` | integer | `1` | GPU request for the Ray head node container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.resources` | map | `{}` | (Optional) Raw Kubernetes `resources` block for the head container. When set, overrides the `request*` fields above |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.name` | string | - | (Optional) Name of an init container to run before the Ray head container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.image` | string | - | (Optional) Image for the head init container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.command` | list | `[]` | (Optional) Command for the head init container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.args` | list | `[]` | (Optional) Args for the head init container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.env` | list | `[]` | (Optional) Environment variables for the head init container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.resources` | map | `{}` | (Optional) Resource requests/limits for the head init container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.mountPvcStorage` | boolean | `false` | (Optional) Mount the model's PVC into the head init container |
+| `servingEngineSpec.modelSpec[].raySpec.headNode.initContainer.extraVolumeMounts` | list | `[]` | (Optional) Additional volume mounts for the head init container |
+
+> **Note**: Ray worker pods reuse the top-level `modelSpec` fields — set `modelSpec.requestCPU`/`requestMemory`/`requestGPU` (or `modelSpec.resources` for a raw override) to size the workers, and `modelSpec.initContainer` to inject an init container into each worker pod.
+
 #### Serving Engine Monitoring Configuration
 
 | Field | Type | Default | Description |

--- a/helm/templates/ray-cluster.yaml
+++ b/helm/templates/ray-cluster.yaml
@@ -41,6 +41,51 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if and (hasKey $modelSpec "raySpec") (hasKey $modelSpec.raySpec "headNode") (hasKey $modelSpec.raySpec.headNode "initContainer") }}
+        {{- $container := $modelSpec.raySpec.headNode.initContainer }}
+        initContainers:
+          - name: {{ $container.name }}
+            image: {{ $container.image }}
+            {{- if $container.command }}
+            command: {{ toYaml $container.command | nindent 14 }}
+            {{- end }}
+            {{- if $container.args }}
+            args: {{ toYaml $container.args | nindent 14 }}
+            {{- end }}
+            {{- if $modelSpec.envFromSecret }}
+            envFrom:
+              - secretRef:
+                  name: {{ $modelSpec.envFromSecret.name }}
+            {{- end }}
+            env:
+              - name: RELEASE_NAME
+                value: {{ .Release.Name }}
+              {{- if and .Values.cacheserverSpec.enabled .Values.cacheserverSpec.servicePort }}
+              - name: LMCACHE_SERVER_SERVICE_PORT
+                value: {{ .Values.cacheserverSpec.servicePort | quote }}
+              {{- end }}
+              {{- if $container.env }}
+              {{- toYaml $container.env | nindent 14 }}
+              {{- end }}
+            {{- if $container.resources }}
+            resources: {{ toYaml $container.resources | nindent 14 }}
+            {{- end }}
+            {{- $pvcMountEnabled := and (hasKey $container "mountPvcStorage") $container.mountPvcStorage (hasKey $modelSpec "pvcStorage") }}
+            {{- if or $pvcMountEnabled $container.extraVolumeMounts }}
+            volumeMounts:
+              {{- if $pvcMountEnabled }}
+              - name: {{ .Release.Name }}-storage
+                mountPath: /data
+              {{- end }}
+              {{- with $container.extraVolumeMounts }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.servingEngineSpec.containerSecurityContext }}
+            securityContext:
+              {{- toYaml .Values.servingEngineSpec.containerSecurityContext | nindent 14 }}
+            {{- end }}
+        {{- end }}
         containers:
           - name: vllm-ray-head
             image: "{{ required "Required value 'modelSpec.repository' must be defined !" $modelSpec.repository }}:{{ required "Required value 'modelSpec.tag' must be defined !" $modelSpec.tag }}"
@@ -175,7 +220,11 @@ spec:
             livenessProbe:
               exec:
                 command: ["/bin/bash", "-c", "echo TBD"]
+            {{- if $modelSpec.raySpec.headNode.resources }}
+            resources: {{ toYaml $modelSpec.raySpec.headNode.resources | nindent 14 }}
+            {{- else }}
             resources: {{- include "chart.resources" $modelSpec.raySpec.headNode | nindent 14 }}
+            {{- end }}
             startupProbe:
               exec:
                 command: ["/bin/bash", "-c", "python3 /scripts/wait_for_ray.py"]
@@ -302,6 +351,51 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if hasKey $modelSpec "initContainer" }}
+          {{- $container := $modelSpec.initContainer }}
+          initContainers:
+            - name: {{ $container.name }}
+              image: {{ $container.image }}
+              {{- if $container.command }}
+              command: {{ toYaml $container.command | nindent 16 }}
+              {{- end }}
+              {{- if $container.args }}
+              args: {{ toYaml $container.args | nindent 16 }}
+              {{- end }}
+              {{- if $modelSpec.envFromSecret }}
+              envFrom:
+                - secretRef:
+                    name: {{ $modelSpec.envFromSecret.name }}
+              {{- end }}
+              env:
+                - name: RELEASE_NAME
+                  value: {{ .Release.Name }}
+                {{- if and .Values.cacheserverSpec.enabled .Values.cacheserverSpec.servicePort }}
+                - name: LMCACHE_SERVER_SERVICE_PORT
+                  value: {{ .Values.cacheserverSpec.servicePort | quote }}
+                {{- end }}
+                {{- if $container.env }}
+                {{- toYaml $container.env | nindent 16 }}
+                {{- end }}
+              {{- if $container.resources }}
+              resources: {{ toYaml $container.resources | nindent 16 }}
+              {{- end }}
+              {{- $pvcMountEnabled := and (hasKey $container "mountPvcStorage") $container.mountPvcStorage (hasKey $modelSpec "pvcStorage") }}
+              {{- if or $pvcMountEnabled $container.extraVolumeMounts }}
+              volumeMounts:
+                {{- if $pvcMountEnabled }}
+                - name: {{ .Release.Name }}-storage
+                  mountPath: /data
+                {{- end }}
+                {{- with $container.extraVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              {{- end }}
+              {{- if .Values.servingEngineSpec.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.servingEngineSpec.containerSecurityContext | nindent 16 }}
+              {{- end }}
+          {{- end }}
           containers:
             - name: vllm-ray-worker
               image: "{{ required "Required value 'modelSpec.repository' must be defined !" $modelSpec.repository }}:{{ required "Required value 'modelSpec.tag' must be defined !" $modelSpec.tag }}"
@@ -421,7 +515,11 @@ spec:
               livenessProbe:
                 exec:
                   command: ["/bin/bash", "-c", "echo TBD"]
+              {{- if $modelSpec.resources }}
+              resources: {{ toYaml $modelSpec.resources | nindent 16 }}
+              {{- else }}
               resources: {{- include "chart.resources" $modelSpec | nindent 16 }}
+              {{- end }}
               {{- if or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) (hasKey $modelSpec "chatTemplate") (hasKey $modelSpec "extraVolumeMounts") $modelSpec.extraVolumeMounts }}
               volumeMounts:
               {{- end }}

--- a/helm/tests/ray-cluster_test.yaml
+++ b/helm/tests/ray-cluster_test.yaml
@@ -663,3 +663,348 @@ tests:
       notMatchRegex:
         path: data["vllm-entrypoint.sh"]
         pattern: "--revision"
+
+  - it: should not render initContainers on head or worker when not configured
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      isNull:
+        path: spec.headGroupSpec.template.spec.initContainers
+    - documentIndex: 0
+      isNull:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers
+
+  - it: should render initContainer on head node from raySpec.headNode.initContainer
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+                initContainer:
+                  name: "head-init"
+                  image: "busybox:latest"
+                  command: ["sh", "-c"]
+                  args: ["echo head-init"]
+                  env:
+                    - name: HEAD_VAR
+                      value: "head-value"
+                  resources:
+                    requests:
+                      cpu: "50m"
+                      memory: "64Mi"
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.initContainers[0].name
+        value: head-init
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.initContainers[0].image
+        value: busybox:latest
+    - documentIndex: 0
+      contains:
+        path: spec.headGroupSpec.template.spec.initContainers[0].env
+        content:
+          name: RELEASE_NAME
+          value: vllm
+        any: true
+    - documentIndex: 0
+      contains:
+        path: spec.headGroupSpec.template.spec.initContainers[0].env
+        content:
+          name: HEAD_VAR
+          value: "head-value"
+        any: true
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.initContainers[0].resources.requests.cpu
+        value: "50m"
+    - documentIndex: 0
+      isNull:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers
+
+  - it: should render initContainer on worker nodes from modelSpec.initContainer
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 2
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            initContainer:
+              name: "worker-init"
+              image: "busybox:latest"
+              command: ["sh", "-c"]
+              args: ["echo worker-init"]
+              env:
+                - name: WORKER_VAR
+                  value: "worker-value"
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: kind
+        value: RayCluster
+    - documentIndex: 0
+      isNull:
+        path: spec.headGroupSpec.template.spec.initContainers
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers[0].name
+        value: worker-init
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers[0].image
+        value: busybox:latest
+    - documentIndex: 0
+      contains:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers[0].env
+        content:
+          name: RELEASE_NAME
+          value: vllm
+        any: true
+    - documentIndex: 0
+      contains:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers[0].env
+        content:
+          name: WORKER_VAR
+          value: "worker-value"
+        any: true
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers[0].resources.requests.memory
+        value: "128Mi"
+
+  - it: should render independent initContainers on head and worker when both are configured
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 1
+            initContainer:
+              name: "worker-init"
+              image: "busybox:latest"
+              command: ["sh", "-c"]
+              args: ["echo worker"]
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 1
+                initContainer:
+                  name: "head-init"
+                  image: "busybox:latest"
+                  command: ["sh", "-c"]
+                  args: ["echo head"]
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.initContainers[0].name
+        value: head-init
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.initContainers[0].name
+        value: worker-init
+
+  - it: should honor raySpec.headNode.resources override on the head container
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 0
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 0
+                resources:
+                  requests:
+                    cpu: "3"
+                    memory: "12Gi"
+                    nvidia.com/gpu: "1"
+                  limits:
+                    cpu: "6"
+                    memory: "24Gi"
+                    nvidia.com/gpu: "1"
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.containers[0].resources.requests.cpu
+        value: "3"
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.containers[0].resources.requests.memory
+        value: "12Gi"
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+        value: "1"
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.containers[0].resources.limits.cpu
+        value: "6"
+
+  - it: should honor modelSpec.resources override on the worker container
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 1
+            requestMemory: "1Gi"
+            requestGPU: 0
+            resources:
+              requests:
+                cpu: "8"
+                memory: "32Gi"
+                nvidia.com/gpu: "2"
+              limits:
+                cpu: "16"
+                memory: "64Gi"
+                nvidia.com/gpu: "2"
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 1
+                requestMemory: "1Gi"
+                requestGPU: 0
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.containers[0].resources.requests.cpu
+        value: "8"
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.containers[0].resources.requests.memory
+        value: "32Gi"
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+        value: "2"
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.containers[0].resources.limits.memory
+        value: "64Gi"
+
+  - it: should fall back to simplified request* fields when no raw resources override is given
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+          - name: "test-model"
+            repository: "vllm/vllm-openai"
+            tag: "latest"
+            modelURL: "facebook/opt-125m"
+            replicaCount: 1
+            requestCPU: 4
+            requestMemory: "16Gi"
+            requestGPU: 1
+            raySpec:
+              enabled: true
+              headNode:
+                requestCPU: 2
+                requestMemory: "8Gi"
+                requestGPU: 1
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.containers[0].resources.requests.cpu
+        value: "2"
+    - documentIndex: 0
+      equal:
+        path: spec.headGroupSpec.template.spec.containers[0].resources.requests.memory
+        value: "8Gi"
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.containers[0].resources.requests.cpu
+        value: "4"
+    - documentIndex: 0
+      equal:
+        path: spec.workerGroupSpecs[0].template.spec.containers[0].resources.requests.memory
+        value: "16Gi"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1454,6 +1454,54 @@
                                             "requestMemory": {
                                                 "description": "Memory request for the head node",
                                                 "type": "string"
+                                            },
+                                            "resources": {
+                                                "description": "Raw Kubernetes resources block for the head node container. If specified, takes priority over the simplified request* fields.",
+                                                "type": "object"
+                                            },
+                                            "initContainer": {
+                                                "description": "The configuration for an init container to be run before the Ray head container starts.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "args": {
+                                                        "description": "Additional arguments to pass to the command",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "command": {
+                                                        "description": "The command to run in the init container",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "env": {
+                                                        "description": "List of environment variables to set in the container",
+                                                        "type": "array"
+                                                    },
+                                                    "extraVolumeMounts": {
+                                                        "description": "Additional volume mounts to add to the init container, in Kubernetes volumeMount format.",
+                                                        "type": "array"
+                                                    },
+                                                    "image": {
+                                                        "description": "The Docker image for the init container",
+                                                        "type": "string"
+                                                    },
+                                                    "mountPvcStorage": {
+                                                        "description": "Whether to mount the model's PVC storage into the init container",
+                                                        "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                        "description": "The name of the init container",
+                                                        "type": "string"
+                                                    },
+                                                    "resources": {
+                                                        "description": "The resource requests and limits for the init container",
+                                                        "type": "object"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -275,6 +275,29 @@ servingEngineSpec:
         requestMemory: "1Gi"
         # -- GPU request for the head node
         requestGPU: 1
+        # -- Raw Kubernetes resources block for the head node container. When set, overrides the request*/limit* fields above.
+        # resources:
+        #   requests:
+        #     cpu: "2"
+        #     memory: "8Gi"
+        #     nvidia.com/gpu: "1"
+        #   limits:
+        #     cpu: "4"
+        #     memory: "16Gi"
+        #     nvidia.com/gpu: "1"
+        # -- Optional init container run before the Ray head container starts. Mirrors modelSpec.initContainer.
+        # initContainer:
+        #   name: "init"
+        #   image: "busybox:latest"
+        #   command: ["sh", "-c"]
+        #   args: ["ls"]
+        #   env: []
+        #   resources: {}
+        #   mountPvcStorage: true
+        #   extraVolumeMounts: []
+      # Worker nodes reuse the top-level modelSpec fields:
+      #   - resources come from modelSpec.requestCPU / requestMemory / requestGPU (or modelSpec.resources for a raw override)
+      #   - the optional init container comes from modelSpec.initContainer
 
   # -- Container port
   containerPort: 8000


### PR DESCRIPTION
Extends the Ray cluster template so users can now:

- Provide a raw Kubernetes resources block on both the Ray head (raySpec.headNode.resources) and the Ray workers (modelSpec.resources). When set, the raw block takes priority over the simplified request*/limit* fields, mirroring the existing behavior in deployment-vllm-multi.yaml.
- Attach an init container to the Ray head pod via raySpec.headNode.initContainer and to each Ray worker pod via modelSpec.initContainer, using the same block shape as the regular vLLM deployment (name, image, command, args, env, resources, mountPvcStorage, extraVolumeMounts).

The values.yaml documentation, values.schema.json and helm/README.md are updated so contributors can discover the new fields, and helm/tests/ray-cluster_test.yaml is extended with helm-unittest cases that cover the new head/worker init containers, the raw resources overrides, and the fall-through to the simplified request* fields.

Bumps helm/Chart.yaml to 0.1.12 per the chart's version-bump instructions.

The change is backwards compatible: existing raySpec configurations without initContainer or resources render identically to before.

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.
