### PR TITLE
[CI/Build] Clean up timed-out K8s E2E runs and fail fast on backend exits

### DIFF
--- a/.github/workflows/router-e2e-test.yml
+++ b/.github/workflows/router-e2e-test.yml
@@ -144,6 +144,15 @@ jobs:
             --timeout 20
         timeout-minutes: 20
 
+      - name: Cleanup k8s discovery resources
+        if: always()
+        run: |
+          if helm status vllm >/dev/null 2>&1; then
+            helm uninstall vllm --wait
+          else
+            echo "No vllm Helm release found; skipping cleanup."
+          fi
+
       - name: Archive k8s discovery routing test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()

--- a/.github/workflows/router-e2e-test.yml
+++ b/.github/workflows/router-e2e-test.yml
@@ -189,13 +189,24 @@ jobs:
           echo "🚀 Starting vLLM serve backend"
           mkdir -p "$LOG_DIR"
           CUDA_VISIBLE_DEVICES=0 vllm serve facebook/opt-125m --port 8001 --gpu-memory-utilization 0.7 --chat-template tests/assets/template-chatml.jinja > "$LOG_DIR/backend1.log" 2>&1 &
+          backend_1_pid=$!
+          echo "STATIC_BACKEND_1_PID=$backend_1_pid" >> "$GITHUB_ENV"
           CUDA_VISIBLE_DEVICES=1 vllm serve facebook/opt-125m --port 8002 --gpu-memory-utilization 0.7 --chat-template tests/assets/template-chatml.jinja > "$LOG_DIR/backend2.log" 2>&1 &
+          backend_2_pid=$!
+          echo "STATIC_BACKEND_2_PID=$backend_2_pid" >> "$GITHUB_ENV"
 
       - name: Wait for backends to be ready
         run: |
           echo "⏳ Waiting for backends to be ready"
           chmod +x tests/e2e/wait-for-backends.sh
-          ./tests/e2e/wait-for-backends.sh 180 "http://localhost:8001" "http://localhost:8002"
+          ./tests/e2e/wait-for-backends.sh \
+            180 \
+            "http://localhost:8001" \
+            "http://localhost:8002" \
+            "$STATIC_BACKEND_1_PID" \
+            "$STATIC_BACKEND_2_PID" \
+            "$LOG_DIR/backend1.log" \
+            "$LOG_DIR/backend2.log"
 
       - name: Run All Static Discovery Routing Tests
         run: |

--- a/tests/e2e/wait-for-backends.sh
+++ b/tests/e2e/wait-for-backends.sh
@@ -6,14 +6,46 @@ echo "⏳ Waiting for backends to be ready"
 timeout=${1:-120}
 backend1=${2:-"http://localhost:8001"}
 backend2=${3:-"http://localhost:8002"}
+backend1_pid=${4:-}
+backend2_pid=${5:-}
+backend1_log=${6:-}
+backend2_log=${7:-}
+
+print_backend_log() {
+    local backend_name=$1
+    local log_file=$2
+
+    if [ -n "$log_file" ] && [ -f "$log_file" ]; then
+        echo "Last 50 lines from ${backend_name} log (${log_file}):"
+        tail -n 50 "$log_file"
+    fi
+}
+
+check_backend_process() {
+    local backend_name=$1
+    local backend_pid=$2
+    local log_file=$3
+
+    if [ -n "$backend_pid" ] && ! kill -0 "$backend_pid" 2>/dev/null; then
+        echo "❌ ${backend_name} process exited before becoming reachable"
+        print_backend_log "$backend_name" "$log_file"
+        return 1
+    fi
+}
+
 start_time=$(date +%s)
 echo "⏳ Waiting for backends to become reachable..."
 while true; do
     current_time=$(date +%s)
     elapsed=$((current_time - start_time))
 
+    check_backend_process "Backend 1" "$backend1_pid" "$backend1_log" || exit 1
+    check_backend_process "Backend 2" "$backend2_pid" "$backend2_log" || exit 1
+
     if [ $elapsed -ge "$timeout" ]; then
         echo "❌ Backends failed to become reachable after ${timeout} seconds"
+        print_backend_log "Backend 1" "$backend1_log"
+        print_backend_log "Backend 2" "$backend2_log"
         exit 1
     fi
 

--- a/tests/e2e/wait-for-backends.sh
+++ b/tests/e2e/wait-for-backends.sh
@@ -17,8 +17,9 @@ print_backend_log() {
 
     if [ -n "$log_file" ] && [ -f "$log_file" ]; then
         echo "Last 50 lines from ${backend_name} log (${log_file}):"
-        tail -n 50 "$log_file"
+        tail -n 50 "$log_file" || true
     fi
+    return 0
 }
 
 check_backend_process() {
@@ -31,6 +32,7 @@ check_backend_process() {
         print_backend_log "$backend_name" "$log_file"
         return 1
     fi
+    return 0
 }
 
 start_time=$(date +%s)


### PR DESCRIPTION
## Summary
In several recent PRs, a timed-out K8s E2E test could leave GPU pods running, causing the subsequent static-discovery job to fail due to insufficient GPU memory. The job then continued polling the unreachable backends even though their processes had already exited.
A representative example is PR #1027, attempt 2:
  - [K8s discovery test timed out](https://github.com/vllm-project/production-stack/actions/runs/30682282854/job/91628930623)
  - [Static backends subsequently failed to start because of insufficient GPU memory](https://github.com/vllm-project/production-stack/actions/runs/30682282854/job/91628930664)
  - [Static backend logs](https://github.com/vllm-project/production-stack/actions/runs/30682282854/artifacts/8849598894)

This PR improves failure handling and observability in the router E2E workflow: 

- always uninstall the K8s discovery Helm release after the test step, including when the step times out.

- track the two static backend processes while waiting for them to become reachable, fail immediately if either backend exits during startup.

- print the last 50 lines of the relevant backend log.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
