### PR TITLE
[Router] Standardize route_request signature across all routers

### DIFF
--- a/src/tests/test_request_auth_headers.py
+++ b/src/tests/test_request_auth_headers.py
@@ -32,7 +32,7 @@ def _build_request(headers=None):
     state.callbacks = None
     state.request_stats_monitor.get_request_stats.return_value = {}
     state.engine_stats_scraper.get_engine_stats.return_value = {}
-    state.router.route_request.return_value = "http://whisper-engine"
+    state.router.route_request = AsyncMock(return_value="http://whisper-engine")
 
     request = MagicMock()
     request.headers = headers or {}

--- a/src/tests/test_roundrobin_router.py
+++ b/src/tests/test_roundrobin_router.py
@@ -62,7 +62,7 @@ def assert_even_distribution(route_counts: Counter):
     assert max(counts) - min(counts) <= 1
 
 
-def test_roundrobin_logic(
+async def test_roundrobin_logic(
     dynamic_discoveries: int = 10, max_endpoints: int = 1000, max_requests: int = 10000
 ):
     """
@@ -70,12 +70,14 @@ def test_roundrobin_logic(
     """
     router = RoundRobinRouter()
 
-    def assert_router_stays_balanced(num_endpoints: int, num_requests: int):
+    async def assert_router_stays_balanced(num_endpoints: int, num_requests: int):
         endpoints, engine_stats, request_stats = generate_request_args(num_endpoints)
         route_counts = Counter()
         for _ in range(num_requests):
             request = generate_request()
-            url = router.route_request(endpoints, engine_stats, request_stats, request)
+            url = await router.route_request(
+                endpoints, engine_stats, request_stats, request, {}
+            )
             route_counts[url] += 1
 
         assert_even_distribution(route_counts)
@@ -83,10 +85,10 @@ def test_roundrobin_logic(
     for _ in range(dynamic_discoveries):
         num_endpoints = random.randint(1, max_endpoints)
         num_requests = random.randint(1, max_requests)
-        assert_router_stays_balanced(num_endpoints, num_requests)
+        await assert_router_stays_balanced(num_endpoints, num_requests)
 
 
-def test_roundrobin_keeps_state_per_endpoint_set():
+async def test_roundrobin_keeps_state_per_endpoint_set():
     router = RoundRobinRouter()
     request = generate_request()
     engine_stats = {}
@@ -97,16 +99,20 @@ def test_roundrobin_keeps_state_per_endpoint_set():
     route_counts_b = Counter()
 
     for _ in range(100):
-        url_a = router.route_request(endpoints_a, engine_stats, request_stats, request)
+        url_a = await router.route_request(
+            endpoints_a, engine_stats, request_stats, request, {}
+        )
         route_counts_a[url_a] += 1
-        url_b = router.route_request(endpoints_b, engine_stats, request_stats, request)
+        url_b = await router.route_request(
+            endpoints_b, engine_stats, request_stats, request, {}
+        )
         route_counts_b[url_b] += 1
 
     assert_even_distribution(route_counts_a)
     assert_even_distribution(route_counts_b)
 
 
-def test_roundrobin_keeps_state_when_endpoint_order_changes():
+async def test_roundrobin_keeps_state_when_endpoint_order_changes():
     router = RoundRobinRouter()
     request = generate_request()
     engine_stats = {}
@@ -115,10 +121,11 @@ def test_roundrobin_keeps_state_when_endpoint_order_changes():
     endpoints_a_reordered = [EndpointInfo(url="a1"), EndpointInfo(url="a0")]
 
     assert (
-        router.route_request(endpoints_a, engine_stats, request_stats, request) == "a0"
+        await router.route_request(endpoints_a, engine_stats, request_stats, request)
+        == "a0"
     )
     assert (
-        router.route_request(
+        await router.route_request(
             endpoints_a_reordered,
             engine_stats,
             request_stats,
@@ -128,8 +135,8 @@ def test_roundrobin_keeps_state_when_endpoint_order_changes():
     )
 
 
-def test_roundrobin_rejects_empty_endpoint_list():
+async def test_roundrobin_rejects_empty_endpoint_list():
     router = RoundRobinRouter()
 
     with pytest.raises(ValueError, match="at least one endpoint"):
-        router.route_request([], {}, {}, generate_request())
+        await router.route_request([], {}, {}, generate_request())

--- a/src/tests/test_route_request_signature.py
+++ b/src/tests/test_route_request_signature.py
@@ -1,0 +1,249 @@
+"""Tests for the standardized ``route_request`` signature (issue #1022).
+
+Every router must expose ``async def route_request(self, endpoints,
+engine_stats, request_stats, request, request_json)`` so that call sites can
+always ``await`` and always pass ``request_json`` without isinstance-based
+dispatch guards.
+"""
+
+import inspect
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from vllm_router.routers.routing_logic import (
+    DisaggregatedPrefillOrchestratedRouter,
+    DisaggregatedPrefillRouter,
+    KvawareRouter,
+    PrefixAwareRouter,
+    RoundRobinRouter,
+    RoutingInterface,
+    SessionRouter,
+)
+from vllm_router.utils import SingletonABCMeta
+
+ALL_ROUTER_CLASSES = [
+    RoundRobinRouter,
+    SessionRouter,
+    KvawareRouter,
+    PrefixAwareRouter,
+    DisaggregatedPrefillRouter,
+    DisaggregatedPrefillOrchestratedRouter,
+]
+
+
+class EndpointInfo:
+    def __init__(self, url, model_names=None, sleep=False, Id=None):
+        self.url = url
+        self.model_names = model_names or ["test-model"]
+        self.sleep = sleep
+        self.Id = Id
+
+
+class RecordingAsyncRouter(RoutingInterface):
+    """A router that is NOT in any isinstance whitelist at the call sites.
+
+    It records the ``request_json`` it receives, so tests can verify that the
+    call sites actually awaited the coroutine (the body of an un-awaited
+    coroutine never runs) and passed the request body through.
+    """
+
+    def __init__(self):
+        if hasattr(self, "_initialized"):
+            return
+        self.received_request_jsons = []
+        self.max_instance_failover_reroute_attempts = 0
+        self._initialized = True
+
+    async def route_request(
+        self,
+        endpoints,
+        engine_stats,
+        request_stats,
+        request,
+        request_json=None,
+    ) -> str:
+        self.received_request_jsons.append(request_json)
+        return endpoints[0].url
+
+
+@pytest.fixture(autouse=True)
+def cleanup_singletons():
+    yield
+    for cls in list(SingletonABCMeta._instances.keys()):
+        del SingletonABCMeta._instances[cls]
+
+
+@pytest.mark.parametrize("router_cls", ALL_ROUTER_CLASSES)
+def test_route_request_is_coroutine_function(router_cls):
+    assert inspect.iscoroutinefunction(
+        router_cls.route_request
+    ), f"{router_cls.__name__}.route_request must be an async def"
+
+
+@pytest.mark.parametrize("router_cls", ALL_ROUTER_CLASSES)
+def test_route_request_accepts_request_json(router_cls):
+    params = inspect.signature(router_cls.route_request).parameters
+    assert "request_json" in params, (
+        f"{router_cls.__name__}.route_request must accept a request_json" " parameter"
+    )
+    param_names = list(params)
+    assert param_names[:6] == [
+        "self",
+        "endpoints",
+        "engine_stats",
+        "request_stats",
+        "request",
+        "request_json",
+    ], f"{router_cls.__name__}.route_request has unexpected parameter order"
+
+
+def test_base_interface_route_request_is_async_with_request_json():
+    assert inspect.iscoroutinefunction(RoutingInterface.route_request)
+    assert (
+        "request_json" in inspect.signature(RoutingInterface.route_request).parameters
+    )
+
+
+@pytest.mark.asyncio
+async def test_roundrobin_routes_via_awaited_path():
+    router = RoundRobinRouter()
+    endpoints = [EndpointInfo(url="http://engine1"), EndpointInfo(url="http://engine2")]
+    request = MagicMock()
+
+    urls = [
+        await router.route_request(endpoints, {}, {}, request, {}) for _ in range(4)
+    ]
+
+    assert urls == ["http://engine1", "http://engine2"] * 2
+
+
+@pytest.mark.asyncio
+async def test_route_general_request_awaits_any_router_and_passes_request_json():
+    """Call-site dispatch must not depend on the router's concrete type."""
+    router = RecordingAsyncRouter()
+
+    sd = MagicMock()
+    sd.get_endpoint_info.return_value = [
+        EndpointInfo(url="http://engine1"),
+        EndpointInfo(url="http://engine2"),
+    ]
+    sd.aliases = None
+    sd.has_ever_seen_model.return_value = True
+
+    state = MagicMock()
+    state.router = router
+    state.engine_stats_scraper.get_engine_stats.return_value = {}
+    state.request_stats_monitor.get_request_stats.return_value = {}
+    state.otel_enabled = False
+    state.semantic_cache_available = False
+    state.callbacks = None
+    state.external_provider_registry = None
+
+    req = MagicMock()
+    req.headers = {"content-type": "application/json"}
+    req.query_params = {}
+    req.method = "POST"
+    req.url = "http://router/v1/chat/completions"
+    req.app.state = state
+
+    request_body = {"model": "test-model", "stream": False}
+
+    async def body():
+        return json.dumps(request_body).encode()
+
+    req.body = body
+
+    mock_headers = MagicMock()
+    mock_headers.items.return_value = [("content-type", "text/event-stream")]
+
+    async def ok(*args, **kwargs):
+        yield mock_headers, 200
+        yield b"done"
+
+    with (
+        patch(
+            "vllm_router.services.request_service.request.get_service_discovery",
+            return_value=sd,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.is_request_rewriter_initialized",
+            return_value=False,
+        ),
+        patch(
+            "vllm_router.services.request_service.request.process_request",
+            side_effect=ok,
+        ) as mock_process,
+    ):
+        from vllm_router.services.request_service.request import route_general_request
+
+        resp = await route_general_request(req, "/v1/chat/completions", MagicMock())
+
+    assert resp.status_code == 200
+    # The coroutine body only runs when awaited, so this proves the call site
+    # awaited route_request and forwarded the parsed JSON body.
+    assert router.received_request_jsons == [request_body]
+    # process_request must receive the resolved URL string, not a coroutine.
+    assert mock_process.call_args.args[2] == "http://engine1"
+
+
+@pytest.mark.asyncio
+async def test_proxy_multipart_request_awaits_route_request_with_request_json():
+    router = RecordingAsyncRouter()
+
+    state = MagicMock()
+    state.router = router
+    state.engine_stats_scraper.get_engine_stats.return_value = {}
+    state.request_stats_monitor.get_request_stats.return_value = {}
+    state.otel_enabled = False
+
+    req = MagicMock()
+    req.headers = {"content-type": "multipart/form-data; boundary=router-boundary"}
+    req.query_params = {}
+    req.method = "POST"
+    req.url = "http://router/v1/audio/transcriptions"
+    req.app.state = state
+
+    backend_response = MagicMock()
+    backend_response.status = 200
+    backend_response.headers.items.return_value = [("content-type", "application/json")]
+    backend_response.json = AsyncMock(return_value={"ok": True})
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=backend_response)
+    req.app.state.aiohttp_client_wrapper = MagicMock(return_value=mock_client)
+
+    sd = MagicMock()
+    sd.get_endpoint_info.return_value = [
+        EndpointInfo(url="http://engine1", model_names=["whisper-model"])
+    ]
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", b"audio-bytes", filename="sample.wav")
+    form_data.add_field("model", "whisper-model")
+
+    with patch(
+        "vllm_router.services.request_service.request.get_service_discovery",
+        return_value=sd,
+    ):
+        from vllm_router.services.request_service.request import (
+            proxy_multipart_request,
+        )
+
+        response = await proxy_multipart_request(
+            form_data,
+            "whisper-model",
+            "/v1/audio/transcriptions",
+            req,
+        )
+
+    assert response.status_code == 200
+    # Proves the call site awaited route_request and passed a request_json
+    # ({} because multipart requests carry no JSON body).
+    assert router.received_request_jsons == [{}]
+    # And the backend was called with the resolved URL string.
+    assert (
+        mock_client.post.await_args.args[0] == "http://engine1/v1/audio/transcriptions"
+    )

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -115,12 +115,13 @@ class RoutingInterface(metaclass=SingletonABCMeta):
         return val if val is not None else request_json.get(session_key, None)
 
     @abc.abstractmethod
-    def route_request(
+    async def route_request(
         self,
         endpoints: List[EndpointInfo],
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         Route the request to the appropriate engine URL
@@ -132,6 +133,8 @@ class RoutingInterface(metaclass=SingletonABCMeta):
             request_stats (Dict[str, RequestStats]): The request stats
                 indicating the request-level performance of each engine
             request (Request): The incoming request
+            request_json (Optional[Dict]): The parsed JSON body of the
+                request, if any (used by routers that inspect the body)
         """
         raise NotImplementedError
 
@@ -165,12 +168,13 @@ class RoundRobinRouter(RoutingInterface):
             self._sorted_cache[urls] = key
         return key
 
-    def route_request(
+    async def route_request(
         self,
         endpoints: List[EndpointInfo],
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         Route the request to the appropriate engine URL using a simple
@@ -183,6 +187,8 @@ class RoundRobinRouter(RoutingInterface):
             request_stats (Dict[str, RequestStats]): The request stats
                 indicating the request-level performance of each engine
             request (Request): The incoming request
+            request_json (Optional[Dict]): The request body (unused by this
+                router)
         """
         endpoint_urls = self._endpoint_key(endpoints)
         idx = self._next_index.get(endpoint_urls, 0)
@@ -216,7 +222,7 @@ class SessionRouter(RoutingInterface):
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
-        request_json: Dict,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         Route the request to the appropriate engine URL by the 'session id' in
@@ -231,8 +237,10 @@ class SessionRouter(RoutingInterface):
             request_stats (Dict[str, RequestStats]): The request stats
                 indicating the request-level performance of each engine
             request (Request): The incoming request
-            request_json (Dict): The request body (needed for finding the session id)
+            request_json (Optional[Dict]): The request body (needed for finding the session id)
         """
+        if request_json is None:
+            request_json = {}
         session_id = self.extract_session_id(request, request_json)
         logger.debug(f"Got session id: {session_id}")
 
@@ -335,7 +343,7 @@ class KvawareRouter(RoutingInterface):
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
-        request_json: Dict,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         Route the request to the appropriate engine URL by where the KV cache
@@ -350,9 +358,11 @@ class KvawareRouter(RoutingInterface):
             request_stats (Dict[str, RequestStats]): The request stats
                indicating the request-level performance of each engine
             request (Request): The incoming request
-            request_json (Dict): The request body (needed for finding the
-            longest prefix match)
+            request_json (Optional[Dict]): The request body (needed for
+            finding the longest prefix match)
         """
+        if request_json is None:
+            request_json = {}
         token_ids = None
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         # TODO (Yuhan): Handle chat completions
@@ -454,7 +464,7 @@ class PrefixAwareRouter(RoutingInterface):
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
-        request_json: Dict,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         Route the request to the appropriate engine URL by where the longest
@@ -469,9 +479,11 @@ class PrefixAwareRouter(RoutingInterface):
             request_stats (Dict[str, RequestStats]): The request stats
                indicating the request-level performance of each engine
             request (Request): The incoming request
-            request_json (Dict): The request body (needed for finding the
-            longest prefix match)
+            request_json (Optional[Dict]): The request body (needed for
+            finding the longest prefix match)
         """
+        if request_json is None:
+            request_json = {}
 
         # Handle chat completions
         if "messages" in request_json:
@@ -533,18 +545,20 @@ class DisaggregatedPrefillRouter(RoutingInterface):
         self.decode_model_labels = decode_model_labels
         self.request_cache = {}  # Cache to store prefill results
 
-    def route_request(
+    async def route_request(
         self,
         endpoints: List[EndpointInfo],
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
-        request_json: Dict,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         Route the request to appropriate endpoints for prefill and decode operations.
         First request goes to prefill endpoint, then second request goes to decode endpoint.
         """
+        if request_json is None:
+            request_json = {}
         # Find prefill and decode endpoints
         is_prefill = request_json.get("max_tokens", 0) == 1
         if is_prefill:
@@ -661,7 +675,7 @@ class DisaggregatedPrefillOrchestratedRouter(RoutingInterface):
         engine_stats: Dict[str, EngineStats],
         request_stats: Dict[str, RequestStats],
         request: Request,
-        request_json: Dict,
+        request_json: Optional[Dict] = None,
     ) -> str:
         """
         This method is called by the router framework but for orchestrated routing,

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -30,9 +30,6 @@ from vllm_router.log import init_logger
 from vllm_router.routers.routing_logic import (
     DisaggregatedPrefillOrchestratedRouter,
     DisaggregatedPrefillRouter,
-    KvawareRouter,
-    PrefixAwareRouter,
-    SessionRouter,
 )
 from vllm_router.service_discovery import get_service_discovery
 from vllm_router.services.request_service.rewriter import (
@@ -558,15 +555,9 @@ async def route_general_request(
             f"Routing request {request_id} to engine with Id: {endpoints[0].Id}"
         )
 
-    elif isinstance(
-        request.app.state.router, (KvawareRouter, PrefixAwareRouter, SessionRouter)
-    ):
+    else:
         server_url = await request.app.state.router.route_request(
             endpoints, engine_stats, request_stats, request, request_json
-        )
-    else:
-        server_url = request.app.state.router.route_request(
-            endpoints, engine_stats, request_stats, request
         )
 
     curr_time = time.time()
@@ -605,16 +596,9 @@ async def route_general_request(
                 break
             if request_endpoint:
                 server_url = remaining[0].url
-            elif isinstance(
-                request.app.state.router,
-                (KvawareRouter, PrefixAwareRouter, SessionRouter),
-            ):
+            else:
                 server_url = await request.app.state.router.route_request(
                     remaining, engine_stats, request_stats, request, request_json
-                )
-            else:
-                server_url = request.app.state.router.route_request(
-                    remaining, engine_stats, request_stats, request
                 )
             logger.info(
                 f"Routing request {request_id} to {server_url} "
@@ -1242,11 +1226,12 @@ async def proxy_multipart_request(
     request_stats = request_stats_monitor.get_request_stats(time.time())
 
     # pick one using the router's configured logic (roundrobin, least-loaded, etc.)
-    chosen_url = router.route_request(
+    chosen_url = await router.route_request(
         endpoints,
         engine_stats,
         request_stats,
         request,
+        {},  # multipart/form-data requests carry no JSON body
     )
     logger.info(
         "Proxying multi-part form request for model %s to %s", model, chosen_url


### PR DESCRIPTION
Implements #1022, proposed by @shernshiou.

`route_request` was inconsistent across the 6 router implementations (some sync, some async, some without `request_json`), which forced isinstance dispatch guards at every call site and would break silently whenever a new router is added.

Changes:
- `RoutingInterface.route_request` is now `async def` and takes `request_json`; all 6 routers share the signature. Sync routers just do not await internally; no routing behavior changed.
- `route_general_request` (initial + failover call sites) and `proxy_multipart_request` always await and always pass `request_json`; the `(KvawareRouter, PrefixAwareRouter, SessionRouter)` isinstance guards are gone. The `DisaggregatedPrefill*` isinstance checks stay because they dispatch to different request handlers, not `route_request` variants.
- One deviation from the issue text: `request_json: Optional[Dict] = None` (normalized inside) instead of the mutable `dict = {}` default, matching the repo's existing typing style and avoiding the shared-default hazard. Happy to change if you prefer the literal proposal.

Tests: new `test_route_request_signature.py` (16 tests) checks every router's signature plus behavioral probes proving the call sites really await and forward the body (via a router subclass that is not in any old isinstance whitelist). Existing roundrobin/auth-header tests updated for async. Full suite: 186 passed, 0 failed (baseline on main was 170 passed, 0 failed). black/isort/ruff clean.

Relates to #1019: this standardizes the surface that made that bug possible. PRs #1020/#1021 fix the immediate call-site bug; this PR is complementary and rebases cleanly in either order.
