### PR TITLE
[Doc] Document disaggregated_prefill_orchestrated routingLogic option

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -239,7 +239,7 @@ This table documents all available configuration values for the Production Stack
 | `routerSpec.k8sServiceDiscoveryType` | string | `"pod-ip"` | Service discovery Type ("pod-ip" or "service-name") if serviceDiscovery is "k8s" |
 | `routerSpec.staticBackends` | string | `""` | Comma-separated list of backend addresses if serviceDiscovery is "static" |
 | `routerSpec.staticModels` | string | `""` | Comma-separated list of model names if serviceDiscovery is "static" |
-| `routerSpec.routingLogic` | string | `"roundrobin"` | Routing logic: `"roundrobin"`, `"session"`, `"prefixaware"`, or `"kvaware"` |
+| `routerSpec.routingLogic` | string | `"roundrobin"` | Routing logic: `"roundrobin"`, `"session"`, `"prefixaware"`, `"kvaware"`, `"disaggregated_prefill"`, or `"disaggregated_prefill_orchestrated"` |
 | `routerSpec.prefixMinMatchLength` | integer | `0` | Minimum prefix match length for `prefixaware` routing to reuse a matched endpoint; below this, requests fall back to QPS routing. Quantized to the prefix chunk size (default 128). `0` disables it |
 | `routerSpec.sessionKey` | string | `""` | Session key if using "session" routing logic |
 | `routerSpec.extraArgs` | list | `[]` | Extra command line arguments to pass to the router |

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -870,14 +870,15 @@
                     }
                 },
                 "routingLogic": {
-                    "description": "routing logic, supports \"roundrobin\", \"session\", \"prefixaware\", \"kvaware\" or \"disaggregated_prefill\"",
+                    "description": "routing logic, supports \"roundrobin\", \"session\", \"prefixaware\", \"kvaware\", \"disaggregated_prefill\" or \"disaggregated_prefill_orchestrated\"",
                     "type": "string",
                     "enum": [
                         "roundrobin",
                         "session",
                         "prefixaware",
                         "kvaware",
-                        "disaggregated_prefill"
+                        "disaggregated_prefill",
+                        "disaggregated_prefill_orchestrated"
                     ]
                 },
                 "securityContext": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -514,8 +514,8 @@ routerSpec:
   staticBackends: ""
   staticModels: ""
 
-  # -- routing logic, supports "roundrobin", "session", "prefixaware", "kvaware" or "disaggregated_prefill"
-  routingLogic: "roundrobin" # @schema enum:[roundrobin,session,prefixaware,kvaware,disaggregated_prefill]
+  # -- routing logic, supports "roundrobin", "session", "prefixaware", "kvaware", "disaggregated_prefill" or "disaggregated_prefill_orchestrated"
+  routingLogic: "roundrobin" # @schema enum:[roundrobin,session,prefixaware,kvaware,disaggregated_prefill,disaggregated_prefill_orchestrated]
 
   # -- Minimum prefix match length required for prefixaware routing to reuse a
   # matched endpoint. If the longest prefix match is shorter than this value,


### PR DESCRIPTION
Documents the `disaggregated_prefill_orchestrated` routing option in the Helm chart.

The router's `RoutingLogic` enum in `src/vllm_router/routers/routing_logic.py` supports `disaggregated_prefill_orchestrated`, and `initialize_routing_logic` wires it to `DisaggregatedPrefillOrchestratedRouter`. However, the chart docs never mention it, so a user reading the chart has no way to know the value is accepted. This adds it to:

- `helm/values.yaml` — the `routingLogic` doc comment and the `@schema enum:[...]` list
- `helm/values.schema.json` — the generated `routingLogic` description and `enum` array (matches what the `helm-schema` pre-commit hook regenerates from `values.yaml`)
- `helm/README.md` — the `routerSpec.routingLogic` parameter table row (which was also missing `disaggregated_prefill`)

Documentation only; no behavior change.

FIX #xxxx — N/A, no existing tracking issue.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.

</details>