### PR TITLE
[Feat] Add multi-node multiprocessing deployment via LeaderWorkerSet

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.servingEngineSpec.enableEngine -}}
 {{- range $modelSpec := .Values.servingEngineSpec.modelSpec }}
 {{- if ne $modelSpec.enabled false }}
-{{- if not (and (hasKey $modelSpec "raySpec") $modelSpec.raySpec.enabled) }}
+{{- if not (or (and (hasKey $modelSpec "raySpec") $modelSpec.raySpec.enabled) (and (hasKey $modelSpec "lwsSpec") $modelSpec.lwsSpec.enabled)) }}
 {{- $kv_role := "kv_both" }}
 {{- $kv_rank := 0 }}
 {{- $kv_parallel_size := 1 }}

--- a/helm/templates/lws-vllm.yaml
+++ b/helm/templates/lws-vllm.yaml
@@ -9,6 +9,10 @@
 {{- $modelSpec := .modelSpec -}}
 {{- $root := .root -}}
 {{- $role := .role -}}
+{{- $kv_role := "kv_both" -}}
+{{- if and $modelSpec.lmcacheConfig $modelSpec.lmcacheConfig.kvRole -}}
+{{- $kv_role = $modelSpec.lmcacheConfig.kvRole -}}
+{{- end -}}
 {{- if eq $modelSpec.repository "lmcache/vllm-openai" }}
 - "/opt/venv/bin/vllm"
 {{- else }}
@@ -42,6 +46,8 @@
 {{- end }}
 {{- if .enablePrefixCaching }}
 - "--enable-prefix-caching"
+{{- else }}
+- "--no-enable-prefix-caching"
 {{- end }}
 {{- if hasKey . "maxModelLen" }}
 - "--max-model-len"
@@ -67,6 +73,14 @@
 - "--max-loras"
 - {{ .maxLoras | quote }}
 {{- end }}
+{{- if hasKey . "runner" }}
+- "--runner"
+- {{ .runner | quote }}
+{{- end }}
+{{- if hasKey . "convert" }}
+- "--convert"
+- {{ .convert | quote }}
+{{- end }}
 {{- range .extraArgs }}
 - {{ . | quote }}
 {{- end }}
@@ -74,6 +88,20 @@
 {{- if $modelSpec.modelRevision }}
 - "--revision"
 - {{ $modelSpec.modelRevision | quote }}
+{{- end }}
+{{- if $modelSpec.lmcacheConfig }}
+{{- if $modelSpec.lmcacheConfig.enabled }}
+{{- if hasKey $modelSpec.lmcacheConfig "enablePD" }}
+- "--kv-transfer-config"
+- '{"kv_connector":"LMCacheConnectorV1","kv_role":"{{ $kv_role }}","kv_connector_extra_config":{"discard_partial_chunks": false, "lmcache_rpc_port": {{ $modelSpec.lmcacheConfig.nixlRole | quote }}}}'
+{{- else if and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "v0") (eq (toString $modelSpec.vllmConfig.v0) "1") }}
+- "--kv-transfer-config"
+- '{"kv_connector":"LMCacheConnector","kv_role":"{{ $kv_role }}"}'
+{{- else }}
+- "--kv-transfer-config"
+- '{"kv_connector":"LMCacheConnectorV1","kv_role":"{{ $kv_role }}"}'
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if $modelSpec.chatTemplate }}
 - "--chat-template"
