### PR TITLE
[Bugfix][Router] Authenticate static backend health checks

### DIFF
--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -99,6 +99,56 @@ def test_is_model_healthy_when_requests_responds_with_status_code_200_returns_tr
     assert utils.is_model_healthy("http://localhost", "test", "chat") is True
 
 
+def test_is_model_healthy_json_request_includes_api_key_and_content_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_API_KEY", "test-api-key")
+    request_mock = MagicMock(return_value=MagicMock(status_code=200))
+    monkeypatch.setattr("requests.post", request_mock)
+
+    assert utils.is_model_healthy("http://localhost", "test", "chat") is True
+
+    request_kwargs = request_mock.call_args.kwargs
+    assert request_kwargs["headers"] == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer test-api-key",
+    }
+
+
+def test_is_model_healthy_transcription_request_includes_api_key_and_multipart_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_API_KEY", "test-api-key")
+    request_mock = MagicMock(return_value=MagicMock(status_code=200))
+    monkeypatch.setattr("requests.post", request_mock)
+
+    assert utils.is_model_healthy("http://localhost", "test", "transcription") is True
+
+    request_kwargs = request_mock.call_args.kwargs
+    assert request_kwargs["headers"] == {"Authorization": "Bearer test-api-key"}
+    assert "Content-Type" not in request_kwargs["headers"]
+    assert request_kwargs["files"] == utils.ModelType.get_test_payload("transcription")
+    assert request_kwargs["data"] == {"model": "test"}
+
+
+@pytest.mark.parametrize("api_key", (None, ""))
+@pytest.mark.parametrize("model_type", ("chat", "transcription"))
+def test_is_model_healthy_without_api_key_omits_authorization_header(
+    monkeypatch: pytest.MonkeyPatch, api_key: str | None, model_type: str
+) -> None:
+    if api_key is None:
+        monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_API_KEY", api_key)
+    request_mock = MagicMock(return_value=MagicMock(status_code=200))
+    monkeypatch.setattr("requests.post", request_mock)
+
+    assert utils.is_model_healthy("http://localhost", "test", model_type) is True
+
+    request_headers = request_mock.call_args.kwargs.get("headers", {})
+    assert "Authorization" not in request_headers
+
+
 def test_is_model_healthy_when_requests_raises_exception_returns_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/vllm_router/README.md
+++ b/src/vllm_router/README.md
@@ -101,6 +101,8 @@ vllm-router --port 8000 \
 By enabling the `--static-backend-health-checks` flag, **vllm-router** will send a simple request to
 your LLM nodes every minute to verify that they still work.
 If a node is down, it will output a warning and exclude the node from being routed to.
+When `VLLM_API_KEY` is set, health-check requests send it as a Bearer token in the
+`Authorization` header.
 
 If you enable this flag, its also required that you specify `--static-model-types` as we have to use
 different endpoints for each model type.

--- a/src/vllm_router/utils.py
+++ b/src/vllm_router/utils.py
@@ -246,14 +246,13 @@ def is_model_healthy(url: str, model: str, model_type: str, timeout: int = 10) -
         if model_type == "transcription":
             # for transcription, the backend expects multipart/form-data with a file
             # we will use pre-generated silent wav bytes
-            request_kwargs = {
-                "files": ModelType.get_test_payload(model_type),
-                "data": {"model": model},
-                "timeout": timeout,
-            }
-            if auth_headers:
-                request_kwargs["headers"] = auth_headers
-            response = requests.post(f"{url}{model_url}", **request_kwargs)
+            response = requests.post(
+                f"{url}{model_url}",
+                files=ModelType.get_test_payload(model_type),
+                data={"model": model},
+                headers=auth_headers,
+                timeout=timeout,
+            )
         else:
             # for other model types (chat, completion, etc.)
             response = requests.post(

--- a/src/vllm_router/utils.py
+++ b/src/vllm_router/utils.py
@@ -2,6 +2,7 @@ import abc
 import enum
 import io
 import json
+import os
 import re
 import resource
 import wave
@@ -238,22 +239,26 @@ def update_content_length(request: Request, request_body: str):
 
 def is_model_healthy(url: str, model: str, model_type: str, timeout: int = 10) -> bool:
     model_url = ModelType.get_url(model_type)
+    api_key = os.getenv("VLLM_API_KEY")
+    auth_headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
     try:
         if model_type == "transcription":
             # for transcription, the backend expects multipart/form-data with a file
             # we will use pre-generated silent wav bytes
-            response = requests.post(
-                f"{url}{model_url}",
-                files=ModelType.get_test_payload(model_type),  # multipart/form-data
-                data={"model": model},
-                timeout=timeout,
-            )
+            request_kwargs = {
+                "files": ModelType.get_test_payload(model_type),
+                "data": {"model": model},
+                "timeout": timeout,
+            }
+            if auth_headers:
+                request_kwargs["headers"] = auth_headers
+            response = requests.post(f"{url}{model_url}", **request_kwargs)
         else:
             # for other model types (chat, completion, etc.)
             response = requests.post(
                 f"{url}{model_url}",
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": "application/json"} | auth_headers,
                 json={"model": model} | ModelType.get_test_payload(model_type),
                 timeout=timeout,
             )


### PR DESCRIPTION
## Summary

- reuse the router's existing `VLLM_API_KEY` environment variable for static backend health checks
- send the key as a Bearer token while preserving JSON and multipart request-specific behavior
- keep unauthenticated health checks unchanged when the variable is unset or empty
- document the behavior and add mocked unit coverage for JSON and transcription requests

The optional generic `/ping` health-check mode discussed in the issue remains out of scope because authenticated model-specific checks resolve the reported failure without introducing a new endpoint or configuration contract.

Fixes #631

## Testing

- `uv run --frozen --group test pytest src/tests/test_utils.py src/tests/test_static_service_discovery.py` (26 passed)
- `uv run --frozen --group test pytest src/tests` (226 passed)
- `uv run --frozen pre-commit run --files src/vllm_router/utils.py src/tests/test_utils.py src/vllm_router/README.md`

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using `-s` when doing `git commit`
- [x] Classify the PR with `[Bugfix][Router]`.
