### PR TITLE
[Router] Add routerSpec.tolerations to router Deployment

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -257,6 +257,7 @@ This table documents all available configuration values for the Production Stack
 | `routerSpec.podAnnotations` | map | `{}` | (Optional) Annotations to add to the pod, e.g., {model: "opt125m"} |
 | `routerSpec.affinity` | map | {} | (Optional) Affinity configuration. If specified, this takes precedence over `nodeSelectorTerms`. |
 | `routerSpec.nodeSelectorTerms` | list | `[]` | (Optional) Node selector terms. This is ignored if `affinity` is specified. |
+| `routerSpec.tolerations` | list | `[]` | (Optional) Tolerations configuration for the router pod. Use when the router should schedule onto tainted nodes (e.g., a dedicated node pool). Mirrors `servingEngineSpec.tolerations` for the engine. |
 | `routerSpec.hf_token` | string | `""`| Hugging Face token for router |
 | `routerSpec.lmcacheControllerPort` | integer | `""` | LMCache controller port, used when `routingLogic` is `"kvaware"` (e.g. `9000`) |
 | `routerSpec.lmcacheConfig.logLevel` | string | `"INFO"`| Log level for LMCache in the router when routingLogic is kvaware |

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -42,6 +42,10 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
       {{- end }}
+      {{- with .Values.routerSpec.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.routerSpec.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/tests/deployment-router_test.yaml
+++ b/helm/tests/deployment-router_test.yaml
@@ -233,3 +233,29 @@ tests:
               secretKeyRef:
                 name: custom-secret
                 key: custom-apikey
+
+  - it: should not render tolerations by default
+    set:
+      routerSpec:
+        enableRouter: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: should render tolerations when routerSpec.tolerations is set
+    set:
+      routerSpec:
+        enableRouter: true
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: router
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: dedicated
+              operator: Equal
+              value: router
+              effect: NoSchedule

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -997,6 +997,10 @@
                     "description": "docker tag for the router pod",
                     "type": "string"
                 },
+                "tolerations": {
+                    "description": "Tolerations configuration for the router pod (when there are taints on nodes). Mirrors servingEngineSpec.tolerations for the engine deployment.",
+                    "type": "array"
+                },
                 "vllmApiKey": {
                     "description": "API key for securing the vLLM models. Must be an object referencing an existing secret. If not set, it defaults to .Values.servingEngineSpec.vllmApiKey.",
                     "type": "object",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -676,6 +676,16 @@ routerSpec:
     #     values:
     #     - "NVIDIA-RTX-A6000"
 
+  # -- Tolerations configuration for the router pod (when there are taints on nodes).
+  # Mirrors servingEngineSpec.tolerations for the engine deployment.
+  # Example:
+  # tolerations:
+  #   - key: "dedicated"
+  #     operator: "Equal"
+  #     value: "router"
+  #     effect: "NoSchedule"
+  tolerations: []
+
   # -- Liveness probe configuration for the router pod.
   livenessProbe:
     # -- Number of seconds after the container has started before liveness probe is initiated


### PR DESCRIPTION
## Summary

Add support for `routerSpec.tolerations` in the Helm chart, enabling the router deployment to schedule onto tainted nodes (e.g., dedicated node pools).

## Motivation

The router deployment template currently renders `routerSpec.affinity` and `routerSpec.nodeSelectorTerms` but silently drops `routerSpec.tolerations`. The serving engine deployment already supports `servingEngineSpec.tolerations`, so the two deployment schemas are asymmetric.

When deploying the router to a dedicated node pool with taints (e.g., for larger root volumes to accommodate the 5.4 GiB router image), there was no way to add the matching toleration to the router pod.

## Changes

- **helm/values.yaml**: Add `routerSpec.tolerations` field with helm-docs comment
- **helm/templates/deployment-router.yaml**: Render tolerations block using `{{- with .Values.routerSpec.tolerations }}`
- **helm/README.md**: Add `routerSpec.tolerations` row to Router Configuration table
- **helm/tests/deployment-router_test.yaml**: Add test cases for tolerations rendering
- **helm/values.schema.json**: Add tolerations property to routerSpec schema

## Testing

- `helm template` with default values: no tolerations block rendered (correct)
- `helm template` with `routerSpec.tolerations` set: tolerations block rendered correctly
- Added helm-unittest test cases to verify both scenarios

## Example Usage

```yaml
routerSpec:
  tolerations:
    - key: dedicated
      operator: Equal
      value: router
      effect: NoSchedule
```

Signed-off-by: Arkaniad <arkaniad@users.noreply.github.com>