### PR TITLE
[Doc] Document loading local and offline models

### DIFF
--- a/tutorials/03-load-model-from-pv.md
+++ b/tutorials/03-load-model-from-pv.md
@@ -145,6 +145,7 @@ Populate the PV backing directory before installing the chart. Run the following
 sudo mkdir -p /data/llama3/Llama-3.1-8B-Instruct
 sudo cp -a /path/to/downloaded/Llama-3.1-8B-Instruct/. \
   /data/llama3/Llama-3.1-8B-Instruct/
+sudo chmod -R a+rX /data/llama3/Llama-3.1-8B-Instruct
 test -f /data/llama3/Llama-3.1-8B-Instruct/config.json
 ```
 

--- a/tutorials/03-load-model-from-pv.md
+++ b/tutorials/03-load-model-from-pv.md
@@ -1,156 +1,318 @@
-# Tutorial: Loading Model Weights from Persistent Volume
+# Tutorial: Loading Model Weights from Persistent Volumes
 
 ## Introduction
 
-In this tutorial, you will learn how to load a model from a Persistent Volume (PV) in Kubernetes to optimize deployment performance. The steps include creating a PV, matching it using `pvcMatchLabels`, and deploying the Helm chart to utilize the PV. You will also verify the setup by examining the contents and measuring performance improvements.
+A Persistent Volume (PV) can be used with vLLM Production Stack in two different ways:
+
+1. **Persist the Hugging Face cache:** vLLM downloads a model from Hugging Face on the first start and reuses the cached files on later starts.
+2. **Serve a pre-downloaded model offline:** model files are placed in the PV before deployment, and vLLM starts directly from their local path without downloading them.
+
+This tutorial demonstrates both workflows. In either workflow, the chart mounts the model volume at `/data` inside the serving-engine container.
 
 ## Table of Contents
 
 1. [Prerequisites](#prerequisites)
-2. [Step 1: Creating a Persistent Volume](#step-1-creating-a-persistent-volume)
-3. [Step 2: Deploying with Helm Using the PV](#step-2-deploying-with-helm-using-the-pv)
-4. [Step 3: Verifying the Deployment](#step-3-verifying-the-deployment)
+2. [Create a Persistent Volume](#create-a-persistent-volume)
+3. [Workflow A: Persist the Hugging Face Cache](#workflow-a-persist-the-hugging-face-cache)
+4. [Workflow B: Serve a Pre-Downloaded Model Offline](#workflow-b-serve-a-pre-downloaded-model-offline)
+5. [Use an Existing Persistent Volume Claim](#use-an-existing-persistent-volume-claim)
+6. [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
 - A running Kubernetes cluster with GPU support.
-- Completion of previous tutorials:
-  - [00-install-kubernetes-env.md](00-install-kubernetes-env.md)
-  - [01-minimal-helm-installation.md](01-minimal-helm-installation.md)
-  - [02-basic-vllm-config.md](02-basic-vllm-config.md)
-- Basic understanding of Kubernetes PV and PVC concepts.
+- Completion of the previous tutorials:
+  - [Install Kubernetes Environment](00-install-kubernetes-env.md)
+  - [Minimal Helm Installation](01-minimal-helm-installation.md)
+  - [Basic vLLM Configuration](02-basic-vllm-config.md)
+- Basic knowledge of Kubernetes PVs and Persistent Volume Claims (PVCs).
+- For the offline workflow, a complete model directory in a format supported by vLLM. A Hugging Face-format model normally contains `config.json`, tokenizer files, and all referenced weight shards.
 
-## Step 1: Creating a Persistent Volume
+## Create a Persistent Volume
 
-1. Locate the persistent Volume manifest file at [`tutorials/assets/pv-03.yaml`](assets/pv-03.yaml) with the following content:
+The example PV is defined in [`tutorials/assets/pv-03.yaml`](assets/pv-03.yaml):
 
-   ```yaml
-   apiVersion: v1
-   kind: PersistentVolume
-   metadata:
-     name: test-vllm-pv
-     labels:
-       model: "llama3-pv"
-   spec:
-     capacity:
-       storage: 50Gi
-     accessModes:
-       - ReadWriteOnce
-     persistentVolumeReclaimPolicy: Retain
-     storageClassName: standard
-     hostPath:
-       path: /data/llama3
-   ```
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-vllm-pv
+  labels:
+    model: "llama3-pv"
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard
+  hostPath:
+    path: /data/llama3
+```
 
