### PR TITLE
[Bugfix] Align vllm version in requirements-test.txt with pyproject.toml

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ pytest
 pytest-asyncio
 sentence-transformers>=2.2.2
 transformers==4.51.1
-vllm==0.9.2
+vllm==0.13.0


### PR DESCRIPTION
## Summary

requirements-test.txt pinned vllm==0.9.2, but pyproject.toml specifies vllm==0.13.0 in the test and lmcache optional dependencies, causing test environment version inconsistency.

## Changes

- Updated requirements-test.txt: vllm==0.9.2 → vllm==0.13.0

## Testing

Verified by grep that vllm versions now match across both files.