### PR TITLE
[CI/Build] Extend Helm validation timeouts

### DIFF
--- a/.github/workflows/functionality-helm-chart.yml
+++ b/.github/workflows/functionality-helm-chart.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Validate the installation and send query to the stack
         run: |
           bash tests/scripts/port-forward.sh curl-05-secure-vllm
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Archive functionality results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
@@ -123,7 +123,7 @@ jobs:
       - name: Validate the installation and send query to the stack
         run: |
           bash tests/scripts/port-forward.sh curl-02-two-pods
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Archive functionality results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()


### PR DESCRIPTION
## Summary

- extend the `Secure-Minimal-Example` validation timeout from 3 to 5 minutes
- extend the `Two-Pods-Minimal-Example` validation timeout from 3 to 5 minutes
- keep a bounded timeout and align both jobs with the existing 5-minute `Multiple-Models` validation

## Why

I reviewed the latest 50 pull requests, including merged PRs, and compared workflow attempts on unchanged head SHAs. After excluding successful administrative reruns and cancellations, 8 workflows had a failure-to-success transition; the Helm functionality workflow accounted for 5 of them.

Within those failed Helm attempts, the 3-minute validation deadline caused 6 failures across PRs #971, #1021, #1024, and #1027:

- `Secure-Minimal-Example` hit the 3-minute deadline 4 times while waiting for the model pod to become ready. In one recent run the pod was still `ContainerCreating` at 2:58 and only reached `Running` after 3 minutes.
- `Two-Pods-Minimal-Example` hit the deadline twice even though the request had already succeeded. In both recent examples, the log printed `Requests were successful.` and the step timed out a few seconds later.

Representative failures:

- https://github.com/vllm-project/production-stack/actions/runs/30885123286/job/92121320465
- https://github.com/vllm-project/production-stack/actions/runs/30885123286/job/92123683153
- https://github.com/vllm-project/production-stack/actions/runs/30405405710/job/90967843492
- https://github.com/vllm-project/production-stack/actions/runs/30385989478/job/90370681221

Each workflow later passed on the same head SHA. Giving these two validations the same 5-minute budget already used by `Multiple-Models` absorbs observed startup variance without retrying commands or ignoring failures. Command failures still exit immediately, and a hung deployment remains bounded.

## Validation

- `pre-commit run --files .github/workflows/functionality-helm-chart.yml`
- `git diff --check`

