### PR TITLE
[Doc] Fix references to non-existent tutorial values files

### DIFF
--- a/docs/source/use_cases/sharing-kv-cache.rst
+++ b/docs/source/use_cases/sharing-kv-cache.rst
@@ -28,7 +28,7 @@ Prerequisites
 Step 1: Configuring Remote KV Cache Storage
 --------------------------------------------
 
-Locate the file `tutorials/assets/values-06-remote-shared-storage.yaml <https://github.com/vllm-project/production-stack/blob/main/tutorials/assets/values-06-remote-shared-storage.yaml>`_ with the following content:
+Locate the file `tutorials/assets/values-06-shared-storage.yaml <https://github.com/vllm-project/production-stack/blob/main/tutorials/assets/values-06-shared-storage.yaml>`_ with the following content:
 
 .. code-block:: yaml
 

--- a/docs/source/use_cases/tool-enabled-installation.rst
+++ b/docs/source/use_cases/tool-enabled-installation.rst
@@ -58,7 +58,7 @@ Create a Kubernetes secret with your Hugging Face token:
 3.1: Use the Example Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We'll use the example configuration file located at ``tutorials/assets/values-08-tool-enabled.yaml``. This file contains all the necessary settings for enabling tool calling:
+We'll use the example configuration file located at ``tutorials/assets/values-13-tool-enabled.yaml``. This file contains all the necessary settings for enabling tool calling:
 
 .. code-block:: yaml
 
@@ -113,7 +113,7 @@ We'll use the example configuration file located at ``tutorials/assets/values-08
    helm repo add vllm https://vllm-project.github.io/production-stack
 
    # Deploy the vLLM stack with tool calling support using the example configuration
-   helm install vllm-tool vllm/vllm-stack -f tutorials/assets/values-08-tool-enabled.yaml
+   helm install vllm-tool vllm/vllm-stack -f tutorials/assets/values-13-tool-enabled.yaml
 
 The deployment will:
 

--- a/tutorials/06-remote-shared-kv-cache.md
+++ b/tutorials/06-remote-shared-kv-cache.md
@@ -23,7 +23,7 @@ vLLM Production Stack uses LMCache for remote KV cache sharing. For more details
 
 ## Step 1: Configuring KV Cache Shared Storage
 
-Locate the file [`tutorials/assets/values-06-remote-shared-storage.yaml`](assets/values-06-remote-shared-storage.yaml) with the following content:
+Locate the file [`tutorials/assets/values-06-shared-storage.yaml`](assets/values-06-shared-storage.yaml) with the following content:
 
 ```yaml
 servingEngineSpec:

--- a/tutorials/11-secure-vllm-serve.md
+++ b/tutorials/11-secure-vllm-serve.md
@@ -32,7 +32,7 @@ how to specify the model details, set up necessary environment variables (like
    - Write your actual vllmApiKey in `vllmApiKey: <YOUR VLLM API KEY>` in the
      yaml file.
 
-### Explanation of Key Items in `values-11-secure-vllm-serve.yaml`
+### Explanation of Key Items in `values-11-secure-vllm.yaml`
 
 - **`vllmApiKey`**: The api key to secure the model serving with vllm.
 - **`name`**: The unique identifier for your model deployment.
@@ -95,7 +95,7 @@ Deploy the configuration using Helm:
 
 ```bash
 helm repo add vllm https://vllm-project.github.io/production-stack
-helm install vllm vllm/vllm-stack -f tutorials/assets/values-11-secure-vllm-serve.yaml
+helm install vllm vllm/vllm-stack -f tutorials/assets/values-11-secure-vllm.yaml
 ```
 
 Expected output:

--- a/tutorials/13-tool-enabled-installation.md
+++ b/tutorials/13-tool-enabled-installation.md
@@ -53,7 +53,7 @@ kubectl create secret generic huggingface-credentials \
 
 #### 3.1: Use the Example Configuration
 
-We'll use the example configuration file located at `tutorials/assets/values-08-tool-enabled.yaml`. This file contains all the necessary settings for enabling tool calling:
+We'll use the example configuration file located at `tutorials/assets/values-13-tool-enabled.yaml`. This file contains all the necessary settings for enabling tool calling:
 
 ```yaml
 servingEngineSpec:
@@ -105,7 +105,7 @@ servingEngineSpec:
 helm repo add vllm https://vllm-project.github.io/production-stack
 
 # Deploy the vLLM stack with tool calling support using the example configuration
-helm install vllm-tool vllm/vllm-stack -f tutorials/assets/values-08-tool-enabled.yaml
+helm install vllm-tool vllm/vllm-stack -f tutorials/assets/values-13-tool-enabled.yaml
 ```
 
 The deployment will:


### PR DESCRIPTION
Three tutorials (and their `docs/source/use_cases/` mirrors) reference values files that do not exist under `tutorials/assets/`, so the documented `helm install -f ...` commands fail verbatim with `Error: open ...: no such file or directory`.

| Documented (wrong) | Actual file in `tutorials/assets/` |
|---|---|
| `values-08-tool-enabled.yaml` | `values-13-tool-enabled.yaml` |
| `values-11-secure-vllm-serve.yaml` | `values-11-secure-vllm.yaml` |
| `values-06-remote-shared-storage.yaml` | `values-06-shared-storage.yaml` |

Only the right-hand names exist in the repo. Notably, the secure-serve tutorial (`11`) and shared-storage tutorial (`06`) already use the correct name in Step 1, and only a later command / markdown link uses the wrong one — so this is a clear internal inconsistency.

Files touched: `tutorials/13-tool-enabled-installation.md`, `tutorials/11-secure-vllm-serve.md`, `tutorials/06-remote-shared-kv-cache.md`, `docs/source/use_cases/tool-enabled-installation.rst`, `docs/source/use_cases/sharing-kv-cache.rst`. Docs-only.