### PR TITLE
feat(operator): support shmSize on VLLMRuntime for tensor parallelism (#899)

### DIFF
--- a/operator/api/v1alpha1/vllmruntime_types.go
+++ b/operator/api/v1alpha1/vllmruntime_types.go
@@ -45,6 +45,13 @@ type DeploymentConfig struct {
 	// +kubebuilder:default=nvidia
 	RuntimeClass string `json:"runtimeClass,omitempty"`
 
+	// ShmSize, when set, mounts an emptyDir with medium=Memory at /dev/shm
+	// sized to this value (e.g. "24Gi"). Tensor parallelism uses shared
+	// memory for inter-process communication and the container default
+	// /dev/shm (typically 64Mi) is too small. Accepts any Kubernetes quantity.
+	// +optional
+	ShmSize string `json:"shmSize,omitempty"`
+
 	// Resource requirements
 	Resources ResourceRequirements `json:"resources"`
 

--- a/operator/config/crd/bases/production-stack.vllm.ai_vllmruntimes.yaml
+++ b/operator/config/crd/bases/production-stack.vllm.ai_vllmruntimes.yaml
@@ -283,6 +283,13 @@ spec:
                     default: nvidia
                     description: RuntimeClass
                     type: string
+                  shmSize:
+                    description: |-
+                      ShmSize, when set, mounts an emptyDir with medium=Memory at /dev/shm
+                      sized to this value (e.g. "24Gi"). Tensor parallelism uses shared
+                      memory for inter-process communication and the container default
+                      /dev/shm (typically 64Mi) is too small. Accepts any Kubernetes quantity.
+                    type: string
                   sidecarConfig:
                     description: Sidecar configuration
                     properties:

--- a/operator/internal/controller/vllmruntime_controller.go
+++ b/operator/internal/controller/vllmruntime_controller.go
@@ -738,6 +738,23 @@ func (r *VLLMRuntimeReconciler) deploymentForVLLMRuntime(
 		})
 	}
 
+	// Mount an emptyDir (medium=Memory) at /dev/shm when a size is requested.
+	// Tensor parallelism communicates over shared memory, and the container
+	// default /dev/shm is usually too small for it.
+	if vllmRuntime.Spec.DeploymentConfig.ShmSize != "" {
+		shmSource := corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+		}
+		if q, err := resource.ParseQuantity(vllmRuntime.Spec.DeploymentConfig.ShmSize); err == nil {
+			shmSource.EmptyDir.SizeLimit = &q
+		}
+		volumes = append(volumes, corev1.Volume{Name: "dshm", VolumeSource: shmSource})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "dshm",
+			MountPath: "/dev/shm",
+		})
+	}
+
 	var affinity *corev1.Affinity
 
 	if vllmRuntime.Spec.DeploymentConfig.NodeSelectorTerms != nil {

--- a/operator/internal/controller/vllmruntime_controller.go
+++ b/operator/internal/controller/vllmruntime_controller.go
@@ -1111,17 +1111,10 @@ func (r *VLLMRuntimeReconciler) deploymentNeedsUpdate(
 		}
 	}
 
-	// Detect drift in the /dev/shm volume (driven by shmSize). Without this,
-	// toggling shmSize on an existing VLLMRuntime is seen as "no change" and
-	// the running Deployment never picks up (or drops) the mount.
-	//
-	// We compare the "dshm" volume/mount specifically rather than the whole
-	// Volumes slice: the API server defaults fields on some volume sources
-	// (e.g. ConfigMap DefaultMode, used by the chat-template volume) that the
-	// freshly generated expected spec does not carry, so a blanket
-	// reflect.DeepEqual would report a permanent mismatch and cause an endless
-	// reconcile loop. The dshm emptyDir/mount have no such server-side
-	// defaulting, so comparing them directly is safe.
+	// Detect drift in the /dev/shm volume (driven by shmSize). We compare the
+	// "dshm" volume/mount specifically instead of the whole Volumes slice,
+	// whose server-side defaults (e.g. ConfigMap DefaultMode) would otherwise
+	// cause a permanent mismatch and an endless reconcile loop.
 	if !reflect.DeepEqual(
 		findVolumeByName(expectedDep.Spec.Template.Spec.Volumes, "dshm"),
 		findVolumeByName(dep.Spec.Template.Spec.Volumes, "dshm"),

--- a/operator/internal/controller/vllmruntime_controller.go
+++ b/operator/internal/controller/vllmruntime_controller.go
@@ -747,6 +747,13 @@ func (r *VLLMRuntimeReconciler) deploymentForVLLMRuntime(
 		}
 		if q, err := resource.ParseQuantity(vllmRuntime.Spec.DeploymentConfig.ShmSize); err == nil {
 			shmSource.EmptyDir.SizeLimit = &q
+		} else {
+			// Don't silently mount an unbounded /dev/shm on a typo: surface the
+			// bad value so the misconfiguration is visible instead of defaulting
+			// to the node's memory limit without any indication.
+			log.Log.Error(err, "Invalid shmSize; mounting /dev/shm without a size limit",
+				"vllmRuntime", vllmRuntime.Name,
+				"shmSize", vllmRuntime.Spec.DeploymentConfig.ShmSize)
 		}
 		volumes = append(volumes, corev1.Volume{Name: "dshm", VolumeSource: shmSource})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -1104,7 +1111,55 @@ func (r *VLLMRuntimeReconciler) deploymentNeedsUpdate(
 		}
 	}
 
