### PR TITLE
fix(router): opt-in --k8s-known-models so scale-to-zero returns 503 not 404 (#1003)

### DIFF
--- a/src/tests/test_static_known_models.py
+++ b/src/tests/test_static_known_models.py
@@ -1,0 +1,37 @@
+import pytest
+
+from vllm_router.service_discovery import _parse_static_known_models
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, set()),
+        ("", set()),
+        ("   ", set()),
+        ("modelA", {"modelA"}),
+        ("modelA,modelB", {"modelA", "modelB"}),
+        ("  modelA , modelB ", {"modelA", "modelB"}),
+        ("modelA,,modelB,", {"modelA", "modelB"}),
+        ("modelA,modelA", {"modelA"}),
+    ],
+)
+def test_parse_static_known_models(raw, expected):
+    assert _parse_static_known_models(raw) == expected
+
+
+def test_static_known_models_seed_marks_model_as_seen():
+    """A pod-ip discovery seeded with static models reports them as seen even
+    when no engine has ever been observed (issue #1003, scale-to-zero). The k8s
+    client / watcher thread in __init__ is bypassed via __new__ so no cluster is
+    required."""
+    import threading
+
+    from vllm_router import service_discovery as sd
+
+    instance = sd.K8sPodIPServiceDiscovery.__new__(sd.K8sPodIPServiceDiscovery)
+    instance.known_models = sd._parse_static_known_models("modelA,modelB")
+    instance.known_models_lock = threading.Lock()
+
+    assert instance.has_ever_seen_model("modelA") is True
+    assert instance.has_ever_seen_model("modelC") is False

--- a/src/vllm_router/app.py
+++ b/src/vllm_router/app.py
@@ -234,6 +234,7 @@ def initialize_all(app: FastAPI, args):
             decode_model_labels=args.decode_model_labels,
             watcher_timeout_seconds=args.k8s_watcher_timeout_seconds,
             health_check_timeout_seconds=args.backend_health_check_timeout_seconds,
+            static_known_models=args.k8s_known_models,
         )
 
     elif args.service_discovery == "external-only":

--- a/src/vllm_router/parsers/parser.py
+++ b/src/vllm_router/parsers/parser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import argparse
 import json
+import os
 import sys
 
 from vllm_router import utils
@@ -218,6 +219,19 @@ def parse_args():
         type=int,
         default=0,
         help="Timeout in seconds for Kubernetes watcher streams (default: 0).",