-   > **Note:** You can change the path specified in the `hostPath` field to any valid directory on your Kubernetes node.
+Apply it and confirm that it is available:
 
-2. Apply the manifest:
+```bash
+kubectl apply -f tutorials/assets/pv-03.yaml
+kubectl get pv test-vllm-pv
+```
 
-   ```bash
-   kubectl apply -f tutorials/assets/pv-03.yaml
-   ```
+Expected status before Helm creates the matching PVC:
 
-3. Verify the PV is created:
+```text
+NAME           CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      STORAGECLASS
+test-vllm-pv   50Gi       RWO            Retain           Available   standard
+```
 
-   ```bash
-   kubectl get pv
-   ```
+> [!WARNING]
+> `hostPath` refers to one Kubernetes node. It is useful for a controlled single-node development example, but it is not shared storage. For production or multi-node deployments, use storage accessible from every eligible node, or constrain the serving pod to the node that contains the files.
 
-   Expected output:
+## Workflow A: Persist the Hugging Face Cache
 
-   ```plaintext
-   NAME           CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   AGE
-   test-vllm-pv   50Gi       RWO            Retain           Available           standard       2m
-   ```
+This workflow lets vLLM download the model on its first start. Because the chart sets `HF_HOME=/data` when model PVC storage is configured, the Hugging Face cache is written to the PV and reused by later pods.
 
-## Step 2: Deploying with Helm Using the PV
+### Deploy the online example
 
-1. Locate the example values file at [`tutorials/assets/values-03-match-pv.yaml`](assets/values-03-match-pv.yaml) with the following content:
+The existing values file [`tutorials/assets/values-03-match-pv.yaml`](assets/values-03-match-pv.yaml) selects the PV by label:
 
-   ```yaml
-   servingEngineSpec:
-     modelSpec:
-     - name: "llama3"
-       repository: "vllm/vllm-openai"
-       tag: "latest"
-       modelURL: "meta-llama/Llama-3.1-8B-Instruct"
-       replicaCount: 1
+```yaml
+servingEngineSpec:
+  runtimeClassName: ""
+  modelSpec:
+  - name: "llama3"
+    repository: "vllm/vllm-openai"
+    tag: "latest"
+    modelURL: "meta-llama/Llama-3.1-8B-Instruct"
+    replicaCount: 1
 
-       requestCPU: 10
-       requestMemory: "16Gi"
-       requestGPU: 1
+    requestCPU: 10
+    requestMemory: "16Gi"
+    requestGPU: 1
 
-       pvcStorage: "50Gi"
-       pvcMatchLabels:
-         model: "llama3-pv"
+    pvcStorage: "50Gi"
+    pvcAccessMode:
+      - ReadWriteOnce
+    pvcMatchLabels:
+      model: "llama3-pv"
 
-       vllmConfig:
-         maxModelLen: 4096
+    vllmConfig:
+      maxModelLen: 4096
 
-       hf_token: <YOUR HF TOKEN>
-   ```
+    hf_token: <YOUR HF TOKEN>
+```
 
-   > **Explanation:** The `pvcMatchLabels` field specifies the labels to match an existing Persistent Volume. In this example, it ensures that the deployment uses the PV with the label `model: "llama3-pv"`. This provides a way to link a specific PV to your application.
+Replace `<YOUR HF TOKEN>`, then install the chart:
 
-   > **Note:** Make sure to replace `<YOUR_HF_TOKEN>` with your actual Hugging Face token in the yaml.
+```bash
+helm install vllm vllm/vllm-stack \
+  -f tutorials/assets/values-03-match-pv.yaml
+```
 
