### PR TITLE
[Bugfix] Expose LMCache controller reply/heartbeat ports on the router Service

### DIFF
--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -168,7 +168,15 @@ spec:
           - name: "router-port"
             containerPort: {{ .Values.routerSpec.containerPort }}
           - name: "lmcache-port"
-            containerPort: 9000
+            containerPort: {{ .Values.routerSpec.lmcacheControllerPort | default 9000 }}
+          {{- if .Values.routerSpec.lmcacheControllerReplyPort }}
+          - name: "lmcache-reply"
+            containerPort: {{ .Values.routerSpec.lmcacheControllerReplyPort }}
+          {{- end }}
+          {{- if .Values.routerSpec.lmcacheControllerHeartbeatPort }}
+          - name: "lmcache-hbeat"
+            containerPort: {{ .Values.routerSpec.lmcacheControllerHeartbeatPort }}
+          {{- end }}
         {{- with .Values.routerSpec.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}

--- a/helm/templates/service-router.yaml
+++ b/helm/templates/service-router.yaml
@@ -21,9 +21,21 @@ spec:
       nodePort: {{ .Values.routerSpec.nodePort }}
       {{- end }}
     - name: "lmcache-port"
-      port: 9000
+      port: {{ .Values.routerSpec.lmcacheControllerPort | default 9000 }}
       targetPort: lmcache-port
       protocol: TCP
+    {{- if .Values.routerSpec.lmcacheControllerReplyPort }}
+    - name: "lmcache-reply"
+      port: {{ .Values.routerSpec.lmcacheControllerReplyPort }}
+      targetPort: lmcache-reply
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.routerSpec.lmcacheControllerHeartbeatPort }}
+    - name: "lmcache-hbeat"
+      port: {{ .Values.routerSpec.lmcacheControllerHeartbeatPort }}
+      targetPort: lmcache-hbeat
+      protocol: TCP
+    {{- end }}
   {{- include "chart.routerExtraPorts" $ | nindent 4 }}
   selector:
   {{- include "chart.routerStandardLabels" (dict "releaseName" .Release.Name "chartName" .Chart.Name) | nindent 4 }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -637,7 +637,7 @@
                     }
                 },
                 "lmcacheControllerHeartbeatPort": {
-                    "description": "lmcache controller heartbeat port. Enables workers to re-register with the controller after a router restart.",
+                    "description": "lmcache controller heartbeat port. Strongly recommended when routingLogic is \"kvaware\": without it, workers cannot re-register after a router restart, so KV-aware routing degrades to QPS routing until the engines are restarted too.",
                     "type": [
                         "integer",
                         "string"
@@ -651,7 +651,7 @@
                     ]
                 },
                 "lmcacheControllerReplyPort": {
-                    "description": "lmcache controller reply port. Engines are pointed at this port on the router Service (see LMCACHE_CONTROLLER_REPLY_URL), so setting it here is what opens it.",
+                    "description": "lmcache controller reply port. Required when routingLogic is \"kvaware\": engines are pointed at this port on the router Service (see LMCACHE_CONTROLLER_REPLY_URL), and worker registration blocks silently if it is not open.",
                     "type": [
                         "integer",
                         "string"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -636,8 +636,22 @@
                         }
                     }
                 },
