### PR TITLE
[Router][Bugfix] reset K8s watcher on stale resource version errors

### DIFF
--- a/src/tests/test_k8s_service_discovery.py
+++ b/src/tests/test_k8s_service_discovery.py
@@ -9,7 +9,6 @@ from vllm_router.service_discovery import (
     _is_stale_resource_version_error,
 )
 
-
 K8sDiscoveryClass = (
     type[K8sPodIPServiceDiscovery] | type[K8sServiceNameServiceDiscovery]
 )

--- a/src/tests/test_k8s_service_discovery.py
+++ b/src/tests/test_k8s_service_discovery.py
@@ -1,0 +1,184 @@
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes import client
+
+from vllm_router.service_discovery import (
+    K8sPodIPServiceDiscovery,
+    K8sServiceNameServiceDiscovery,
+    _is_stale_resource_version_error,
+)
+
+
+K8sDiscoveryClass = (
+    type[K8sPodIPServiceDiscovery] | type[K8sServiceNameServiceDiscovery]
+)
+
+
+@pytest.fixture
+def k8s_discovery_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock K8s dependencies so service discovery can be unit-tested."""
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.config.load_incluster_config",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.config.load_kube_config",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.client.CoreV1Api",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.threading.Thread",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.time.sleep",
+        lambda _: None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("Timeout: Too large resource version: 123, current: 456", True),
+        ("410 Gone: too old resource version", True),
+        ("resourceVersion is too old", True),
+        ("TOO LARGE RESOURCE VERSION", True),
+        ("connection refused", False),
+        ("Unexpected error", False),
+        ("", False),
+    ],
+)
+def test_is_stale_resource_version_error(message: str, expected: bool) -> None:
+    assert _is_stale_resource_version_error(Exception(message)) is expected
+
+
+@pytest.mark.parametrize(
+    ("status", "reason", "expected"),
+    [
+        (410, "Gone", True),
+        (504, "Timeout: Too large resource version: 1, current: 2", True),
+        (504, "Gateway timeout", False),
+        (500, "Internal server error", False),
+    ],
+)
+def test_is_stale_resource_version_error_with_api_exception(
+    status: int,
+    reason: str,
+    expected: bool,
+) -> None:
+    """410 is unconditionally stale; 504 only when the message matches."""
+    exc = client.rest.ApiException(status=status, reason=reason)
+    assert _is_stale_resource_version_error(exc) is expected
+
+
+def _run_watcher_recovery(
+    discovery_class: K8sDiscoveryClass,
+    monkeypatch: pytest.MonkeyPatch,
+    k8s_discovery_setup: None,
+    stale_message: str,
+) -> None:
+    """Drive a K8s discovery instance through one stale error and recovery."""
+    watch_cls = MagicMock()
+    first_watcher = MagicMock()
+    second_watcher = MagicMock()
+    watch_cls.side_effect = [first_watcher, second_watcher]
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.watch.Watch",
+        watch_cls,
+    )
+
+    discovery = discovery_class(
+        app=None,
+        namespace="default",
+        port="8000",
+        label_selector="model=test",
+    )
+
+    calls = 0
+
+    def first_stream(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise Exception(stale_message)
+
+    def second_stream(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        discovery.running = False
+        return iter([])
+
+    first_watcher.stream.side_effect = first_stream
+    second_watcher.stream.side_effect = second_stream
+
+    discovery.running = True
+    discovery._watch_engines()
+
+    assert watch_cls.call_count == 2
+    assert first_watcher.stream.call_count == 1
+    assert second_watcher.stream.call_count == 1
+
+
+def test_k8s_pod_ip_service_discovery_recovers_from_stale_resource_version(
+    monkeypatch: pytest.MonkeyPatch,
+    k8s_discovery_setup: None,
+) -> None:
+    _run_watcher_recovery(
+        K8sPodIPServiceDiscovery,
+        monkeypatch,
+        k8s_discovery_setup,
+        "Timeout: Too large resource version: 123, current: 456",
+    )
+
+
+def test_k8s_service_name_service_discovery_recovers_from_stale_resource_version(
+    monkeypatch: pytest.MonkeyPatch,
+    k8s_discovery_setup: None,
+) -> None:
+    _run_watcher_recovery(
+        K8sServiceNameServiceDiscovery,
+        monkeypatch,
+        k8s_discovery_setup,
+        "410 Gone: too old resource version",
+    )
+
+
+def test_k8s_watcher_does_not_reset_on_unrelated_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    k8s_discovery_setup: None,
+) -> None:
+    watch_cls = MagicMock()
+    watcher = MagicMock()
+    watch_cls.return_value = watcher
+    monkeypatch.setattr(
+        "vllm_router.service_discovery.watch.Watch",
+        watch_cls,
+    )
+
+    discovery = K8sPodIPServiceDiscovery(
+        app=None,
+        namespace="default",
+        port="8000",
+        label_selector="model=test",
+    )
+
+    calls = 0
+
+    def stream_side_effect(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ConnectionError("connection refused")
+        discovery.running = False
+        return iter([])
+
+    watcher.stream.side_effect = stream_side_effect
+
+    discovery.running = True
+    discovery._watch_engines()
+
+    assert watch_cls.call_count == 1
+    assert calls == 2

--- a/src/tests/test_k8s_service_discovery.py
+++ b/src/tests/test_k8s_service_discovery.py
@@ -43,8 +43,9 @@ def k8s_discovery_setup(monkeypatch: pytest.MonkeyPatch) -> None:
     ("message", "expected"),
     [
         ("Timeout: Too large resource version: 123, current: 456", True),
-        ("410 Gone: too old resource version", True),
-        ("resourceVersion is too old", True),
+        ("too old resource version: 100 (110)", True),
+        ("The resourceVersion for the provided list is too old.", True),
+        ("The resourceVersion for the provided watch is too old.", True),
         ("TOO LARGE RESOURCE VERSION", True),
         ("connection refused", False),
         ("Unexpected error", False),
@@ -59,6 +60,7 @@ def test_is_stale_resource_version_error(message: str, expected: bool) -> None:
     ("status", "reason", "expected"),
     [
         (410, "Gone", True),
+        (410, "Gateway timeout", True),
         (504, "Timeout: Too large resource version: 1, current: 2", True),
         (504, "Gateway timeout", False),
         (500, "Internal server error", False),
@@ -119,6 +121,13 @@ def _run_watcher_recovery(
     assert watch_cls.call_count == 2
     assert first_watcher.stream.call_count == 1
     assert second_watcher.stream.call_count == 1
+
+
+def test_is_stale_resource_version_error_uses_full_exception_string() -> None:
+    """Phrases in the ApiException body must be detected, not just the reason."""
+    exc = client.rest.ApiException(status=504, reason="Gateway Timeout")
+    exc.body = "Timeout: Too large resource version: 1, current: 2"
+    assert _is_stale_resource_version_error(exc) is True
 
 
 def test_k8s_pod_ip_service_discovery_recovers_from_stale_resource_version(

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -20,6 +20,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import aiohttp
@@ -43,24 +44,31 @@ _MODEL_INFO_KNOWN_FIELDS = frozenset(
     }
 )
 
+# Lower-case substrings of the authoritative messages emitted by kube-apiserver.
+# These are not exported by the kubernetes Python client so we quote the Go source strings.
 _STALE_RESOURCE_VERSION_PHRASES: Tuple[str, ...] = (
-    "too large resource version",
+    # storage/etcd3/errors.go: "The resourceVersion for the provided list is too old."
+    "the resourceversion for the provided list is too old",
+    # storage/etcd3/errors.go: "The resourceVersion for the provided watch is too old."
+    "the resourceversion for the provided watch is too old",
+    # Legacy etcd-formatted message: "too old resource version: <rv> (<current>)"
     "too old resource version",
-    "resource version is too old",
-    "resourceversion is too old",
+    # storage/errors.go: "Too large resource version"
+    "too large resource version",
 )
 
 # 410 Gone from the Kubernetes API server always means the watch bookmark is stale.
-_STALE_RESOURCE_VERSION_STATUS: int = 410
+# This is the same HTTP status the Kubernetes watch module uses internally.
+_STALE_RESOURCE_VERSION_STATUS: int = HTTPStatus.GONE.value
 
 
 def _is_stale_resource_version_error(exc: Exception) -> bool:
     """Return True if exc indicates the K8s watch bookmark is stale."""
-    status = getattr(exc, "status", None)
-    if isinstance(status, int) and status == _STALE_RESOURCE_VERSION_STATUS:
-        return True
-    message = str(exc).lower()
-    return any(phrase in message for phrase in _STALE_RESOURCE_VERSION_PHRASES)
+    if isinstance(exc, client.rest.ApiException):
+        status = exc.status
+        if isinstance(status, int) and status == _STALE_RESOURCE_VERSION_STATUS:
+            return True
+    return any(phrase in str(exc).lower() for phrase in _STALE_RESOURCE_VERSION_PHRASES)
 
 
 def _reset_k8s_watcher_if_stale(watcher: watch.Watch, exc: Exception) -> watch.Watch:

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -20,7 +20,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import aiohttp
 import requests
@@ -42,6 +42,41 @@ _MODEL_INFO_KNOWN_FIELDS = frozenset(
         "parent",
     }
 )
+
+_STALE_RESOURCE_VERSION_PHRASES: Tuple[str, ...] = (
+    "too large resource version",
+    "too old resource version",
+    "resource version is too old",
+    "resourceversion is too old",
+)
+
+# 410 Gone from the Kubernetes API server always means the watch bookmark is stale.
+_STALE_RESOURCE_VERSION_STATUS: int = 410
+
+
+def _is_stale_resource_version_error(exc: Exception) -> bool:
+    """Return True if exc indicates the K8s watch bookmark is stale."""
+    status = getattr(exc, "status", None)
+    if isinstance(status, int) and status == _STALE_RESOURCE_VERSION_STATUS:
+        return True
+    message = str(exc).lower()
+    return any(phrase in message for phrase in _STALE_RESOURCE_VERSION_PHRASES)
+
+
+def _reset_k8s_watcher_if_stale(watcher: watch.Watch, exc: Exception) -> watch.Watch:
+    """Reset the K8s watcher when its bookmark is stale.
+
+    The Kubernetes Python client's Watch.stream() docs state that when the
+    watch expires and the last resourceVersion is too old, the caller must
+    recover by listing the resource again to obtain a fresh state. Creating a
+    new Watch() does exactly that: it starts with resource_version=None, so the
+    next stream() call performs a fresh LIST and resumes from the current
+    resourceVersion.
+    """
+    if _is_stale_resource_version_error(exc):
+        logger.info("Resetting K8s watcher to recover from stale resource version")
+        return watch.Watch()
+    return watcher
 
 
 class ServiceDiscoveryType(enum.Enum):
@@ -719,6 +754,7 @@ class K8sPodIPServiceDiscovery(ServiceDiscovery):
                     )
             except Exception as e:
                 logger.error(f"K8s watcher error: {e}")
+                self.k8s_watcher = _reset_k8s_watcher_if_stale(self.k8s_watcher, e)
                 time.sleep(0.5)
 
     def _add_engine(
@@ -1177,6 +1213,7 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
                     )
             except Exception as e:
                 logger.error(f"K8s watcher error: {e}")
+                self.k8s_watcher = _reset_k8s_watcher_if_stale(self.k8s_watcher, e)
                 time.sleep(0.5)
 
     def _add_engine(self, engine_name: str, model_names: List[str], model_label: str):


### PR DESCRIPTION
Getting `504 Timeout: Too large resource version` looping in the router logs. vLLM pods were healthy, but the K8s watcher was stuck.

The bug: both `K8sPodIPServiceDiscovery` and `K8sServiceNameServiceDiscovery` create one `kubernetes.watch.Watch` instance and never replace it. The Python client stores the last `resourceVersion` it saw and feeds it back into every reconnect. Once the API server's watch cache moves past that version, the server throws the `504` (or `410 Gone`) and the router catches it, sleeps 0.5s then calls `stream()` again with the same stale bookmark forever.

The Kubernetes Python client docs call this out explicitly in `Watch.stream()` [here](https://github.com/kubernetes-client/python/blob/master/kubernetes/base/watch/watch.py#L154):

> "Note that watching an API resource can expire... if that last result is too old as well, an `ApiException` exception will be thrown... In that case you have to recover yourself, probably by listing the API resource to obtain the latest state..."

So the fix is to reset the watcher when we hit a stale resource version. A new `Watch()` starts with `resource_version=None`, which forces a fresh `LIST` on the next attempt. Then we grab the current bookmark and resume. I only do this for stale-version errors.


Here is below an anonymized snippet so you can see the watcher logs `504` with a stale resource version over and over while the router reports 0 serving engine(s).

```bash
2026-07-17T16:25:53.730Z INFO:     Application startup complete.
2026-07-17T16:25:53.730Z INFO:     Uvicorn running on http://0.0.0.0:8000
2026-07-17T16:25:56.694Z ERROR: K8s watcher error: (504)
Reason: Timeout: Timeout: Too large resource version: <newer>, current: <current>
 (service_discovery.py:721)
 
2026-07-17T16:26:00.208Z ERROR: K8s watcher error: (504)
Reason: Timeout: Timeout: Too large resource version: <newer>, current: <current>
 (service_discovery.py:721)
 
2026-07-17T16:26:03.722Z ERROR: K8s watcher error: (504)
Reason: Timeout: Timeout: Too large resource version: <newer>, current: <current>
 (service_discovery.py:721)
 
2026-07-17T16:26:08.678Z INFO: Scraping metrics from 0 serving engine(s)
2026-07-17T16:26:10.749Z ERROR: K8s watcher error: (504)
Reason: Timeout: Timeout: Too large resource version: <newer>, current: <current>
 (service_discovery.py:721)
 
...

2026-07-17T16:28:03.203Z ERROR: K8s watcher error: (504)
Reason: Timeout: Timeout: Too large resource version: <newer>, current: <current>
 (service_discovery.py:721)
 ```