### PR TITLE
[CI/Build] Increase Secure-Minimal-Example validation timeout to 10 minutes

### DIFF
--- a/.github/workflows/functionality-helm-chart.yml
+++ b/.github/workflows/functionality-helm-chart.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Validate the installation and send query to the stack
         run: |
           bash tests/scripts/port-forward.sh curl-05-secure-vllm
-        timeout-minutes: 3
+        timeout-minutes: 10
       - name: Archive functionality results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()


### PR DESCRIPTION
Increase the Secure-Minimal-Example validation step timeout from 3 to 10 minutes to reduce flaky CI failures.