### PR TITLE
[Doc][Bugfix] Use a Ray-capable image in the KubeRay tutorial

### DIFF
--- a/docs/source/use_cases/pipeline-parallelism-kuberay.rst
+++ b/docs/source/use_cases/pipeline-parallelism-kuberay.rst
@@ -52,7 +52,7 @@ Explanation of Key Items in ``values-15-a-minimal-pipeline-parallel-example-rayc
   - **requestGPU**: Defines the number of GPUs to allocate for the KubeRay head pod. Currently, the Ray head node must also participate in both tensor parallelism and pipeline parallelism. This requirement exists because the ``vllm serve ...`` command is executed on the Ray head node, and vLLM mandates that the pod where this command is run must have at least one visible GPU.
 
 - **name**: The unique identifier for your model deployment.
-- **repository**: The Docker repository containing the model's serving engine image.
+- **repository**: The Docker repository containing the model's serving engine image. RayCluster images must include both the Ray Python package and the ``ray`` CLI because KubeRay uses them to start the head and worker nodes. The example uses ``lmcache/vllm-openai``, which includes the Ray runtime.
 - **tag**: Specifies the version of the model image to use.
 - **modelURL**: The URL pointing to the model on Hugging Face or another hosting service.
 - **replicaCount**: The number of total Kuberay worker pods.
@@ -89,7 +89,7 @@ In the following example, we configure a total of two Ray nodes each equipped wi
      runtimeClassName: ""
      modelSpec:
      - name: "distilgpt2"
-       repository: "vllm/vllm-openai"
+       repository: "lmcache/vllm-openai"
        tag: "latest"
        modelURL: "distilbert/distilgpt2"
 

--- a/tutorials/15-basic-pipeline-parallel.md
+++ b/tutorials/15-basic-pipeline-parallel.md
@@ -46,7 +46,7 @@ This tutorial provides a step-by-step guide for configuring and deploying the vL
   - **`requestMemory`**: Memory allocation for Kuberay head pod. Sufficient memory is required to load the model.
   - **`requestGPU`**: Defines the number of GPUs to allocate for the KubeRay head pod. Currently, the Ray head node must also participate in both tensor parallelism and pipeline parallelism. This requirement exists because the `vllm serve ...` command is executed on the Ray head node, and vLLM mandates that the pod where this command is run must have at least one visible GPU.
 - **`name`**: The unique identifier for your model deployment.
-- **`repository`**: The Docker repository containing the model's serving engine image.
+- **`repository`**: The Docker repository containing the model's serving engine image. RayCluster images must include both the Ray Python package and the `ray` CLI because KubeRay uses them to start the head and worker nodes. The example uses `lmcache/vllm-openai`, which includes the Ray runtime.
 - **`tag`**: Specifies the version of the model image to use.
 - **`modelURL`**: The URL pointing to the model on Hugging Face or another hosting service.
 - **`replicaCount`**: The number of total Kuberay worker pods.
@@ -76,7 +76,7 @@ servingEngineSpec:
   runtimeClassName: ""
   modelSpec:
   - name: "distilgpt2"
-    repository: "vllm/vllm-openai"
+    repository: "lmcache/vllm-openai"
     tag: "latest"
     modelURL: "distilbert/distilgpt2"
 
@@ -108,7 +108,7 @@ Deploy the configuration using Helm:
 
 ```bash
 helm repo add vllm https://vllm-project.github.io/production-stack
-helm install vllm vllm/vllm-stack -f tutorials/assets/values-15-minimal-pipeline-parallel-example.yaml
+helm install vllm vllm/vllm-stack -f tutorials/assets/values-15-a-minimal-pipeline-parallel-example-raycluster.yaml
 ```
 
 Expected output:

--- a/tutorials/assets/values-15-a-minimal-pipeline-parallel-example-raycluster.yaml
+++ b/tutorials/assets/values-15-a-minimal-pipeline-parallel-example-raycluster.yaml
@@ -2,7 +2,7 @@ servingEngineSpec:
   runtimeClassName: ""
   modelSpec:
   - name: "distilgpt2-raycluster"
-    repository: "vllm/vllm-openai"
+    repository: "lmcache/vllm-openai"
     tag: "latest"
     modelURL: "distilbert/distilgpt2"
 

--- a/tutorials/assets/values-15-b-minimal-pipeline-parallel-example-multiple-modelspec.yaml
+++ b/tutorials/assets/values-15-b-minimal-pipeline-parallel-example-multiple-modelspec.yaml
@@ -2,7 +2,7 @@ servingEngineSpec:
   runtimeClassName: ""
   modelSpec:
   - name: "distilgpt2-raycluster"
-    repository: "vllm/vllm-openai"
+    repository: "lmcache/vllm-openai"
     tag: "latest"
     modelURL: "distilbert/distilgpt2"
 


### PR DESCRIPTION
The pipeline-parallel examples currently use `vllm/vllm-openai:latest`. That image does not provide the `ray` command required by KubeRay when it starts the Ray head and worker containers, so the tutorial fails before the vLLM entrypoint runs.

This change:

- switches the RayCluster examples to `lmcache/vllm-openai`, which includes the Ray runtime
- documents that custom RayCluster images must provide both the Ray Python package and CLI
- fixes the stale values filename in the Markdown install command
- keeps the standalone deployment in the mixed example on the regular vLLM image

Validation:

- `helm lint` with both tutorial values files
- `helm template` with both tutorial values files; Ray head and worker render `lmcache/vllm-openai:latest`
- `pre-commit` hooks: `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`, `markdownlint`, `codespell`
- `sphinx-build -W --keep-going -b html docs/source /tmp/production-stack-docs`

Fixes #995