@@ -101,6 +129,125 @@
 {{- end }}
 
 {{/*
+  LMCache environment variables shared by leader and worker templates, mirroring
+  deployment-vllm-multi.yaml so KV offloading behaves identically in LWS mode.
+  Usage: include "chart.lwsLmcacheEnv" (dict "modelSpec" $modelSpec "root" $)
+*/}}
+{{- define "chart.lwsLmcacheEnv" -}}
+{{- $modelSpec := .modelSpec -}}
+{{- $root := .root -}}
+{{- if $modelSpec.lmcacheConfig }}
+{{-   if $modelSpec.lmcacheConfig.enabled }}
+- name: LMCACHE_USE_EXPERIMENTAL
+  value: "True"
+- name: VLLM_RPC_TIMEOUT
+  value: "1000000"
+- name: LMCACHE_LOG_LEVEL
+  value: {{ $modelSpec.lmcacheConfig.logLevel | default "INFO" | quote }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "cudaVisibleDevices" }}
+- name: CUDA_VISIBLE_DEVICES
+  value: {{ $modelSpec.lmcacheConfig.cudaVisibleDevices | quote }}
+{{-   end }}
+{{-   if and (hasKey $modelSpec.lmcacheConfig "enablePD") ($modelSpec.lmcacheConfig.enablePD) }}
+- name: LMCACHE_LOCAL_CPU
+  value: "False"
+- name: LMCACHE_MAX_LOCAL_CPU_SIZE
+  value: "0"
+- name: LMCACHE_REMOTE_SERDE
+  value: "NULL"
+- name: UCX_TLS
+  value: "cuda_ipc,cuda_copy,tcp"
+{{-     if hasKey $modelSpec.lmcacheConfig "enableNixl" }}
+- name: LMCACHE_ENABLE_NIXL
+  value: {{ ternary "True" "False" $modelSpec.lmcacheConfig.enableNixl | quote }}
+{{-     end }}
+{{-     if hasKey $modelSpec.lmcacheConfig "nixlRole" }}
+- name: LMCACHE_NIXL_ROLE
+  value: {{ $modelSpec.lmcacheConfig.nixlRole | quote }}
+{{-     end }}
+{{-     if hasKey $modelSpec.lmcacheConfig "nixlPeerHost" }}
+- name: LMCACHE_NIXL_RECEIVER_HOST
+  value: {{ $modelSpec.lmcacheConfig.nixlPeerHost | quote }}
+{{-     end }}
+{{-     if hasKey $modelSpec.lmcacheConfig "nixlPeerPort" }}
+- name: LMCACHE_NIXL_RECEIVER_PORT
+  value: {{ $modelSpec.lmcacheConfig.nixlPeerPort | quote }}
+{{-     end }}
+{{-     if hasKey $modelSpec.lmcacheConfig "nixlBufferSize" }}
+- name: LMCACHE_NIXL_BUFFER_SIZE
+  value: "{{ $modelSpec.lmcacheConfig.nixlBufferSize }}"
+{{-     end }}
+{{-     if hasKey $modelSpec.lmcacheConfig "nixlBufferDevice" }}
+- name: LMCACHE_NIXL_BUFFER_DEVICE
+  value: {{ $modelSpec.lmcacheConfig.nixlBufferDevice | quote }}
+{{-     end }}
+{{-     if hasKey $modelSpec.lmcacheConfig "nixlEnableGc" }}
+- name: LMCACHE_NIXL_ENABLE_GC
+  value: {{ ternary "True" "False" $modelSpec.lmcacheConfig.nixlEnableGc | quote }}
+{{-     end }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "cpuOffloadingBufferSize" }}
+{{-     if gt (int $modelSpec.lmcacheConfig.cpuOffloadingBufferSize) 0 }}
+- name: LMCACHE_LOCAL_CPU
+  value: "True"
+- name: LMCACHE_MAX_LOCAL_CPU_SIZE
+  value: "{{ $modelSpec.lmcacheConfig.cpuOffloadingBufferSize }}"
+{{-     end }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "diskOffloadingBufferSize" }}
+- name: LMCACHE_MAX_LOCAL_DISK_SIZE
+  value: "{{ $modelSpec.lmcacheConfig.diskOffloadingBufferSize }}"
+{{-   end }}
+{{-   if $root.Values.cacheserverSpec.enabled }}
+- name: LMCACHE_REMOTE_URL
+  value: "{{ include "cacheserver.formatRemoteUrl" (dict "service_name" (print $root.Release.Name "-cache-server-service") "port" $root.Values.cacheserverSpec.servicePort) }}"
+{{-     if $root.Values.cacheserverSpec.serde }}
+- name: LMCACHE_REMOTE_SERDE
+  value: "{{ $root.Values.cacheserverSpec.serde }}"
+{{-     end }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "enableController" }}
+- name: LMCACHE_ENABLE_CONTROLLER
+  value: {{ ternary "True" "False" $modelSpec.lmcacheConfig.enableController | quote }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "instanceId" }}
+- name: LMCACHE_LMCACHE_INSTANCE_ID
+  value: {{ $modelSpec.lmcacheConfig.instanceId | quote }}
+{{-   else }}
+- name: LMCACHE_LMCACHE_INSTANCE_ID
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "controllerPort" }}
+- name: LMCACHE_CONTROLLER_PULL_URL
+  value: "{{ $root.Release.Name }}-router-service:{{ $modelSpec.lmcacheConfig.controllerPort }}"
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "controllerReplyPort" }}
+- name: LMCACHE_CONTROLLER_REPLY_URL
+  value: "{{ $root.Release.Name }}-router-service:{{ $modelSpec.lmcacheConfig.controllerReplyPort }}"
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "workerPorts" }}
+- name: LMCACHE_LMCACHE_WORKER_PORTS
+  value: {{ $modelSpec.lmcacheConfig.workerPorts | quote }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "p2pHost" }}
+- name: LMCACHE_P2P_HOST
+  value: {{ $modelSpec.lmcacheConfig.p2pHost | quote }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "p2pInitPorts" }}
+- name: LMCACHE_P2P_INIT_PORTS
+  value: {{ $modelSpec.lmcacheConfig.p2pInitPorts | quote }}
+{{-   end }}
+{{-   if hasKey $modelSpec.lmcacheConfig "workerHeartbeatTime" }}
+- name: LMCACHE_LMCACHE_WORKER_HEARTBEAT_TIME
+  value: {{ $modelSpec.lmcacheConfig.workerHeartbeatTime | quote }}
+{{-   end }}
+{{- end }}
+{{- end }}
+
+{{/*
   Pod-level volumes shared by leader and worker templates.
   Usage: include "chart.lwsVolumes" (dict "modelSpec" $modelSpec "root" $)
 */}}
