### PR TITLE
[Bugfix](router): strip Server header to avoid duplicate headers on response

### DIFF
--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -96,6 +96,7 @@ _HEADERS_TO_STRIP_FROM_RESPONSE = {
     "content-encoding",
     "transfer-encoding",
     "connection",
+    "server",
 }
 
 


### PR DESCRIPTION
Vllm backend uvicorn sends `server: uvicorn` header. The router copies that into resp_headers, and then the router's own server (uvicorn) appends its Server header when sending the response, so the client sees the Server header twice. Some packages (such as `aiohttp >=3.14`) reject responses with duplicate Server headers, hence the error `Duplicate 'Server' header found.` Let's strip server header from response. 

Let me know if you prefer to add `"server_header": False,` here instead https://github.com/vllm-project/production-stack/blob/90ddf82b97ec9b09098de9976dc8dcb75c6be363/src/vllm_router/app.py#L397-L402
