### PR TITLE
[Router][Bugfix] Fix KvawareRouter event-loop blocking during tokenization (#1016)

### DIFF
--- a/src/tests/test_kvaware_router_event_loop.py
+++ b/src/tests/test_kvaware_router_event_loop.py
@@ -1,0 +1,182 @@
+# Copyright 2024-2025 The vLLM Production Stack Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for https://github.com/vllm-project/production-stack/issues/1016
+
+KvawareRouter.route_request performed blocking I/O (tokenizer download,
+fallback /tokenize HTTP POST) directly on the uvicorn event loop, starving
+/health probes and CrashLooping the router under sustained traffic.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from uhashring import HashRing
+
+from vllm_router.routers import routing_logic
+from vllm_router.routers.routing_logic import KvawareRouter
+
+
+@pytest.fixture(autouse=True)
+def stub_lmcache_names(monkeypatch):
+    """lmcache is an optional runtime dep; provide the message names the
+    router constructs (they only reach the mocked query_manager)."""
+    monkeypatch.setattr(routing_logic, "LookupMsg", MagicMock(), raising=False)
+    monkeypatch.setattr(routing_logic, "QueryInstMsg", MagicMock(), raising=False)
+
+
+class EndpointInfo:
+    def __init__(self, url: str, model_names=None):
+        self.url = url
+        self.model_names = model_names or ["test-model"]
+
+
+class Request:
+    def __init__(self, headers: Dict[str, str], body: Dict[str, Any] = None):
+        self.headers = headers
+        self.body = body
+
+
+class FakeTokenizer:
+    def encode(self, text):
+        return [1, 2, 3]
+
+
+def make_router() -> KvawareRouter:
+    """KvawareRouter without __init__ (avoids LMCache controller setup)."""
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = None
+    router._tokenizer_load_failed = False
+    router.session_key = None
+    router.threshold = 2000
+    router.hash_ring = HashRing()
+    router.instance_id_to_ip = {}
+    # No KV layout hits: fall through to the QPS/session fallback path,
+    # which returns endpoints[0].url when request_stats is empty.
+    router.query_manager = AsyncMock(return_value=SimpleNamespace(layout_info={}))
+    return router
+
+
+async def run_with_health_probe(coro, probe_interval=0.05):
+    """Run coro alongside a fake /health probe; return probe ticks at coro end."""
+    ticks = 0
+
+    async def health_probe():
+        nonlocal ticks
+        for _ in range(20):
+            ticks += 1
+            await asyncio.sleep(probe_interval)
+
+    route_task = asyncio.ensure_future(coro)
+    probe_task = asyncio.ensure_future(health_probe())
+    await route_task
+    ticks_when_route_finished = ticks
+    probe_task.cancel()
+    return ticks_when_route_finished
+
+
+@pytest.mark.asyncio
+async def test_tokenizer_load_does_not_block_event_loop():
+    """A slow tokenizer download must not freeze the event loop."""
+    router = make_router()
+    endpoint = EndpointInfo(url="http://engine1.com")
+
+    with patch.object(routing_logic, "AutoTokenizer") as at:
+        at.from_pretrained.side_effect = lambda name: time.sleep(0.3) or FakeTokenizer()
+        ticks = await run_with_health_probe(
+            router.route_request(
+                [endpoint], None, {}, Request(headers={}), {"prompt": "hi"}
+            )
+        )
+
+    # If the loop were blocked for the full 0.3s load, the probe could not
+    # tick at all before the route finished.
+    assert ticks >= 3, f"health probe starved during tokenizer load ({ticks} ticks)"
+
+
+@pytest.mark.asyncio
+async def test_remote_tokenize_fallback_does_not_block_event_loop():
+    """The fallback /tokenize HTTP POST must not freeze the event loop."""
+    router = make_router()
+    endpoint = EndpointInfo(url="http://engine1.com")
+
+    response = MagicMock()
+    response.json.return_value = {"tokens": [1, 2, 3]}
+
+    with (
+        patch.object(routing_logic, "AutoTokenizer") as at,
+        patch.object(routing_logic, "requests") as req,
+    ):
+        at.from_pretrained.side_effect = RuntimeError("huggingface.co unreachable")
+        req.post.side_effect = lambda *a, **k: time.sleep(0.3) or response
+        ticks = await run_with_health_probe(
+            router.route_request(
+                [endpoint], None, {}, Request(headers={}), {"prompt": "hi"}
+            )
+        )
+
+    assert ticks >= 3, f"health probe starved during /tokenize POST ({ticks} ticks)"
+
+
+@pytest.mark.asyncio
+async def test_failed_tokenizer_load_is_not_retried_every_request():
+    """A doomed tokenizer load (alias model name / blocked egress) must be
+    cached as failed instead of re-attempted on every request."""
+    router = make_router()
+    endpoint = EndpointInfo(url="http://engine1.com")
+
+    response = MagicMock()
+    response.json.return_value = {"tokens": [1, 2, 3]}
+
+    with (
+        patch.object(routing_logic, "AutoTokenizer") as at,
+        patch.object(routing_logic, "requests") as req,
+    ):
+        at.from_pretrained.side_effect = RuntimeError("huggingface.co unreachable")
+        req.post.return_value = response
+
+        for _ in range(3):
+            url = await router.route_request(
+                [endpoint], None, {}, Request(headers={}), {"prompt": "hi"}
+            )
+            assert url == endpoint.url
+
+    assert at.from_pretrained.call_count == 1
+    assert req.post.call_count == 3  # remote /tokenize fallback every time
+
+
+@pytest.mark.asyncio
+async def test_local_tokenizer_loaded_once_and_reused():
+    """Successful local tokenization caches the tokenizer (unchanged behavior)."""
+    router = make_router()
+    endpoint = EndpointInfo(url="http://engine1.com")
+
+    with (
+        patch.object(routing_logic, "AutoTokenizer") as at,
+        patch.object(routing_logic, "requests") as req,
+    ):
+        at.from_pretrained.return_value = FakeTokenizer()
+
+        for _ in range(2):
+            url = await router.route_request(
+                [endpoint], None, {}, Request(headers={}), {"prompt": "hi"}
+            )
+            assert url == endpoint.url
+
+    assert at.from_pretrained.call_count == 1
+    req.post.assert_not_called()

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -295,6 +295,9 @@ class KvawareRouter(RoutingInterface):
         self.session_key = session_key
         self.hash_ring = HashRing()
         self.tokenizer = None
+        # Set when the tokenizer load has failed once (e.g. alias model name or
+        # egress-blocked huggingface.co); skips retrying on every request.
+        self._tokenizer_load_failed = False
         self.threshold = kv_aware_threshold
 
     def start_kv_manager(self):
@@ -357,12 +360,22 @@ class KvawareRouter(RoutingInterface):
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         # TODO (Yuhan): Handle chat completions
         try:
-            if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
-                )
-            token_ids = self.tokenizer.encode(request_json.get("prompt", ""))
+            if not self._tokenizer_load_failed:
+                if self.tokenizer is None:
+                    # The load is network-bound (HF hub fetch) and can hang for
+                    # seconds; run it off the event loop so /health probes and
+                    # other requests stay responsive (#1016).
+                    self.tokenizer = await asyncio.to_thread(
+                        AutoTokenizer.from_pretrained,
+                        endpoints[0].model_names[0],
+                    )
+                token_ids = self.tokenizer.encode(request_json.get("prompt", ""))
         except Exception:
+            if self.tokenizer is None:
+                # Cache the doomed load as failed; otherwise it is retried (and
+                # re-blocks) on every single request (#1016).
+                self._tokenizer_load_failed = True
+        if token_ids is None:
             # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
             remote_url = endpoints[0].url + "/tokenize"
             headers = {"Content-Type": "application/json"}
@@ -370,8 +383,12 @@ class KvawareRouter(RoutingInterface):
                 "model": endpoints[0].model_names[0],
                 "prompt": request_json.get("prompt", ""),
             }
-            body = requests.post(
-                remote_url, headers=headers, json=data, timeout=10
+            # Offloaded for the same reason as the tokenizer load: this POST
+            # carries the full prompt and has a 10s timeout (#1016).
+            body = (
+                await asyncio.to_thread(
+                    requests.post, remote_url, headers=headers, json=data, timeout=10
+                )
             ).json()
             token_ids = body["tokens"]
 


### PR DESCRIPTION
Fixes #1016.

`KvawareRouter.route_request` performed blocking I/O on the uvicorn event loop for every routed request, starving `/health` probes and CrashLooping the router under sustained traffic (25 liveness-kills/hour in the reporter's deployment). Thanks @HipHoff for the downstream patch shape and @waynehacking8 for the lightweight repro — the fix follows both inputs.

## What changed (src/vllm_router/routers/routing_logic.py)

1. **Tokenizer load off the loop** — `AutoTokenizer.from_pretrained` (network-bound HF hub fetch, can hang for seconds with blocked egress) now runs via `asyncio.to_thread`.
2. **Fallback `/tokenize` POST off the loop** — the `requests.post` carrying the full prompt (10s timeout) now runs via `asyncio.to_thread`.
3. **Failed loads are cached** — new `_tokenizer_load_failed` flag: a doomed load (alias `--served-model-name`, egress-blocked huggingface.co) is attempted once, then the router goes straight to the remote `/tokenize` fallback. Previously only *successful* loads were cached, so doomed loads were retried — and re-blocked the loop — on every request.

Behavior is otherwise identical: local-first tokenization, remote fallback on any failure, errors from the fallback still bubble.

## Deliberately NOT changed: `query_manager`

The issue lists the controller lookup as a third blocking call. On current lmcache, `handle_orchestration_message` → [`kv_controller.lookup`](https://github.com/LMCache/LMCache/blob/main/lmcache/v1/cache_controller/controllers/kv_controller.py#L388) is an **in-memory registry read** (no ZMQ round-trip), so awaiting it does not block the loop. Moving it to an ad-hoc thread would risk racing the controller's own registry state, so it's left alone. Happy to revisit if maintainers see blocking there in their deployments.

## Tests

New `src/tests/test_kvaware_router_event_loop.py` (4 tests, all failing pre-fix except the characterization guard):

- `test_tokenizer_load_does_not_block_event_loop` — probe starved at 1 tick pre-fix
- `test_remote_tokenize_fallback_does_not_block_event_loop` — probe starved at 1 tick pre-fix
- `test_failed_tokenizer_load_is_not_retried_every_request` — `from_pretrained` called 3× pre-fix, 1× post-fix
- `test_local_tokenizer_loaded_once_and_reused` — unchanged behavior guard

Full `src/tests` suite: **116 passed**. `pre-commit` on changed files: black, isort, ruff, codespell all pass.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

Made with [Cursor](https://cursor.com)