### PR TITLE
[Router][Bugfix] prefixaware: accept token-id prompts

### DIFF
--- a/src/tests/test_prefixaware_router.py
+++ b/src/tests/test_prefixaware_router.py
@@ -190,3 +190,68 @@ async def test_default_threshold_zero_preserves_original_behavior():
     assert url == "http://engine1.com"
 
     fake_hashtrie.insert.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "prompt, expected_key",
+    [
+        pytest.param([1, 2, 3], "1,2,3", id="token-ids"),
+        pytest.param([[1, 2], [3]], "1,2 3", id="token-id-batch"),
+        pytest.param(["a", "b"], "a b", id="string-list"),
+        pytest.param("plain text", "plain text", id="string"),
+        pytest.param([], "", id="empty-list"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_route_accepts_token_id_prompts(prompt, expected_key):
+    """
+    /v1/completions accepts token ids as well as text, so `prompt` may be
+    list[int] or list[list[int]]. HashTrie slices the prompt by characters and
+    hashes each slice with xxhash, which raises TypeError on a list and fails
+    the request. The prompt must be normalized to a string first.
+    """
+
+    endpoints = [EndpointInfo(url="http://engine1.com")]
+    request = Request(headers={})
+    request_json = {"prompt": prompt}
+
+    router = PrefixAwareRouter()
+
+    fake_hashtrie = AsyncMock()
+    fake_hashtrie.longest_prefix_match.return_value = (0, {"http://engine1.com"})
+    router.hashtrie = fake_hashtrie
+
+    url = await router.route_request(endpoints, None, {}, request, request_json)
+
+    assert url == "http://engine1.com"
+    # The trie must see a string, and the same one on both lookup and insert.
+    fake_hashtrie.longest_prefix_match.assert_awaited_once()
+    assert fake_hashtrie.longest_prefix_match.await_args.args[0] == expected_key
+    fake_hashtrie.insert.assert_awaited_once_with(expected_key, "http://engine1.com")
+
+
+@pytest.mark.asyncio
+async def test_token_id_prompts_preserve_prefix_affinity():
+    """
+    Normalizing token ids must not flatten distinct prompts onto one key, and
+    a shared token prefix must still yield a shared character prefix so the
+    real (unmocked) HashTrie routes a continuation back to the same endpoint.
+    """
+    from vllm_router.prefix.hashtrie import HashTrie
+
+    endpoints = [
+        EndpointInfo(url="http://engine1.com"),
+        EndpointInfo(url="http://engine2.com"),
+    ]
+    request = Request(headers={})
+    router = PrefixAwareRouter()
+    router.hashtrie = HashTrie(chunk_size=4)
+
+    shared = list(range(1000, 1100))
+    first = await router.route_request(endpoints, None, {}, request, {"prompt": shared})
+    # Same session, one more turn: strictly extends the token prefix.
+    second = await router.route_request(
+        endpoints, None, {}, request, {"prompt": shared + [1100, 1101]}
+    )
+
+    assert second == first

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -89,6 +89,33 @@ def _loadaware_beta(override: Optional[float]) -> float:
         return DEFAULT_LOADAWARE_BETA
 
 
+def _prompt_to_trie_key(prompt) -> str:
+    """Normalize a `/v1/completions` prompt into a string for `HashTrie`.
+
+    The OpenAI completions API accepts token ids as well as text: `prompt` may
+    be `str`, `list[str]`, `list[int]`, or `list[list[int]]`. `HashTrie` slices
+    the value by characters and feeds each slice to `xxhash`, so anything that
+    is not a string raises `TypeError` and fails the request.
+
+    Rendering token ids to a stable decimal string keeps the trie's algorithm
+    unchanged -- prompts sharing a token prefix still share a character prefix,
+    so prefix affinity works as intended, only the alphabet differs.
+    """
+    if isinstance(prompt, str):
+        return prompt
+    if isinstance(prompt, list):
+        if not prompt:
+            return ""
+        # list[list[int]]: a batch of token-id sequences.
+        if isinstance(prompt[0], list):
+            return " ".join(",".join(str(t) for t in seq) for seq in prompt)
+        # list[str]: already text. list[int]: token ids.
+        if isinstance(prompt[0], str):
+            return " ".join(prompt)
+        return ",".join(str(t) for t in prompt)
+    return str(prompt)
+
+
 class RoutingInterface(metaclass=SingletonABCMeta):
     def _qps_routing(
         self, endpoints: List[EndpointInfo], request_stats: Dict[str, RequestStats]
@@ -809,7 +836,7 @@ class PrefixAwareRouter(RoutingInterface):
                 prompt = ""
         else:
             # Handle regular completions
-            prompt = request_json["prompt"]
+            prompt = _prompt_to_trie_key(request_json["prompt"])
 
         available_endpoints = set(endpoint.url for endpoint in endpoints)
         match_length, matched_endpoint = await self.hashtrie.longest_prefix_match(


### PR DESCRIPTION
### Summary

`--routing-logic prefixaware` returns a 500 for any `/v1/completions` request that sends **token ids** instead of text.

The OpenAI completions API accepts `prompt` as `str`, `list[str]`, `list[int]` or `list[list[int]]`. `PrefixAwareRouter.route_request` passes the raw value to `HashTrie`, which slices it by characters and hashes each slice:

```python
# src/vllm_router/prefix/hashtrie.py
for i in range(0, len(request), self.chunk_size):
    yield xxhash.xxh64(request[i : i + self.chunk_size]).intdigest()
```

For a list, `request[i:i+chunk_size]` is a *sublist*, and xxhash raises `TypeError: unicode/bytes-like object expected`. The exception propagates out of routing and the request fails.

### Reproduce on `main`

```bash
vllm-router --routing-logic prefixaware --service-discovery static \
            --static-backends http://127.0.0.1:8000 --static-models <model>

curl -s http://127.0.0.1:8000/v1/completions \
     -H 'Content-Type: application/json' \
     -d '{"model":"<model>","prompt":[1,2,3,4],"max_tokens":1}'
# -> 500; router log shows TypeError at hashtrie.py:57
```

The same request succeeds with `--routing-logic roundrobin`, so it is specific to the prefix-aware path.

### Fix

Normalize the prompt to a string before it reaches the trie (`_prompt_to_trie_key`). The routing algorithm is unchanged — prompts sharing a token prefix still share a character prefix, so prefix affinity behaves as before, only the alphabet differs. `list[str]` is joined rather than `str()`-ified so existing text batches keep matching exactly as they do today.

There is precedent for this normalization: SGLang's model gateway renders token-id input to a space-joined decimal string for its own routing decisions on the native `/generate` endpoint (`openai-protocol`, `generate.rs`, `extract_text_for_routing`). Hashing a rendering of the ids is not as good as hashing the ids themselves, but it preserves prefix structure, which is all the character-chunked trie needs.

### Test plan

```bash
pytest src/tests/test_prefixaware_router.py -q
```

Six new cases. Five of them fail on `main` with the `TypeError` above:

| case | on `main` | with fix |
|---|---|---|
| `token-ids` (`[1,2,3]`) | TypeError | pass |
| `token-id-batch` (`[[1,2],[3]]`) | TypeError | pass |
| `string-list` (`["a","b"]`) | TypeError | pass |
| `empty-list` (`[]`) | TypeError | pass |
| `string` (unchanged path) | pass | pass |
| prefix affinity over real `HashTrie` | TypeError | pass |

The last one is not a mock: it drives the real `HashTrie` with a token-id prompt and then a continuation of it, asserting the continuation routes back to the endpoint that served the prefix. That is what guards the "affinity still works after normalization" claim rather than just "it no longer crashes".

### Test result

```
$ pytest src/tests/test_prefixaware_router.py -q
..........                    [100%]
10 passed

$ pytest src/tests/ -q --ignore=src/tests/perftest --ignore=src/tests/external_providers
153 passed
```

`black`, `isort`, `ruff` and `codespell` clean on both changed files.