-2. Deploy the Helm chart:
+Confirm that the generated PVC is bound to the example PV:
 
-   ```bash
-   helm install vllm vllm/vllm-stack -f tutorials/assets/values-03-match-pv.yaml
-   ```
+```bash
+kubectl get pv test-vllm-pv
+kubectl get pvc vllm-llama3-storage-claim
+```
 
-3. Verify the deployment:
+After the model is downloaded, the PV backing directory contains the Hugging Face cache. For the example `hostPath`, inspect it on the Kubernetes node:
 
-   ```bash
-   kubectl get pods
-   ```
+```bash
+sudo ls /data/llama3/hub
+```
 
-   Expected output:
+A later serving pod can reuse this cache instead of downloading every model file again.
 
-   ```plaintext
-   NAME                                             READY   STATUS    RESTARTS   AGE
-   vllm-deployment-router-xxxx-xxxx             1/1     Running   0          1m
-   vllm-llama3-deployment-vllm-xxxx-xxxx        1/1     Running   0          1m
-   ```
+## Workflow B: Serve a Pre-Downloaded Model Offline
 
-## Step 3: Verifying the Deployment
+This workflow starts vLLM directly from model files that already exist in the PV. It does not use a Hugging Face repository ID at startup.
 
-1. Check the contents of the host directory:
+### Understand the node path and container path
 
-   - If using a standard Kubernetes node:
+`modelURL` is evaluated **inside the serving-engine container**. It must not point to an unmounted path on the Kubernetes node.
 
-     ```bash
-     sudo ls /data/llama3
-     ```
+The example PV root is `/data/llama3` on the node, while the chart mounts that root at `/data` in the container. Therefore these paths identify the same directory:
 
-   - If using Minikube, access the Minikube VM and check the path:
+| Location | Model directory |
+| --- | --- |
+| Kubernetes node | `/data/llama3/Llama-3.1-8B-Instruct` |
+| Serving container | `/data/Llama-3.1-8B-Instruct` |
+| `modelURL` value | `/data/Llama-3.1-8B-Instruct` |
 
-     ```bash
-     minikube ssh
-     ls /data/llama3/hub
-     ```
+Populate the PV backing directory before installing the chart. Run the following on the node that owns the example `hostPath`, replacing the source path with your downloaded model directory:
 
-   Expected output:
+```bash
+sudo mkdir -p /data/llama3/Llama-3.1-8B-Instruct
+sudo cp -a /path/to/downloaded/Llama-3.1-8B-Instruct/. \
+  /data/llama3/Llama-3.1-8B-Instruct/
+test -f /data/llama3/Llama-3.1-8B-Instruct/config.json
+```
 
-   You should see the model files loaded into the directory:
+For other storage providers, use the provider's supported method to populate the volume before deployment.
 
-   ```plaintext
-   models--meta-llama--Llama-3.1-8B-Instruct  version.txt
-   ```
+### Deploy the offline example
 
-2. Uninstall and reinstall the deployment to observe faster startup:
+Use [`tutorials/assets/values-03-local-model.yaml`](assets/values-03-local-model.yaml):
 