+    )
+    parser.add_argument(
+        "--k8s-known-models",
+        type=str,
+        default=os.environ.get("VLLM_ROUTER_KNOWN_MODELS", ""),
+        help="Comma-separated list of model names that this router should always "
+        "treat as known when using K8s (pod-ip) service discovery, even before an "
+        "engine serving them has been observed. Requests for these models with no "
+        "live endpoints then return a retryable 503 instead of a fatal 404. This "
+        "matters for scale-to-zero deployments (e.g. KEDA), where a router pod may "
+        "start while a model's deployment sits at 0 replicas and would otherwise "
+        "answer 404 for a model that merely needs a cold start. Falls back to the "
+        "VLLM_ROUTER_KNOWN_MODELS environment variable.",
     )
     parser.add_argument(
         "--backend-health-check-timeout-seconds",

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -1345,6 +1345,11 @@ def _create_service_discovery(
             normalized_type = k8s_discovery_type.strip().lower()
 
         if normalized_type == "service-name":
+            if static_known_models:
+                logger.warning(
+                    "--k8s-known-models is only supported with pod-ip service "
+                    "discovery; ignoring it for service-name discovery."
+                )
             return K8sServiceNameServiceDiscovery(*args, **kwargs)
         else:
             return K8sPodIPServiceDiscovery(

--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -408,6 +408,13 @@ class StaticServiceDiscovery(ServiceDiscovery):
             self.loop.close()
 
 
+def _parse_static_known_models(raw: str | None) -> Set[str]:
+    """Parse a comma-separated list of model names into a set, dropping blanks."""
+    if not raw:
+        return set()
+    return {name.strip() for name in raw.split(",") if name.strip()}
+
+
 class K8sPodIPServiceDiscovery(ServiceDiscovery):
     def __init__(
         self,
@@ -419,6 +426,7 @@ class K8sPodIPServiceDiscovery(ServiceDiscovery):
         decode_model_labels: List[str] | None = None,
         watcher_timeout_seconds: int = 0,
         health_check_timeout_seconds: int = 10,
+        static_known_models: str | None = None,
     ):
         """
         Initialize the Kubernetes service discovery module. This module
@@ -439,7 +447,10 @@ class K8sPodIPServiceDiscovery(ServiceDiscovery):
         self.port = port
         self.available_engines: Dict[str, EndpointInfo] = {}
         self.available_engines_lock = threading.Lock()
-        self.known_models: Set[str] = set()
+        # Pre-seed with statically-declared models so a router pod that starts
+        # while a model's deployment is scaled to zero still reports the model as
+        # "seen" (retryable 503) instead of a fatal 404. See issue #1003.
+        self.known_models: Set[str] = _parse_static_known_models(static_known_models)
         self.known_models_lock = threading.Lock()
         self.label_selector = label_selector
         self.watcher_timeout_seconds = watcher_timeout_seconds
@@ -1325,6 +1336,9 @@ def _create_service_discovery(
         return StaticServiceDiscovery(*args, **kwargs)
     elif service_discovery_type == ServiceDiscoveryType.K8S:
         k8s_discovery_type = kwargs.pop("k8s_service_discovery_type", "pod-ip")
+        # Only the pod-ip discovery tracks per-process "known models"; drop the
+        # option here so it is never forwarded to the service-name variant.
+        static_known_models = kwargs.pop("static_known_models", None)
         if k8s_discovery_type is None or not k8s_discovery_type.strip():
             normalized_type = "pod-ip"
         else:
@@ -1333,7 +1347,9 @@ def _create_service_discovery(
         if normalized_type == "service-name":
             return K8sServiceNameServiceDiscovery(*args, **kwargs)
         else:
-            return K8sPodIPServiceDiscovery(*args, **kwargs)
+            return K8sPodIPServiceDiscovery(
+                *args, static_known_models=static_known_models, **kwargs
+            )
     elif service_discovery_type == ServiceDiscoveryType.EXTERNAL_ONLY:
         return ExternalOnlyServiceDiscovery()
     else:


### PR DESCRIPTION
## Summary

Fixes #1003 — a router pod that starts (or restarts) while a model's deployment is scaled to **0 replicas** returns a **fatal 404** for that model, instead of a **retryable 503**.

`request_service` decides 404-vs-503 for a model with no live endpoints via `has_ever_seen_model()`:

```python
if not endpoints:
    if not model_ever_existed:
        return JSONResponse(status_code=404, ...)   # fatal
    else:
        return JSONResponse(status_code=503, ...)   # retryable
```

For `K8sPodIPServiceDiscovery`, `has_ever_seen_model()` consults `self.known_models`, a set populated **only by pods this router process has observed**. A router that never saw an engine for a scaled-to-zero model answers a fatal 404, while a sibling pod started earlier answers 503 for the same request. With kube-proxy round-robin ~50% of requests get the fatal answer, and under autoscale-to-zero (KEDA) the 404s are self-reinforcing: clients fail instantly and stop sustaining the request-rate metric the autoscaler needs to wake the pool.

## Change

Implements **option 1** from the issue (the reporter's carried patch): an **opt-in** way to declare a router's known models up front.

- New flag `--k8s-known-models` (comma-separated), defaulting to the `VLLM_ROUTER_KNOWN_MODELS` environment variable.
- `K8sPodIPServiceDiscovery` pre-seeds `known_models` from it at construction, so declared models report as "seen" and return a retryable **503** even before any engine is observed.
- **Default is empty → existing behavior is completely unchanged.** This is purely additive and opt-in.
- Only the **pod-ip** discovery consumes the option; it is popped in `_create_service_discovery` before the service-name variant is constructed, so that path is untouched.

This does not preclude the richer option 2 (watching Deployments/ReplicaSets at 0 replicas) — it's a low-risk escape hatch that operators running scale-to-zero can adopt today.

## Files

| File | What |
|---|---|
| `parsers/parser.py` | add `--k8s-known-models` arg + `VLLM_ROUTER_KNOWN_MODELS` env fallback |
| `app.py` | thread `static_known_models=args.k8s_known_models` into the K8s discovery init |
| `service_discovery.py` | `_parse_static_known_models()` helper; seed `known_models` in pod-ip `__init__`; route the option only to pod-ip |
| `tests/test_static_known_models.py` | unit tests for the parser helper + a seed→`has_ever_seen_model` check (no cluster needed) |

## Test

```bash
pytest src/tests/test_static_known_models.py
```

The construction test bypasses the k8s client/watcher via `__new__`, so it needs no cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