@@ -109,8 +256,18 @@
 {{- $root := .root -}}
 {{- if hasKey $modelSpec "pvcStorage" }}
 - name: {{ $root.Release.Name }}-storage
+  {{- if and (kindIs "map" $modelSpec.pvcStorage) (hasKey $modelSpec.pvcStorage "emptyDir") }}
+  emptyDir:
+    {{- toYaml $modelSpec.pvcStorage.emptyDir | nindent 4 }}
+  {{- else }}
   persistentVolumeClaim:
     claimName: "{{ $root.Release.Name }}-{{ $modelSpec.name }}-storage-claim"
+  {{- end }}
+{{- end }}
+{{- if $root.Values.sharedPvcStorage.enabled }}
+- name: {{ $root.Release.Name }}-shared-pvc-storage
+  persistentVolumeClaim:
+    claimName: "{{ $root.Release.Name }}-shared-pvc-storage-claim"
 {{- end }}
 {{- if and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize") }}
 - name: shm
@@ -145,7 +302,7 @@ securityContext:
 imagePullSecrets:
   - name: {{ $modelSpec.imagePullSecret }}
 {{- end }}
-{{- $vols := or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) $modelSpec.extraVolumes }}
+{{- $vols := or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) $modelSpec.extraVolumes $root.Values.sharedPvcStorage.enabled }}
 {{- if $vols }}
 volumes:
   {{- include "chart.lwsVolumes" (dict "modelSpec" $modelSpec "root" $root) | trim | nindent 2 }}
@@ -211,7 +368,9 @@ affinity:
         fieldRef:
           fieldPath: status.podIP
     - name: HF_HOME
-      {{- if hasKey $modelSpec "pvcStorage" }}
+      {{- if $root.Values.sharedPvcStorage.enabled }}
+      value: /data/shared-pvc-storage
+      {{- else if hasKey $modelSpec "pvcStorage" }}
       value: /data
       {{- else }}
       value: /tmp
@@ -261,10 +420,20 @@ affinity:
     {{- with $modelSpec.env }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if $root.Values.servingEngineSpec.configs }}