-   ```bash
-   helm uninstall vllm
-   kubectl delete -f tutorials/assets/pv-03.yaml && kubectl apply -f tutorials/assets/pv-03.yaml
-   helm install vllm vllm/vllm-stack -f tutorials/assets/values-03-match-pv.yaml
-   ```
+```yaml
+servingEngineSpec:
+  runtimeClassName: ""
+  modelSpec:
+  - name: "llama3-local"
+    repository: "vllm/vllm-openai"
+    tag: "latest"
+    modelURL: "/data/Llama-3.1-8B-Instruct"
+    replicaCount: 1
 
-### Explanation
+    requestCPU: 10
+    requestMemory: "16Gi"
+    requestGPU: 1
 
-- During the second installation, the serving engine starts faster because the model files are already loaded into the Persistent Volume.
+    pvcStorage: "50Gi"
+    pvcAccessMode:
+      - ReadWriteOnce
+    pvcMatchLabels:
+      model: "llama3-pv"
+
+    vllmConfig:
+      maxModelLen: 4096
+
+    env:
+      - name: HF_HUB_OFFLINE
+        value: "1"
+      - name: TRANSFORMERS_OFFLINE
+        value: "1"
+```
+
+The offline environment variables prevent an accidental network fallback. No `hf_token` is required when the PV already contains every required file.
+
+Install the chart:
+
+```bash
+helm install vllm vllm/vllm-stack \
+  -f tutorials/assets/values-03-local-model.yaml
+```
+
+Confirm that the PVC selected the expected PV:
+
+```bash
+kubectl get pv test-vllm-pv
+kubectl get pvc vllm-llama3-local-storage-claim
+```
+
+Confirm that the exact path passed as `modelURL` and its metadata are visible in the container:
+
+```bash
+ENGINE_POD=$(kubectl get pods \
+  -l model=llama3-local,helm-release-name=vllm \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl exec "$ENGINE_POD" -c vllm -- \
+  test -f /data/Llama-3.1-8B-Instruct/config.json
+kubectl exec "$ENGINE_POD" -c vllm -- \
+  ls -la /data/Llama-3.1-8B-Instruct
+```
+
+Check the serving-engine logs. The vLLM command and loading messages should reference the local `/data/...` path:
+
+```bash
+kubectl logs "$ENGINE_POD" -c vllm
+```
+
+Finally, forward the router service and verify that the model is advertised:
+
+```bash
+kubectl port-forward service/vllm-router-service 8000:80
+```
+
+In another terminal:
+
+```bash
+curl -s http://localhost:8000/v1/models | jq
+```
+
+## Use an Existing Persistent Volume Claim
+
+If the model is already stored in a PVC managed outside this chart, set `pvcExistingClaimName`. The chart mounts the existing claim at `/data` and does not create another PVC:
+
+```yaml
+servingEngineSpec:
+  modelSpec:
+  - name: "llama3-local"
+    repository: "vllm/vllm-openai"
+    tag: "latest"
+    modelURL: "/data/Llama-3.1-8B-Instruct"
+
+    # pvcStorage enables the model volume. It does not resize the existing PVC.
+    pvcStorage: "50Gi"
+    pvcExistingClaimName: "my-preloaded-model-pvc"
+
+    env:
+      - name: HF_HUB_OFFLINE
+        value: "1"
+      - name: TRANSFORMERS_OFFLINE
+        value: "1"
+```
+
+The existing PVC must be in the same namespace as the Helm release. Its access mode and storage backend must also permit access from every node on which the serving pod can be scheduled.
+
+## Troubleshooting
+
+### `Invalid repository ID or local directory`
+
+This error usually means `modelURL` is neither a valid repository ID nor a valid directory inside the container.
+
+- Use the container path, such as `/data/Llama-3.1-8B-Instruct`, not the node path `/data/llama3/Llama-3.1-8B-Instruct`.
+- Confirm that the directory exists in the `vllm` container.
+- Confirm that `config.json` is directly inside the directory specified by `modelURL`.
+
+### Files exist on the node but not in the container
+
+Check that the PVC is bound to the intended PV:
+
+```bash
+kubectl get pv test-vllm-pv
+kubectl get pvc vllm-llama3-local-storage-claim -o wide
+kubectl describe pvc vllm-llama3-local-storage-claim
+```
+
+Also inspect the pod's volumes and mounts:
+
+```bash
+kubectl describe pod "$ENGINE_POD"
+```
+
+If the pod is running on a different node, a `hostPath` on the original node is not visible there. Use shared storage or constrain pod placement.
+
+### The model is nested one directory deeper than expected
+
+List the mounted directory:
+
+```bash
+kubectl exec "$ENGINE_POD" -c vllm -- find /data -maxdepth 3 -name config.json
+```
+
+Set `modelURL` to the directory that directly contains the correct `config.json`. For example, if the command prints `/data/models/Llama-3.1-8B-Instruct/config.json`, use:
+
+```yaml
+modelURL: "/data/models/Llama-3.1-8B-Instruct"
+```
+
+### The model directory is incomplete
+
+A `config.json` file alone is not sufficient. Ensure the directory also contains the tokenizer assets, model weights, and every shard referenced by the model's index files. Re-run the original download or copy operation if files are missing.
+
+### The serving pod cannot be inspected because it restarts
+
+Read the previous container logs and inspect its volume configuration:
+
+```bash
+kubectl logs "$ENGINE_POD" -c vllm --previous
+kubectl describe pod "$ENGINE_POD"
+```
+
+Local-path and missing-file errors near startup normally identify the path or file that needs correction.
 
 ## Conclusion
 