+                "lmcacheControllerHeartbeatPort": {
+                    "description": "lmcache controller heartbeat port. Enables workers to re-register with the controller after a router restart.",
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
+                },
                 "lmcacheControllerPort": {
-                    "description": "lmcache controller port, used when routingLogic is \"kvaware\"",
+                    "description": "lmcache controller pull port, used when routingLogic is \"kvaware\"",
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
+                },
+                "lmcacheControllerReplyPort": {
+                    "description": "lmcache controller reply port. Engines are pointed at this port on the router Service (see LMCACHE_CONTROLLER_REPLY_URL), so setting it here is what opens it.",
                     "type": [
                         "integer",
                         "string"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -601,12 +601,14 @@ routerSpec:
   # -- lmcache controller pull port, used when routingLogic is "kvaware"
   lmcacheControllerPort: "" # @schema type:[integer, string]
 
-  # -- lmcache controller reply port. Engines are pointed at this port on the router
-  # Service (see LMCACHE_CONTROLLER_REPLY_URL), so setting it here is what opens it.
+  # -- lmcache controller reply port. Required when routingLogic is "kvaware": engines are
+  # pointed at this port on the router Service (see LMCACHE_CONTROLLER_REPLY_URL), and worker
+  # registration blocks silently if it is not open.
   lmcacheControllerReplyPort: "" # @schema type:[integer, string]
 
-  # -- lmcache controller heartbeat port. Enables workers to re-register with the
-  # controller after a router restart.
+  # -- lmcache controller heartbeat port. Strongly recommended when routingLogic is "kvaware":
+  # without it, workers cannot re-register after a router restart, so KV-aware routing degrades
+  # to QPS routing until the engines are restarted too.
   lmcacheControllerHeartbeatPort: "" # @schema type:[integer, string]
 
   # -- router resource requests and limits

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -598,8 +598,16 @@ routerSpec:
     # -- LMCache log level for the router deployment.
     logLevel: "INFO"
 
-  # -- lmcache controller port, used when routingLogic is "kvaware"
+  # -- lmcache controller pull port, used when routingLogic is "kvaware"
   lmcacheControllerPort: "" # @schema type:[integer, string]
+
+  # -- lmcache controller reply port. Engines are pointed at this port on the router
+  # Service (see LMCACHE_CONTROLLER_REPLY_URL), so setting it here is what opens it.
+  lmcacheControllerReplyPort: "" # @schema type:[integer, string]
+
+  # -- lmcache controller heartbeat port. Enables workers to re-register with the
+  # controller after a router restart.
+  lmcacheControllerHeartbeatPort: "" # @schema type:[integer, string]
 
   # -- router resource requests and limits
   resources:


### PR DESCRIPTION
## Description

The chart points the engines at a router Service port that the chart never opens, so KV-aware
routing fails **silently**.

Three templates disagree on `main` today:

| Template | What it does |
|---|---|
| `helm/templates/deployment-router.yaml` | launches the router with `--lmcache-controller-reply-port` / `--lmcache-controller-heartbeat-port` from `routerSpec.*` — so the router **listens** on them — but declares only a hardcoded `containerPort: 9000` |
| `helm/templates/deployment-vllm-multi.yaml` | sets `LMCACHE_CONTROLLER_REPLY_URL={{ .Release.Name }}-router-service:{{ controllerReplyPort }}` — so every engine is **told to connect** there |
| `helm/templates/service-router.yaml` | exposes port `9000` only |

Worker registration then blocks inside ZMQ with **no error on either side**: no exception, no log
line, and `lookup()` simply returns nothing — so `kvaware` degenerates to QPS routing while the
deployment looks healthy. It took us a while to find, because every surface reports success.

This also fixes the pull port itself: both the `containerPort` and the Service port were
hardcoded to `9000` and ignored `routerSpec.lmcacheControllerPort`, so any non-default value
pointed the Service at a port the router was not listening on.

Finally, `lmcacheControllerReplyPort` and `lmcacheControllerHeartbeatPort` were already read by
`deployment-router.yaml` but were undocumented in `values.yaml`. Both are now documented, and
`values.schema.json` is updated to match.

## Backward compatibility

Each port renders **only when its value is set**, so charts that do not configure the controller
are untouched. Verified:

```console
$ helm template test ./helm > before.yaml   # on main
$ helm template test ./helm > after.yaml    # with this PR
$ diff before.yaml after.yaml && echo IDENTICAL
IDENTICAL
```

With the ports configured:

```yaml
routerSpec:
  routingLogic: "kvaware"
  lmcacheControllerPort: 9000
  lmcacheControllerReplyPort: 9001
  lmcacheControllerHeartbeatPort: 9002
```

the router Service now renders:

```yaml
  ports:
    - name: "router-sport"
      port: 80
      targetPort: 8000
      protocol: TCP
    - name: "lmcache-port"
      port: 9000
      targetPort: lmcache-port
      protocol: TCP
    - name: "lmcache-reply"
      port: 9001
      targetPort: lmcache-reply
      protocol: TCP
    - name: "lmcache-hbeat"
      port: 9002
      targetPort: lmcache-hbeat
      protocol: TCP
```

with matching named `containerPort`s on the router Deployment. (`lmcache-hbeat` rather than
`lmcache-heartbeat` because Kubernetes port names are limited to 15 characters.)

## How this was found

Deploying the KV-aware setup on a 2×A10 OpenShift cluster. The symptom was that `kvaware`
routing appeared to work but never showed cache affinity. We worked around it with
`oc patch svc ... --type=json` adding the two ports, which confirmed the diagnosis, and are
sending the proper fix upstream.

`helm lint` passes; `values.schema.json` regenerated to match `values.yaml`.

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using `-s` when doing `git commit`
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.