### PR TITLE
[CI/Build] Add CODEOWNERS for automated PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS file for vllm-project/production-stack
+# This file defines code ownership to automatically request reviews from maintainers.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @ApostaC @YuhanLiu11 @Shaoting-Feng @ruizhang0101


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file to enable automatic review assignment from maintainers when PRs are opened.

## Changes

- Created  with the top 4 maintainers (@ApostaC, @YuhanLiu11, @Shaoting-Feng, @ruizhang0101) as default owners
- GitHub will automatically request reviews from these maintainers on new PRs

## Testing

Verified by grep / visual inspection.