+    {{- $lmcacheEnv := include "chart.lwsLmcacheEnv" (dict "modelSpec" $modelSpec "root" $root) }}
+    {{- if trim $lmcacheEnv }}
+    {{- $lmcacheEnv | trim | nindent 4 }}
+    {{- end }}
+  {{- if or $root.Values.servingEngineSpec.configs $modelSpec.envFromSecret }}
   envFrom:
+    {{- if $root.Values.servingEngineSpec.configs }}
     - configMapRef:
         name: "{{ $root.Release.Name }}-configs"
+    {{- end }}
+    {{- if $modelSpec.envFromSecret }}
+    - secretRef:
+        name: {{ $modelSpec.envFromSecret.name }}
+    {{- end }}
   {{- end }}
   {{- if eq $role "leader" }}
   ports:
@@ -281,7 +450,7 @@ affinity:
   {{- else }}
   resources: {{- include "chart.resources" $modelSpec | nindent 4 }}
   {{- end }}
-  {{- $mountVolumes := or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) $modelSpec.extraVolumeMounts }}
+  {{- $mountVolumes := or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) $modelSpec.extraVolumeMounts $root.Values.sharedPvcStorage.enabled }}
   {{- if $mountVolumes }}
   volumeMounts:
     {{- if hasKey $modelSpec "pvcStorage" }}
@@ -294,6 +463,10 @@ affinity:
     {{- end }}
     {{- with $modelSpec.extraVolumeMounts }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if $root.Values.sharedPvcStorage.enabled }}