-In this tutorial, you learned how to utilize a Persistent Volume to store model weights for a vLLM serving engine. This approach optimizes deployment performance and demonstrates the benefits of Kubernetes storage resources. Continue exploring advanced configurations in future tutorials.
+A PV can either persist vLLM's Hugging Face cache or hold a complete model that vLLM loads directly. For offline loading, populate the volume first, use the path as it appears inside the container, and verify that the exact `modelURL` directory contains all required model files.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -14,7 +14,7 @@ Welcome to the tutorials for vLLM Production Stack! This series of tutorials is 
    Learn how to customize vLLM options when using vLLM Production Stack.
 
 4. [Load Model from Persistent Volume](03-load-model-from-pv.md)
-   Discover how to load models from a persistent volume to ensure efficient resource usage.
+   Learn how to persist the Hugging Face cache or serve a pre-downloaded model offline from a persistent volume.
 
 5. [Launch Multiple Models](04-launch-multiple-model.md)
    Learn how to deploy and manage multiple models simultaneously in your vLLM environment.

--- a/tutorials/assets/pv-03.yaml
+++ b/tutorials/assets/pv-03.yaml
@@ -11,5 +11,9 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: standard
+  # For the offline example, populate the backing directory before deployment:
+  # /data/llama3/Llama-3.1-8B-Instruct/config.json
+  # The PV root is mounted at /data in the serving container, so modelURL is
+  # /data/Llama-3.1-8B-Instruct.
   hostPath:
     path: /data/llama3

--- a/tutorials/assets/values-03-local-model.yaml
+++ b/tutorials/assets/values-03-local-model.yaml
@@ -1,0 +1,30 @@
+servingEngineSpec:
+  runtimeClassName: ""
+  modelSpec:
+    - name: "llama3-local"
+      repository: "vllm/vllm-openai"
+      tag: "latest"
+      # The PV root is mounted at /data inside the serving container.
+      modelURL: "/data/Llama-3.1-8B-Instruct"
+      replicaCount: 1
+
+      requestCPU: 10
+      requestMemory: "16Gi"
+      requestGPU: 1
+
+      # Reuse the PV labeled model=llama3-pv from pv-03.yaml.
+      pvcStorage: "50Gi"
+      pvcAccessMode:
+        - ReadWriteOnce
+      pvcMatchLabels:
+        model: "llama3-pv"
+
+      vllmConfig:
+        maxModelLen: 4096
+
+      # Fail instead of attempting a network download if local files are missing.
+      env:
+        - name: HF_HUB_OFFLINE
+          value: "1"
+        - name: TRANSFORMERS_OFFLINE
+          value: "1"


### PR DESCRIPTION
## Summary

- distinguish persistent Hugging Face caching from serving pre-downloaded model files
- add a directly renderable offline/local-model values example
- document node-to-container path mapping, existing PVC usage, and offline environment variables
- add verification and troubleshooting guidance for common local-path failures

## Validation

- `helm lint helm -f tutorials/assets/values-03-match-pv.yaml`
- `helm lint helm -f tutorials/assets/values-03-local-model.yaml`
- rendered the offline example and verified the local model path, `/data` PVC mount, offline environment variables, and absence of `HF_TOKEN`
- rendered the existing-PVC example and verified that no additional PVC is created
- ran pre-commit checks for the changed Markdown and YAML files
- validated referenced local Markdown paths

Closes #304