+	// Detect drift in the /dev/shm volume (driven by shmSize). Without this,
+	// toggling shmSize on an existing VLLMRuntime is seen as "no change" and
+	// the running Deployment never picks up (or drops) the mount.
+	//
+	// We compare the "dshm" volume/mount specifically rather than the whole
+	// Volumes slice: the API server defaults fields on some volume sources
+	// (e.g. ConfigMap DefaultMode, used by the chat-template volume) that the
+	// freshly generated expected spec does not carry, so a blanket
+	// reflect.DeepEqual would report a permanent mismatch and cause an endless
+	// reconcile loop. The dshm emptyDir/mount have no such server-side
+	// defaulting, so comparing them directly is safe.
+	if !reflect.DeepEqual(
+		findVolumeByName(expectedDep.Spec.Template.Spec.Volumes, "dshm"),
+		findVolumeByName(dep.Spec.Template.Spec.Volumes, "dshm"),
+	) {
+		log.Info("shm volume mismatch")
+		return true
+	}
+
+	if len(dep.Spec.Template.Spec.Containers) > 0 &&
+		!reflect.DeepEqual(
+			findVolumeMountByName(expectedDep.Spec.Template.Spec.Containers[0].VolumeMounts, "dshm"),
+			findVolumeMountByName(dep.Spec.Template.Spec.Containers[0].VolumeMounts, "dshm"),
+		) {
+		log.Info("shm volume mount mismatch")
+		return true
+	}
+
 	return false
+}
+
+// findVolumeByName returns a pointer to the named volume, or nil if absent.
+func findVolumeByName(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+// findVolumeMountByName returns a pointer to the named volume mount, or nil.
+func findVolumeMountByName(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
 }
 
 // updateStatus updates the status of the VLLMRuntime


### PR DESCRIPTION
## What

Adds a `shmSize` field to the `VLLMRuntime` CRD (`deploymentConfig.shmSize`). When set, the operator mounts an `emptyDir` with `medium: Memory` at `/dev/shm`, sized to the given quantity.

Fixes #899.

## Why

Tensor-parallel vLLM communicates between ranks over shared memory. In containers `/dev/shm` defaults to a small size (typically 64Mi), which is too small for TP and leads to crashes / `Bus error`. The Helm chart can be worked around with extra volumes, but the `VLLMRuntime` operator had no equivalent knob — exactly what the issue asks for (`shmSize: 24g`).

## What changed

- `api/v1alpha1/vllmruntime_types.go` — new optional `ShmSize string` on `DeploymentConfig`.
- `internal/controller/vllmruntime_controller.go` — when `ShmSize != ""`, append a `dshm` `emptyDir{medium: Memory}` volume + a `/dev/shm` mount on the vLLM container. The size is parsed with `resource.ParseQuantity`; an unparseable value still yields a Memory-backed `/dev/shm` (no size limit) rather than panicking the reconcile loop.
- `config/crd/bases/...vllmruntimes.yaml` — regenerated CRD property.

## Behavior

- Field unset → no change (backwards compatible; `dshm` volume is only added when requested).
- `shmSize: "24Gi"` → `/dev/shm` backed by a 24Gi Memory `emptyDir`.

Example:

```yaml
spec:
  deploymentConfig:
    shmSize: "24Gi"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