+    - name: {{ $root.Release.Name }}-shared-pvc-storage
+      mountPath: /data/shared-pvc-storage
     {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/templates/lws-vllm.yaml
+++ b/helm/templates/lws-vllm.yaml
@@ -1,0 +1,369 @@
+{{/*
+  Build the `vllm serve ...` command for a multi-node (LeaderWorkerSet) pod.
+  The leader (node-rank 0) serves the OpenAI API; workers run with `--headless`.
+  Both leader and worker share identical model args so the distributed process
+  group is configured consistently across nodes.
+  Usage: include "chart.lwsServeCommand" (dict "modelSpec" $modelSpec "root" $ "role" "leader")
+*/}}
+{{- define "chart.lwsServeCommand" -}}
+{{- $modelSpec := .modelSpec -}}
+{{- $root := .root -}}
+{{- $role := .role -}}
+{{- if eq $modelSpec.repository "lmcache/vllm-openai" }}
+- "/opt/venv/bin/vllm"
+{{- else }}
+- "vllm"
+{{- end }}
+- "serve"
+- {{ $modelSpec.modelURL | quote }}
+{{- if eq $role "leader" }}
+- "--host"
+- "0.0.0.0"
+- "--port"
+- {{ include "chart.container-port" $root | quote }}
+{{- end }}
+{{- if $modelSpec.enableLoRA }}
+- "--enable-lora"
+{{- end }}
+{{- if $modelSpec.enableTool }}
+- "--enable-auto-tool-choice"
+{{- end }}
+{{- if $modelSpec.toolCallParser }}
+- "--tool-call-parser"
+- {{ $modelSpec.toolCallParser | quote }}
+{{- end }}
+{{- with $modelSpec.vllmConfig }}
+{{- if hasKey . "enableChunkedPrefill" }}
+{{- if .enableChunkedPrefill }}
+- "--enable-chunked-prefill"
+{{- else }}
+- "--no-enable-chunked-prefill"
+{{- end }}
+{{- end }}
+{{- if .enablePrefixCaching }}
+- "--enable-prefix-caching"
+{{- end }}
+{{- if hasKey . "maxModelLen" }}
+- "--max-model-len"
+- {{ .maxModelLen | quote }}
+{{- end }}
+{{- if hasKey . "dtype" }}
+- "--dtype"
+- {{ .dtype | quote }}
+{{- end }}
+{{- if hasKey . "tensorParallelSize" }}
+- "--tensor-parallel-size"
+- {{ .tensorParallelSize | quote }}
+{{- end }}
+{{- if hasKey . "maxNumSeqs" }}
+- "--max-num-seqs"
+- {{ .maxNumSeqs | quote }}
+{{- end }}
+{{- if hasKey . "gpuMemoryUtilization" }}
+- "--gpu-memory-utilization"
+- {{ .gpuMemoryUtilization | quote }}
+{{- end }}
+{{- if hasKey . "maxLoras" }}
+- "--max-loras"
+- {{ .maxLoras | quote }}
+{{- end }}
+{{- range .extraArgs }}
+- {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- if $modelSpec.modelRevision }}
+- "--revision"
+- {{ $modelSpec.modelRevision | quote }}
+{{- end }}
+{{- if $modelSpec.chatTemplate }}
+- "--chat-template"
+- {{ $modelSpec.chatTemplate | quote }}
+{{- end }}
+{{- /* Multi-node multiprocessing (MP) distributed settings. LWS injects
+     LWS_GROUP_SIZE, LWS_WORKER_INDEX and LWS_LEADER_ADDRESS into every pod. */}}
+- "--distributed-executor-backend"
+- "mp"
+- "--pipeline-parallel-size"
+{{- if and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "pipelineParallelSize") }}
+- {{ $modelSpec.vllmConfig.pipelineParallelSize | quote }}
+{{- else }}
+- "$(LWS_GROUP_SIZE)"
+{{- end }}
+- "--nnodes"
+- "$(LWS_GROUP_SIZE)"
+- "--node-rank"
+- "$(LWS_WORKER_INDEX)"
+- "--master-addr"
+- "$(LWS_LEADER_ADDRESS)"
+{{- if eq $role "worker" }}
+- "--headless"
+{{- end }}
+{{- end }}
+
+{{/*
+  Pod-level volumes shared by leader and worker templates.
+  Usage: include "chart.lwsVolumes" (dict "modelSpec" $modelSpec "root" $)
+*/}}
+{{- define "chart.lwsVolumes" -}}
+{{- $modelSpec := .modelSpec -}}
+{{- $root := .root -}}
+{{- if hasKey $modelSpec "pvcStorage" }}
+- name: {{ $root.Release.Name }}-storage
+  persistentVolumeClaim:
+    claimName: "{{ $root.Release.Name }}-{{ $modelSpec.name }}-storage-claim"
+{{- end }}
+{{- if and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize") }}
+- name: shm
+  emptyDir:
+    medium: Memory
+    sizeLimit: {{ default "20Gi" $modelSpec.shmSize }}
+{{- end }}
+{{- with $modelSpec.extraVolumes }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+  Pod-spec fields (everything under `spec:` except `containers:`) shared by the
+  leader and worker templates, so scheduling and security stay identical.
+  Usage: include "chart.lwsPodSpec" (dict "modelSpec" $modelSpec "root" $)
+*/}}
+{{- define "chart.lwsPodSpec" -}}
+{{- $modelSpec := .modelSpec -}}
+{{- $root := .root -}}
+{{- if $modelSpec.priorityClassName }}
+priorityClassName: {{ $modelSpec.priorityClassName | quote }}
+{{- end }}
+{{- if $modelSpec.serviceAccountName }}
+serviceAccountName: {{ $modelSpec.serviceAccountName }}
+{{- end }}
+{{- with $root.Values.servingEngineSpec.securityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if $modelSpec.imagePullSecret }}
+imagePullSecrets:
+  - name: {{ $modelSpec.imagePullSecret }}
+{{- end }}
+{{- $vols := or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) $modelSpec.extraVolumes }}
+{{- if $vols }}
+volumes:
+  {{- include "chart.lwsVolumes" (dict "modelSpec" $modelSpec "root" $root) | trim | nindent 2 }}
+{{- end }}
+{{- with (ternary $modelSpec.runtimeClassName $root.Values.servingEngineSpec.runtimeClassName (hasKey $modelSpec "runtimeClassName")) }}
+runtimeClassName: {{ . }}
+{{- end }}
+{{- if $root.Values.servingEngineSpec.schedulerName }}
+schedulerName: {{ $root.Values.servingEngineSpec.schedulerName }}
+{{- end }}
+{{- $globalTolerations := $root.Values.servingEngineSpec.tolerations | default list }}
+{{- $modelTolerations := $modelSpec.tolerations | default list }}
+{{- $tolerationsPolicy := $modelSpec.tolerationsPolicy | default "append" }}
+{{- $effectiveTolerations := $globalTolerations }}
+{{- if $modelTolerations }}
+{{- if eq $tolerationsPolicy "override" }}
+{{- $effectiveTolerations = $modelTolerations }}
+{{- else }}
+{{- $effectiveTolerations = concat $globalTolerations $modelTolerations }}
+{{- end }}
+{{- end }}
+{{- if $effectiveTolerations }}
+tolerations:
+  {{- toYaml $effectiveTolerations | nindent 2 }}
+{{- end }}
+{{- if $modelSpec.nodeName }}
+nodeName: {{ $modelSpec.nodeName }}
+{{- end }}
+{{- if not (empty $modelSpec.affinity) }}
+affinity:
+  {{- toYaml $modelSpec.affinity | nindent 2 }}
+{{- else if and $modelSpec.nodeSelectorTerms (not $modelSpec.nodeName) }}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        {{- toYaml $modelSpec.nodeSelectorTerms | nindent 8 }}
+{{- end }}
+{{- end }}
+
+{{/*
+  Full vLLM container spec shared by leader and worker templates.
+  Usage: include "chart.lwsContainer" (dict "modelSpec" $modelSpec "root" $ "role" "leader")
+*/}}
+{{- define "chart.lwsContainer" -}}
+{{- $modelSpec := .modelSpec -}}
+{{- $root := .root -}}
+{{- $role := .role -}}
+- name: {{ printf "vllm-%s" $role | quote }}
+  image: "{{ required "Required value 'modelSpec.repository' must be defined !" $modelSpec.repository }}:{{ required "Required value 'modelSpec.tag' must be defined !" $modelSpec.tag }}"
+  imagePullPolicy: "{{ $root.Values.servingEngineSpec.imagePullPolicy | default "Always" }}"
+  {{- with $root.Values.servingEngineSpec.containerSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  command:
+    {{- include "chart.lwsServeCommand" (dict "modelSpec" $modelSpec "root" $root "role" $role) | trim | nindent 4 }}
+  env:
+    - name: PYTHONHASHSEED
+      value: "123"
+    - name: VLLM_HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: HF_HOME
+      {{- if hasKey $modelSpec "pvcStorage" }}
+      value: /data
+      {{- else }}
+      value: /tmp
+      {{- end }}
+    {{- with $modelSpec.vllmConfig }}
+    {{- if and (hasKey . "v0") (eq (toString .v0) "1") }}
+    - name: VLLM_USE_V1
+      value: "0"
+    {{- else }}
+    - name: PROMETHEUS_MULTIPROC_DIR
+      value: {{ default "/tmp" .prometheusMultiprocDir | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if $modelSpec.hf_token }}
+    - name: HF_TOKEN
+      {{- if kindIs "string" $modelSpec.hf_token }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ $root.Release.Name }}-secrets
+          key: hf_token_{{ $modelSpec.name }}
+      {{- else }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ $modelSpec.hf_token.secretName }}
+          key: {{ $modelSpec.hf_token.secretKey }}
+      {{- end }}
+    {{- end }}
+    {{- $vllmApiKey := $root.Values.servingEngineSpec.vllmApiKey }}
+    {{- if $vllmApiKey }}
+    {{- if kindIs "string" $vllmApiKey }}
+    - name: VLLM_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ $root.Release.Name }}-secrets
+          key: vllmApiKey
+    {{- else if and (kindIs "map" $vllmApiKey) $vllmApiKey.secretName $vllmApiKey.secretKey }}
+    - name: VLLM_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ $vllmApiKey.secretName }}
+          key: {{ $vllmApiKey.secretKey }}
+    {{- end }}
+    {{- end }}
+    {{- with $root.Values.servingEngineSpec.env }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $modelSpec.env }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if $root.Values.servingEngineSpec.configs }}
+  envFrom:
+    - configMapRef:
+        name: "{{ $root.Release.Name }}-configs"
+  {{- end }}
+  {{- if eq $role "leader" }}
+  ports:
+    - name: {{ include "chart.container-port-name" $root }}
+      containerPort: {{ include "chart.container-port" $root }}
+    - name: zmq-port
+      containerPort: 55555
+    - name: ucx-port
+      containerPort: 9999
+  {{- include "chart.probes" $root | trim | nindent 2 }}
+  {{- end }}
+  {{- if $modelSpec.resources }}
+  resources: {{ toYaml $modelSpec.resources | nindent 4 }}
+  {{- else }}
+  resources: {{- include "chart.resources" $modelSpec | nindent 4 }}
+  {{- end }}
+  {{- $mountVolumes := or (hasKey $modelSpec "pvcStorage") (and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize")) $modelSpec.extraVolumeMounts }}
+  {{- if $mountVolumes }}
+  volumeMounts:
+    {{- if hasKey $modelSpec "pvcStorage" }}
+    - name: {{ $root.Release.Name }}-storage
+      mountPath: /data
+    {{- end }}
+    {{- if and $modelSpec.vllmConfig (hasKey $modelSpec.vllmConfig "tensorParallelSize") }}
+    - name: shm
+      mountPath: /dev/shm
+    {{- end }}
+    {{- with $modelSpec.extraVolumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.servingEngineSpec.enableEngine }}
+{{- range $modelSpec := .Values.servingEngineSpec.modelSpec }}
+{{- if ne $modelSpec.enabled false }}
+{{- if and (hasKey $modelSpec "lwsSpec") $modelSpec.lwsSpec.enabled }}
+{{- with $ }}
+---
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: "{{ .Release.Name }}-{{ $modelSpec.name }}-lws"
+  namespace: {{ .Release.Namespace }}
+  {{- with $modelSpec.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    model: {{ $modelSpec.name }}
+    helm-release-name: {{ .Release.Name }}
+    {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 4 }}
+    {{- include "chart.engineLabels" . | nindent 4 }}
+    {{- with $modelSpec.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $modelSpec.replicaCount | default 1 }}
+  leaderWorkerTemplate:
+    size: {{ required "Value 'modelSpec.lwsSpec.size' must be defined !" $modelSpec.lwsSpec.size }}
+    restartPolicy: {{ $modelSpec.lwsSpec.restartPolicy | default "RecreateGroupOnPodRestart" }}
+    leaderTemplate:
+      metadata:
+        {{- with $modelSpec.podAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        labels:
+          model: {{ $modelSpec.name }}
+          helm-release-name: {{ .Release.Name }}
+          vllm-role: leader
+          {{- include "chart.engineStandardLabels" (dict "releaseName" .Release.Name "modelName" $modelSpec.name "chartName" .Chart.Name) | nindent 10 }}
+          {{- include "chart.engineLabels" . | nindent 10 }}
+          {{- with $modelSpec.podLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+      spec:
+        {{- include "chart.lwsPodSpec" (dict "modelSpec" $modelSpec "root" $) | trim | nindent 8 }}
+        containers:
+          {{- include "chart.lwsContainer" (dict "modelSpec" $modelSpec "root" $ "role" "leader") | nindent 10 }}
+    workerTemplate:
+      metadata:
+        {{- with $modelSpec.podAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        labels:
+          model: {{ $modelSpec.name }}
+          helm-release-name: {{ .Release.Name }}
+          vllm-role: worker
+          {{- with $modelSpec.podLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+      spec:
+        {{- include "chart.lwsPodSpec" (dict "modelSpec" $modelSpec "root" $) | trim | nindent 8 }}
+        containers:
+          {{- include "chart.lwsContainer" (dict "modelSpec" $modelSpec "root" $ "role" "worker") | nindent 10 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/templates/scaledobject-vllm.yaml
+++ b/helm/templates/scaledobject-vllm.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.servingEngineSpec.enableEngine -}}
 {{- range $modelSpec := .Values.servingEngineSpec.modelSpec }}
 {{- if and (hasKey $modelSpec "keda") $modelSpec.keda.enabled }}
-{{- if not (hasKey $modelSpec "raySpec") }}
+{{- if not (or (hasKey $modelSpec "raySpec") (and (hasKey $modelSpec "lwsSpec") $modelSpec.lwsSpec.enabled)) }}
 {{- with $ -}}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1377,6 +1377,28 @@
                                     }
                                 }
                             },
+                            "lwsSpec": {
+                                "description": "LeaderWorkerSet (LWS) configuration, to deploy a single model across multiple nodes using vLLM's multiprocessing (MP) distributed backend instead of Ray. Requires the LeaderWorkerSet controller (https://github.com/kubernetes-sigs/lws) to be installed in the cluster.",
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "description": "Whether to deploy the model as a multi-node LeaderWorkerSet using the multiprocessing backend",
+                                        "type": "boolean"
+                                    },
+                                    "restartPolicy": {
+                                        "description": "Restart policy for a group when any of its pods restart. `RecreateGroupOnPodRestart` recreates the whole group together, which is recommended because the nodes form a single distributed process group.",
+                                        "type": "string",
+                                        "enum": [
+                                            "RecreateGroupOnPodRestart",
+                                            "Default"
+                                        ]
+                                    },
+                                    "size": {
+                                        "description": "Number of nodes (pods) per model replica, i.e. vLLM `--nnodes`. Node 0 is the leader and serves the OpenAI API; nodes 1..(size-1) run as headless workers. The number of independent multi-node replicas is taken from `replicaCount`.",
+                                        "type": "integer"
+                                    }
+                                }
+                            },
                             "modelRevision": {
                                 "description": "Hugging Face model revision (branch, tag, or commit hash) to pin the model version",
                                 "type": "string"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -276,6 +276,15 @@ servingEngineSpec:
         # -- GPU request for the head node
         requestGPU: 1
 
+    # -- LeaderWorkerSet (LWS) configuration, to deploy a single model across multiple nodes using vLLM's multiprocessing (MP) distributed backend instead of Ray. Requires the LeaderWorkerSet controller (https://github.com/kubernetes-sigs/lws) to be installed in the cluster.
+    lwsSpec:
+      # -- Whether to deploy the model as a multi-node LeaderWorkerSet using the multiprocessing backend
+      enabled: false
+      # -- Number of nodes (pods) per model replica, i.e. vLLM `--nnodes`. Node 0 is the leader and serves the OpenAI API; nodes 1..(size-1) run as headless workers. The number of independent multi-node replicas is taken from `replicaCount`.
+      size: 2
+      # -- Restart policy for a group when any of its pods restart. `RecreateGroupOnPodRestart` recreates the whole group together, which is recommended because the nodes form a single distributed process group.
+      restartPolicy: "RecreateGroupOnPodRestart" # @schema enum:[RecreateGroupOnPodRestart,Default]
+
   # -- Container port
   containerPort: 8000
   # -- Service port


### PR DESCRIPTION
## Summary

Implements first-class multi-node **multiprocessing (MP)** deployment support.

Fixes #930.

The only distributed path today is `ray-cluster.yaml`, which requires the KubeRay operator and hardcodes `--distributed-executor-backend ray`. Since vLLM v0.19.0 dropped Ray from the default image, this adds an MP alternative modeled on the upstream vLLM LeaderWorkerSet example (vllm-project/vllm#39400).

## Changes

- New `modelSpec.lwsSpec` (`enabled`, `size`, `restartPolicy`) + `values.schema.json` entry
- New `helm/templates/lws-vllm.yaml` rendering a `LeaderWorkerSet`:
  - leader (node-rank 0) serves the OpenAI API; workers run `--headless`
  - `--nnodes` / `--node-rank` / `--master-addr` from `$(LWS_GROUP_SIZE)` / `$(LWS_WORKER_INDEX)` / `$(LWS_LEADER_ADDRESS)`
  - only the leader carries router/engine-service discovery labels
- Exclude LWS-enabled models from the Deployment and KEDA ScaledObject paths (mirrors `raySpec`)

## Notes

- Requires the LeaderWorkerSet controller (kubernetes-sigs/lws) installed in the cluster.
- A tutorial and Helm unit tests will added once I get a thumbs up on the approach.
- Validated with `helm template`, `helm lint`, and structural YAML checks; not yet exercised on a live multi-node GPU cluster.

## Checklist

- [x] Signed-off commit (DCO)
- [x] PR classified (`[Feat]`)
- [ ] pre-commit checks (please run `pre-commit run --all-files`; I could not run the `helm-schema` generator locally)
