### PR TITLE
fix: await router.route_request and pass request_json in proxy_multipart_request [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1242,12 +1242,21 @@ async def proxy_multipart_request(
     request_stats = request_stats_monitor.get_request_stats(time.time())
 
     # pick one using the router's configured logic (roundrobin, least-loaded, etc.)
-    chosen_url = router.route_request(
-        endpoints,
-        engine_stats,
-        request_stats,
-        request,
-    )
+    if isinstance(router, (KvawareRouter, PrefixAwareRouter, SessionRouter)):
+        chosen_url = await router.route_request(
+            endpoints,
+            engine_stats,
+            request_stats,
+            request,
+            {},
+        )
+    else:
+        chosen_url = router.route_request(
+            endpoints,
+            engine_stats,
+            request_stats,
+            request,
+        )
     logger.info(
         "Proxying multi-part form request for model %s to %s", model, chosen_url
     )


### PR DESCRIPTION
Fixes #1019

## What does this PR do?

Fixes a bug in `proxy_multipart_request` where `SessionRouter.route_request()` was called without the required `request_json` argument, and without `await`.

## Root Cause

The `proxy_multipart_request` function (used for audio transcription and image edit requests) called `router.route_request()` synchronously without `request_json`:

```python
chosen_url = router.route_request(
    endpoints,
    engine_stats,
    request_stats,
    request,
)
```

However, `SessionRouter`, `KvawareRouter`, and `PrefixAwareRouter` all have an async `route_request` method that requires a `request_json` argument. The regular `route_general_request` function already handles this correctly with an `isinstance` guard.

## Fix

Mirrors the pattern used in `route_general_request`:
- If the router is a `SessionRouter`, `KvawareRouter`, or `PrefixAwareRouter`, call `await router.route_request(...)` with `{}` as `request_json` (multipart/form-data requests have no JSON body).
- Otherwise, call `router.route_request(...)` synchronously without `request_json`.

## Testing

- The fix follows the exact same pattern as `route_general_request` (lines 561-570), which is already well-tested.
- Only affects multipart routes (`/v1/audio/transcriptions`, `/v1/images/edits`) when using session/kv-aware/prefix-aware routing.
- `roundrobin` routing is unaffected.