### PR TITLE
[Router][Bugfix] KV-aware routing: tokenize chat-completions bodies through the chat template

### DIFF
--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -141,21 +141,23 @@ def test_multimodal_content_parts_are_flattened_to_their_text():
     assert isinstance(messages[0]["content"], list)
 
 
-def test_null_text_part_becomes_an_empty_string():
+def test_null_and_empty_text_parts_are_dropped():
     # {"type": "text", "text": null} is valid JSON a client can send; .get
     # with a default only covers a MISSING key, so an explicit null must not
-    # reach " ".join as None.
+    # reach " ".join as None - and null/empty parts are dropped entirely so
+    # they cannot inject stray spaces into the normalized text.
     messages = [
         {
             "role": "user",
             "content": [
                 {"type": "text", "text": None},
+                {"type": "text", "text": ""},
                 {"type": "text", "text": "hello"},
             ],
         }
     ]
     normalized = _normalize_chat_messages(messages)
-    assert normalized == [{"role": "user", "content": " hello"}]
+    assert normalized == [{"role": "user", "content": "hello"}]
 
 
 def test_none_content_becomes_an_empty_string():

--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -245,6 +245,10 @@ async def test_remote_tokenize_fallback_sends_the_messages_for_chat(monkeypatch)
 
     class Response:
         @staticmethod
+        def raise_for_status():
+            pass
+
+        @staticmethod
         def json():
             return {"count": len(CHAT_IDS), "tokens": CHAT_IDS}
 
@@ -260,3 +264,47 @@ async def test_remote_tokenize_fallback_sends_the_messages_for_chat(monkeypatch)
     assert captured["json"]["messages"] == MESSAGES
     assert captured["json"]["add_generation_prompt"] is True
     assert "prompt" not in captured["json"]
+
+
+# --- tokenization failure degrades to fallback routing, never a 500 -----------
+
+
+@pytest.mark.asyncio
+async def test_kvaware_falls_back_to_qps_when_tokenization_fails(monkeypatch):
+    """A dead /tokenize endpoint (plus no usable local template) must not
+    fail the request - the router still has session/QPS routing."""
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = TemplatelessTokenizer()
+    router.threshold = 2000
+    router.instance_id_to_ip = {}
+    router.session_key = None
+    router.hash_ring = HashRing()
+    lookups = []
+
+    async def query_manager(msg):
+        lookups.append(msg)
+
+    router.query_manager = query_manager
+
+    def dead_post(url, headers=None, json=None, timeout=None):
+        raise ConnectionError("engine unreachable")
+
+    monkeypatch.setattr(routing_logic.requests, "post", dead_post)
+    url = await router.route_request(
+        endpoints(URL_A, URL_B), {}, {}, None, {"messages": MESSAGES}
+    )
+    assert url == URL_A  # QPS routing with no stats picks the first endpoint
+    assert lookups == []  # no KV lookup without token ids
+
+
+@pytest.mark.asyncio
+async def test_loadaware_tokenize_returns_none_when_both_paths_fail(monkeypatch):
+    router = LoadAwareRouter.__new__(LoadAwareRouter)
+    router.tokenizer = TemplatelessTokenizer()
+
+    def dead_post(url, headers=None, json=None, timeout=None):
+        raise ConnectionError("engine unreachable")
+
+    monkeypatch.setattr(routing_logic.requests, "post", dead_post)
+    ids = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
+    assert ids is None

--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -79,6 +79,8 @@ class ChatTokenizer:
         self.chat_template_calls = []
         self.encode_calls = []
 
+    RENDERED = "<chat-template-rendered>"
+
     def apply_chat_template(
         self, messages, add_generation_prompt=False, tokenize=False
     ):
@@ -89,10 +91,20 @@ class ChatTokenizer:
                 "tokenize": tokenize,
             }
         )
-        return list(CHAT_IDS)
+        # tokenize=True return types vary across transformers versions
+        # (ids vs Encoding objects) - the router must NOT use that form.
+        assert tokenize is False, "router must render text, not tokenize=True"
+        return self.RENDERED
 
-    def encode(self, prompt):
-        self.encode_calls.append(prompt)
+    def encode(self, prompt, add_special_tokens=True):
+        self.encode_calls.append(
+            {"prompt": prompt, "add_special_tokens": add_special_tokens}
+        )
+        if prompt == self.RENDERED:
+            # the rendered template must be encoded WITHOUT re-adding
+            # special tokens (the template already carries them)
+            assert add_special_tokens is False
+            return list(CHAT_IDS)
         return [1] * len(prompt)
 
 
@@ -113,7 +125,9 @@ def test_messages_tokenize_through_the_chat_template():
     assert ids == CHAT_IDS
     call = tokenizer.chat_template_calls[0]
     assert call["add_generation_prompt"] is True
-    assert call["tokenize"] is True
+    # rendered to text, then encoded without re-adding special tokens - the
+    # tokenize=True return type varies across transformers versions
+    assert call["tokenize"] is False
     assert tokenizer.encode_calls == []
 
 

--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -128,7 +128,10 @@ def test_messages_tokenize_through_the_chat_template():
     # rendered to text, then encoded without re-adding special tokens - the
     # tokenize=True return type varies across transformers versions
     assert call["tokenize"] is False
-    assert tokenizer.encode_calls == []
+    # exactly one encode: the rendered template text, no special re-adding
+    assert tokenizer.encode_calls == [
+        {"prompt": ChatTokenizer.RENDERED, "add_special_tokens": False}
+    ]
 
 
 def test_prompt_requests_keep_the_plain_encode_path():

--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -1,0 +1,245 @@
+"""Unit tests for chat-completion tokenization in the KV-aware routers.
+
+`kvaware` and `loadaware` place a request by asking the LMCache controller
+which engine already holds KV for the request's token-id prefix. vLLM
+engines cache KV for the token ids *after* chat-template application, so a
+chat-completions body (a "messages" array, no "prompt" key) must be
+tokenized through `apply_chat_template` - the old
+`encode(request_json.get("prompt", ""))` tokenized the empty string, the
+lookup matched nothing, and every chat request silently degraded to the
+session/QPS fallback.
+
+As in `test_loadaware_router.py`, the routers are built with `__new__` and
+only the attributes the tokenize path reads, so no LMCache controller (and
+no network) is needed.
+"""
+
+from typing import Any, Dict
+
+import pytest
+from uhashring import HashRing
+
+import vllm_router.routers.routing_logic as routing_logic
+from vllm_router.routers.routing_logic import (
+    KvawareRouter,
+    LoadAwareRouter,
+    _extract_token_ids,
+    _normalize_chat_messages,
+    _tokenize_request_payload,
+)
+
+
+@pytest.fixture(autouse=True)
+def lookup_msg_stub(monkeypatch):
+    """`LookupMsg`/`QueryInstMsg` come from the optional lmcache dependency;
+    stub them when absent so the routing tests run without the lmcache
+    extra."""
+
+    class _Msg:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    for name in ("LookupMsg", "QueryInstMsg"):
+        if not hasattr(routing_logic, name):
+            monkeypatch.setattr(routing_logic, name, _Msg, raising=False)
+
+
+URL_A = "http://10.0.0.1:8000"
+URL_B = "http://10.0.0.2:8000"
+INST_A = "instance-a"
+LOCAL = "LocalCPUBackend"
+MODEL = "test-model"
+CHAT_IDS = [101, 102, 103, 104, 105]
+MESSAGES = [
+    {"role": "system", "content": "You are terse."},
+    {"role": "user", "content": "Hello there"},
+]
+
+
+class EndpointInfo:
+    def __init__(self, url: str):
+        self.url = url
+        self.model_names = [MODEL]
+
+
+class LookupRet:
+    def __init__(self, layout_info: Dict[str, Any]):
+        self.layout_info = layout_info
+
+
+def endpoints(*urls):
+    return [EndpointInfo(url=url) for url in urls]
+
+
+class ChatTokenizer:
+    """Records calls; template ids are disjoint from encode ids so a test
+    can tell which path produced them."""
+
+    def __init__(self):
+        self.chat_template_calls = []
+        self.encode_calls = []
+
+    def apply_chat_template(
+        self, messages, add_generation_prompt=False, tokenize=False
+    ):
+        self.chat_template_calls.append(
+            {
+                "messages": messages,
+                "add_generation_prompt": add_generation_prompt,
+                "tokenize": tokenize,
+            }
+        )
+        return list(CHAT_IDS)
+
+    def encode(self, prompt):
+        self.encode_calls.append(prompt)
+        return [1] * len(prompt)
+
+
+class TemplatelessTokenizer(ChatTokenizer):
+    """A tokenizer with no chat template, as `apply_chat_template` raises on
+    base models."""
+
+    def apply_chat_template(self, *args, **kwargs):
+        raise ValueError("no chat template defined")
+
+
+# --- local tokenization -------------------------------------------------------
+
+
+def test_messages_tokenize_through_the_chat_template():
+    tokenizer = ChatTokenizer()
+    ids = _extract_token_ids(tokenizer, {"messages": MESSAGES})
+    assert ids == CHAT_IDS
+    call = tokenizer.chat_template_calls[0]
+    assert call["add_generation_prompt"] is True
+    assert call["tokenize"] is True
+    assert tokenizer.encode_calls == []
+
+
+def test_prompt_requests_keep_the_plain_encode_path():
+    tokenizer = ChatTokenizer()
+    ids = _extract_token_ids(tokenizer, {"prompt": "hello"})
+    assert ids == [1] * len("hello")
+    assert tokenizer.chat_template_calls == []
+
+
+def test_multimodal_content_parts_are_flattened_to_their_text():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;..."}},
+                {"type": "text", "text": "this image"},
+            ],
+        }
+    ]
+    normalized = _normalize_chat_messages(messages)
+    assert normalized == [{"role": "user", "content": "describe this image"}]
+    # The request body itself is never mutated.
+    assert isinstance(messages[0]["content"], list)
+
+
+def test_none_content_becomes_an_empty_string():
+    messages = [{"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]}]
+    normalized = _normalize_chat_messages(messages)
+    assert normalized[0]["content"] == ""
+    assert normalized[0]["tool_calls"] == [{"id": "1"}]
+
+
+def test_string_content_messages_pass_through_untouched():
+    assert _normalize_chat_messages(MESSAGES) == MESSAGES
+
+
+# --- the remote /tokenize fallback payload ------------------------------------
+
+
+def test_chat_bodies_use_the_tokenize_chat_request_form():
+    payload = _tokenize_request_payload(MODEL, {"messages": MESSAGES})
+    assert payload == {
+        "model": MODEL,
+        "messages": MESSAGES,
+        "add_generation_prompt": True,
+    }
+
+
+def test_prompt_bodies_keep_the_completion_form():
+    assert _tokenize_request_payload(MODEL, {"prompt": "hello"}) == {
+        "model": MODEL,
+        "prompt": "hello",
+    }
+
+
+# --- through the routers ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kvaware_routes_chat_requests_via_the_kv_lookup_path():
+    """The regression this file exists for: a messages-form body must reach
+    the controller as non-empty, template-aligned token ids and route to the
+    KV holder - not tokenize as "" and fall back to session/QPS."""
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = ChatTokenizer()
+    router.threshold = 2000
+    router.instance_id_to_ip = {INST_A: URL_A}
+    router.session_key = None
+    router.hash_ring = HashRing()
+    seen = {}
+
+    async def query_manager(msg):
+        seen["tokens"] = msg.tokens
+        return LookupRet({INST_A: (LOCAL, len(CHAT_IDS))})
+
+    router.query_manager = query_manager
+    url = await router.route_request(
+        endpoints(URL_A, URL_B), {}, {}, None, {"messages": MESSAGES}
+    )
+    assert seen["tokens"] == CHAT_IDS
+    assert url == URL_A
+
+
+@pytest.mark.asyncio
+async def test_loadaware_tokenizes_chat_requests_through_the_template():
+    router = LoadAwareRouter.__new__(LoadAwareRouter)
+    router.tokenizer = ChatTokenizer()
+    ids = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
+    assert ids == CHAT_IDS
+
+
+@pytest.mark.asyncio
+async def test_prompt_requests_are_unchanged_by_the_chat_support():
+    router = LoadAwareRouter.__new__(LoadAwareRouter)
+    tokenizer = ChatTokenizer()
+    router.tokenizer = tokenizer
+    ids = await router.tokenize_prompt(endpoints(URL_A), {"prompt": "hello"})
+    assert ids == [1] * len("hello")
+    assert tokenizer.chat_template_calls == []
+
+
+@pytest.mark.asyncio
+async def test_remote_tokenize_fallback_sends_the_messages_for_chat(monkeypatch):
+    """A tokenizer without a chat template falls back to the engine's
+    /tokenize with the original messages (vLLM's TokenizeChatRequest), not
+    {"prompt": ""}."""
+    router = LoadAwareRouter.__new__(LoadAwareRouter)
+    router.tokenizer = TemplatelessTokenizer()
+    captured = {}
+
+    class Response:
+        @staticmethod
+        def json():
+            return {"count": len(CHAT_IDS), "tokens": CHAT_IDS}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return Response()
+
+    monkeypatch.setattr(routing_logic.requests, "post", fake_post)
+    ids = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
+    assert ids == CHAT_IDS
+    assert captured["url"] == URL_A + "/tokenize"
+    assert captured["json"]["messages"] == MESSAGES
+    assert captured["json"]["add_generation_prompt"] is True
+    assert "prompt" not in captured["json"]

--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -310,3 +310,61 @@ async def test_loadaware_tokenize_returns_none_when_both_paths_fail(monkeypatch)
     monkeypatch.setattr(routing_logic.requests, "post", dead_post)
     ids = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
     assert ids is None
+
+
+@pytest.mark.asyncio
+async def test_failed_tokenizer_load_is_not_retried_per_request(monkeypatch):
+    """A served-model alias (vLLM --served-model-name) is not a hub id, so
+    the local load always fails - the failure must be cached, not re-paid as
+    a hub lookup on every request before the remote /tokenize fallback."""
+    router = LoadAwareRouter.__new__(LoadAwareRouter)
+    router.tokenizer = None
+    load_attempts = []
+
+    class FailingAuto:
+        @staticmethod
+        def from_pretrained(name):
+            load_attempts.append(name)
+            raise OSError("not a local folder and not a valid repo id")
+
+    # transformers may be absent in the test env (the module import is
+    # guarded), so set the module attribute itself with raising=False
+    monkeypatch.setattr(routing_logic, "AutoTokenizer", FailingAuto, raising=False)
+
+    class Response:
+        @staticmethod
+        def raise_for_status():
+            pass
+
+        @staticmethod
+        def json():
+            return {"count": len(CHAT_IDS), "tokens": CHAT_IDS}
+
+    monkeypatch.setattr(routing_logic.requests, "post", lambda *a, **k: Response())
+    for _ in range(3):
+        ids = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
+        assert ids == CHAT_IDS
+    assert load_attempts == [MODEL]  # exactly one hub attempt, not three
+
+
+@pytest.mark.asyncio
+async def test_cold_tokenizer_load_receives_the_model_name(monkeypatch):
+    """_ensure_tokenizer must resolve endpoints -> model name at load time;
+    a successful cold load caches the tokenizer for subsequent requests."""
+    router = LoadAwareRouter.__new__(LoadAwareRouter)
+    router.tokenizer = None
+    loaded = []
+
+    class FakeAuto:
+        @staticmethod
+        def from_pretrained(name):
+            loaded.append(name)
+            return ChatTokenizer()
+
+    monkeypatch.setattr(routing_logic, "AutoTokenizer", FakeAuto, raising=False)
+    ids = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
+    assert ids == CHAT_IDS
+    assert loaded == [MODEL]  # the NAME string, not the endpoint list
+    ids2 = await router.tokenize_prompt(endpoints(URL_A), {"messages": MESSAGES})
+    assert ids2 == CHAT_IDS
+    assert loaded == [MODEL]  # cached - no second load

--- a/src/tests/test_kvaware_chat_tokenization.py
+++ b/src/tests/test_kvaware_chat_tokenization.py
@@ -141,6 +141,23 @@ def test_multimodal_content_parts_are_flattened_to_their_text():
     assert isinstance(messages[0]["content"], list)
 
 
+def test_null_text_part_becomes_an_empty_string():
+    # {"type": "text", "text": null} is valid JSON a client can send; .get
+    # with a default only covers a MISSING key, so an explicit null must not
+    # reach " ".join as None.
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": None},
+                {"type": "text", "text": "hello"},
+            ],
+        }
+    ]
+    normalized = _normalize_chat_messages(messages)
+    assert normalized == [{"role": "user", "content": " hello"}]
+
+
 def test_none_content_becomes_an_empty_string():
     messages = [{"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]}]
     normalized = _normalize_chat_messages(messages)

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -459,31 +459,45 @@ class KvawareRouter(RoutingInterface):
                 )
             token_ids = _extract_token_ids(self.tokenizer, request_json)
         except Exception:
-            # Remote /tokenize fallback (let errors bubble up to keep behavior
-            # simple). requests is synchronous - run it in an executor so the
-            # fallback does not block the router's event loop.
-            remote_url = endpoints[0].url + "/tokenize"
-            headers = {"Content-Type": "application/json"}
-            data = _tokenize_request_payload(endpoints[0].model_names[0], request_json)
-            loop = asyncio.get_running_loop()
-            response = await loop.run_in_executor(
-                None,
-                lambda: requests.post(
-                    remote_url, headers=headers, json=data, timeout=10
-                ),
-            )
-            token_ids = response.json()["tokens"]
+            # Remote /tokenize fallback. requests is synchronous - run it in
+            # an executor so the fallback does not block the router's event
+            # loop. A failure here (engine timeout, connection error, non-2xx)
+            # must not fail the request: the session/QPS fallback below routes
+            # fine without token ids.
+            try:
+                remote_url = endpoints[0].url + "/tokenize"
+                headers = {"Content-Type": "application/json"}
+                data = _tokenize_request_payload(
+                    endpoints[0].model_names[0], request_json
+                )
+                loop = asyncio.get_running_loop()
+                response = await loop.run_in_executor(
+                    None,
+                    lambda: requests.post(
+                        remote_url, headers=headers, json=data, timeout=10
+                    ),
+                )
+                response.raise_for_status()
+                token_ids = response.json()["tokens"]
+            except Exception as e:
+                logger.warning(
+                    f"Tokenization failed locally and via remote /tokenize "
+                    f"({e}); falling back to session/QPS routing"
+                )
+                token_ids = None
 
-        event_id = "Lookup" + str(uuid.uuid4())
-        msg = LookupMsg(tokens=token_ids, event_id=event_id)
-        instance_id = await self.query_manager(msg)
+        instance_id = None
         matched_tokens = math.inf
-        logger.debug(f"Lookup return message: {instance_id}")
-        if len(list(instance_id.layout_info.keys())) > 0:
-            matched_instance_id = list(instance_id.layout_info.keys())[
-                0
-            ]  # Get the first key
-            matched_tokens = instance_id.layout_info[matched_instance_id][1]
+        if token_ids is not None:
+            event_id = "Lookup" + str(uuid.uuid4())
+            msg = LookupMsg(tokens=token_ids, event_id=event_id)
+            instance_id = await self.query_manager(msg)
+            logger.debug(f"Lookup return message: {instance_id}")
+            if len(list(instance_id.layout_info.keys())) > 0:
+                matched_instance_id = list(instance_id.layout_info.keys())[
+                    0
+                ]  # Get the first key
+                matched_tokens = instance_id.layout_info[matched_instance_id][1]
 
         if (
             instance_id is None
@@ -713,13 +727,15 @@ class LoadAwareRouter(KvawareRouter):
 
     async def tokenize_prompt(
         self, endpoints: List[EndpointInfo], request_json: Dict
-    ) -> List[int]:
+    ) -> Optional[List[int]]:
         """Local-first tokenization with the remote `/tokenize` fallback.
 
         Chat-completion bodies go through the chat template so the token ids
         match what the engine caches KV for (see `_extract_token_ids`). The
         remote fallback is a blocking HTTP call, so it runs in an executor
-        rather than on the event loop.
+        rather than on the event loop. Returns ``None`` when both paths fail
+        (the caller then routes via `fallback_url` instead of erroring the
+        request).
         """
         try:
             if self.tokenizer is None:
@@ -728,17 +744,27 @@ class LoadAwareRouter(KvawareRouter):
                 )
             return _extract_token_ids(self.tokenizer, request_json)
         except Exception:
-            remote_url = endpoints[0].url + "/tokenize"
-            headers = {"Content-Type": "application/json"}
-            data = _tokenize_request_payload(endpoints[0].model_names[0], request_json)
-            loop = asyncio.get_running_loop()
-            response = await loop.run_in_executor(
-                None,
-                lambda: requests.post(
-                    remote_url, headers=headers, json=data, timeout=10
-                ),
-            )
-            return response.json()["tokens"]
+            try:
+                remote_url = endpoints[0].url + "/tokenize"
+                headers = {"Content-Type": "application/json"}
+                data = _tokenize_request_payload(
+                    endpoints[0].model_names[0], request_json
+                )
+                loop = asyncio.get_running_loop()
+                response = await loop.run_in_executor(
+                    None,
+                    lambda: requests.post(
+                        remote_url, headers=headers, json=data, timeout=10
+                    ),
+                )
+                response.raise_for_status()
+                return response.json()["tokens"]
+            except Exception as e:
+                logger.warning(
+                    f"Tokenization failed locally and via remote /tokenize "
+                    f"({e}); falling back to session/QPS routing"
+                )
+                return None
 
     def fallback_url(
         self,
@@ -788,6 +814,8 @@ class LoadAwareRouter(KvawareRouter):
             )
 
         token_ids = await self.tokenize_prompt(endpoints, request_json)
+        if token_ids is None:
+            return self.fallback_url(endpoints, request_stats, request, request_json)
 
         event_id = "Lookup" + str(uuid.uuid4())
         msg = LookupMsg(tokens=token_ids, event_id=event_id)

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -107,7 +107,7 @@ def _normalize_chat_messages(messages: List[Dict]) -> List[Dict]:
         content = message.get("content")
         if isinstance(content, list):
             text_content = " ".join(
-                part.get("text", "")
+                part.get("text") or ""
                 for part in content
                 if isinstance(part, dict) and part.get("type") == "text"
             )
@@ -459,14 +459,20 @@ class KvawareRouter(RoutingInterface):
                 )
             token_ids = _extract_token_ids(self.tokenizer, request_json)
         except Exception:
-            # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
+            # Remote /tokenize fallback (let errors bubble up to keep behavior
+            # simple). requests is synchronous - run it in an executor so the
+            # fallback does not block the router's event loop.
             remote_url = endpoints[0].url + "/tokenize"
             headers = {"Content-Type": "application/json"}
             data = _tokenize_request_payload(endpoints[0].model_names[0], request_json)
-            body = requests.post(
-                remote_url, headers=headers, json=data, timeout=10
-            ).json()
-            token_ids = body["tokens"]
+            loop = asyncio.get_running_loop()
+            response = await loop.run_in_executor(
+                None,
+                lambda: requests.post(
+                    remote_url, headers=headers, json=data, timeout=10
+                ),
+            )
+            token_ids = response.json()["tokens"]
 
         event_id = "Lookup" + str(uuid.uuid4())
         msg = LookupMsg(tokens=token_ids, event_id=event_id)

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -454,8 +454,12 @@ class KvawareRouter(RoutingInterface):
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         try:
             if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
+                # from_pretrained is blocking I/O (possibly a hub download on
+                # first use) - keep it off the event loop too.
+                loop = asyncio.get_running_loop()
+                self.tokenizer = await loop.run_in_executor(
+                    None,
+                    lambda: AutoTokenizer.from_pretrained(endpoints[0].model_names[0]),
                 )
             token_ids = _extract_token_ids(self.tokenizer, request_json)
         except Exception:
@@ -739,8 +743,12 @@ class LoadAwareRouter(KvawareRouter):
         """
         try:
             if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
+                # from_pretrained is blocking I/O (possibly a hub download on
+                # first use) - keep it off the event loop too.
+                loop = asyncio.get_running_loop()
+                self.tokenizer = await loop.run_in_executor(
+                    None,
+                    lambda: AutoTokenizer.from_pretrained(endpoints[0].model_names[0]),
                 )
             return _extract_token_ids(self.tokenizer, request_json)
         except Exception:

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -106,10 +106,16 @@ def _normalize_chat_messages(messages: List[Dict]) -> List[Dict]:
     for message in messages:
         content = message.get("content")
         if isinstance(content, list):
+            # Join only non-empty string parts: empty/null parts would inject
+            # stray spaces into the normalized text, drifting it away from
+            # what a text-only chat template would render.
             text_content = " ".join(
-                part.get("text") or ""
+                part["text"]
                 for part in content
-                if isinstance(part, dict) and part.get("type") == "text"
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+                and part["text"]
             )
             message = {**message, "content": text_content}
         elif content is None:
@@ -454,13 +460,25 @@ class KvawareRouter(RoutingInterface):
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         try:
             if self.tokenizer is None:
-                # from_pretrained is blocking I/O (possibly a hub download on
-                # first use) - keep it off the event loop too.
-                loop = asyncio.get_running_loop()
-                self.tokenizer = await loop.run_in_executor(
-                    None,
-                    lambda: AutoTokenizer.from_pretrained(endpoints[0].model_names[0]),
-                )
+                # Double-checked lock: concurrent cold-start requests would
+                # otherwise each load the tokenizer (benign but redundant -
+                # duplicated disk/CPU work, and possible hub rate-limiting).
+                # The lock is created lazily; there is no await between the
+                # hasattr check and the assignment, so coroutines on one
+                # event loop cannot race it.
+                if not hasattr(self, "_tokenizer_lock"):
+                    self._tokenizer_lock = asyncio.Lock()
+                async with self._tokenizer_lock:
+                    if self.tokenizer is None:
+                        # from_pretrained is blocking I/O (possibly a hub
+                        # download on first use) - keep it off the event loop.
+                        loop = asyncio.get_running_loop()
+                        self.tokenizer = await loop.run_in_executor(
+                            None,
+                            lambda: AutoTokenizer.from_pretrained(
+                                endpoints[0].model_names[0]
+                            ),
+                        )
             token_ids = _extract_token_ids(self.tokenizer, request_json)
         except Exception:
             # Remote /tokenize fallback. requests is synchronous - run it in
@@ -743,13 +761,25 @@ class LoadAwareRouter(KvawareRouter):
         """
         try:
             if self.tokenizer is None:
-                # from_pretrained is blocking I/O (possibly a hub download on
-                # first use) - keep it off the event loop too.
-                loop = asyncio.get_running_loop()
-                self.tokenizer = await loop.run_in_executor(
-                    None,
-                    lambda: AutoTokenizer.from_pretrained(endpoints[0].model_names[0]),
-                )
+                # Double-checked lock: concurrent cold-start requests would
+                # otherwise each load the tokenizer (benign but redundant -
+                # duplicated disk/CPU work, and possible hub rate-limiting).
+                # The lock is created lazily; there is no await between the
+                # hasattr check and the assignment, so coroutines on one
+                # event loop cannot race it.
+                if not hasattr(self, "_tokenizer_lock"):
+                    self._tokenizer_lock = asyncio.Lock()
+                async with self._tokenizer_lock:
+                    if self.tokenizer is None:
+                        # from_pretrained is blocking I/O (possibly a hub
+                        # download on first use) - keep it off the event loop.
+                        loop = asyncio.get_running_loop()
+                        self.tokenizer = await loop.run_in_executor(
+                            None,
+                            lambda: AutoTokenizer.from_pretrained(
+                                endpoints[0].model_names[0]
+                            ),
+                        )
             return _extract_token_ids(self.tokenizer, request_json)
         except Exception:
             try:

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -144,6 +144,28 @@ def _extract_token_ids(tokenizer, request_json: Dict) -> List[int]:
     return tokenizer.encode(request_json.get("prompt", ""))
 
 
+async def _ensure_tokenizer(router, model_name: str):
+    """Load the router's tokenizer once and return it.
+
+    Double-checked lock: concurrent cold-start requests would otherwise each
+    load the tokenizer (benign but redundant - duplicated disk/CPU work and
+    possible hub rate-limiting). The lock is created lazily and there is no
+    await between the check and the assignment, so its creation cannot race
+    on one event loop. from_pretrained is blocking I/O (possibly a hub
+    download on first use), so it runs in an executor.
+    """
+    if router.tokenizer is None:
+        if not hasattr(router, "_tokenizer_lock"):
+            router._tokenizer_lock = asyncio.Lock()
+        async with router._tokenizer_lock:
+            if router.tokenizer is None:
+                loop = asyncio.get_running_loop()
+                router.tokenizer = await loop.run_in_executor(
+                    None, lambda: AutoTokenizer.from_pretrained(model_name)
+                )
+    return router.tokenizer
+
+
 def _tokenize_request_payload(model: str, request_json: Dict) -> Dict:
     """Request body for the engine's ``/tokenize`` fallback.
 
@@ -459,26 +481,7 @@ class KvawareRouter(RoutingInterface):
         token_ids = None
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         try:
-            if self.tokenizer is None:
-                # Double-checked lock: concurrent cold-start requests would
-                # otherwise each load the tokenizer (benign but redundant -
-                # duplicated disk/CPU work, and possible hub rate-limiting).
-                # The lock is created lazily; there is no await between the
-                # hasattr check and the assignment, so coroutines on one
-                # event loop cannot race it.
-                if not hasattr(self, "_tokenizer_lock"):
-                    self._tokenizer_lock = asyncio.Lock()
-                async with self._tokenizer_lock:
-                    if self.tokenizer is None:
-                        # from_pretrained is blocking I/O (possibly a hub
-                        # download on first use) - keep it off the event loop.
-                        loop = asyncio.get_running_loop()
-                        self.tokenizer = await loop.run_in_executor(
-                            None,
-                            lambda: AutoTokenizer.from_pretrained(
-                                endpoints[0].model_names[0]
-                            ),
-                        )
+            await _ensure_tokenizer(self, endpoints)
             token_ids = _extract_token_ids(self.tokenizer, request_json)
         except Exception:
             # Remote /tokenize fallback. requests is synchronous - run it in
@@ -760,26 +763,7 @@ class LoadAwareRouter(KvawareRouter):
         request).
         """
         try:
-            if self.tokenizer is None:
-                # Double-checked lock: concurrent cold-start requests would
-                # otherwise each load the tokenizer (benign but redundant -
-                # duplicated disk/CPU work, and possible hub rate-limiting).
-                # The lock is created lazily; there is no await between the
-                # hasattr check and the assignment, so coroutines on one
-                # event loop cannot race it.
-                if not hasattr(self, "_tokenizer_lock"):
-                    self._tokenizer_lock = asyncio.Lock()
-                async with self._tokenizer_lock:
-                    if self.tokenizer is None:
-                        # from_pretrained is blocking I/O (possibly a hub
-                        # download on first use) - keep it off the event loop.
-                        loop = asyncio.get_running_loop()
-                        self.tokenizer = await loop.run_in_executor(
-                            None,
-                            lambda: AutoTokenizer.from_pretrained(
-                                endpoints[0].model_names[0]
-                            ),
-                        )
+            await _ensure_tokenizer(self, endpoints)
             return _extract_token_ids(self.tokenizer, request_json)
         except Exception:
             try:

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -144,25 +144,43 @@ def _extract_token_ids(tokenizer, request_json: Dict) -> List[int]:
     return tokenizer.encode(request_json.get("prompt", ""))
 
 
-async def _ensure_tokenizer(router, model_name: str):
+async def _ensure_tokenizer(router, endpoints: List[EndpointInfo]):
     """Load the router's tokenizer once and return it.
 
     Double-checked lock: concurrent cold-start requests would otherwise each
     load the tokenizer (benign but redundant - duplicated disk/CPU work and
     possible hub rate-limiting). The lock is created lazily and there is no
     await between the check and the assignment, so its creation cannot race
-    on one event loop. from_pretrained is blocking I/O (possibly a hub
+    on one event loop. ``from_pretrained`` is blocking I/O (possibly a hub
     download on first use), so it runs in an executor.
+
+    The model name is resolved from the endpoint list only when a load
+    actually happens, and a failed load is remembered per name: a served-model
+    alias (e.g. a vLLM ``--served-model-name``) is not a real tokenizer id and
+    can never load, so without the negative cache every request would pay a
+    doomed hub lookup before reaching the remote ``/tokenize`` fallback.
     """
     if router.tokenizer is None:
+        model_name = endpoints[0].model_names[0]
+        if model_name in getattr(router, "_tokenizer_load_failures", ()):
+            raise ValueError(
+                f"tokenizer load for '{model_name}' already failed; "
+                f"using the remote /tokenize fallback"
+            )
         if not hasattr(router, "_tokenizer_lock"):
             router._tokenizer_lock = asyncio.Lock()
         async with router._tokenizer_lock:
             if router.tokenizer is None:
                 loop = asyncio.get_running_loop()
-                router.tokenizer = await loop.run_in_executor(
-                    None, lambda: AutoTokenizer.from_pretrained(model_name)
-                )
+                try:
+                    router.tokenizer = await loop.run_in_executor(
+                        None, lambda: AutoTokenizer.from_pretrained(model_name)
+                    )
+                except Exception:
+                    if not hasattr(router, "_tokenizer_load_failures"):
+                        router._tokenizer_load_failures = set()
+                    router._tokenizer_load_failures.add(model_name)
+                    raise
     return router.tokenizer
 
 

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -90,6 +90,71 @@ def _loadaware_beta(override: Optional[float]) -> float:
         return DEFAULT_LOADAWARE_BETA
 
 
+def _normalize_chat_messages(messages: List[Dict]) -> List[Dict]:
+    """Text-only view of an OpenAI chat ``messages`` array for local
+    chat-template application.
+
+    Multimodal content parts (a list of ``{"type": ...}`` dicts) are
+    flattened to their text parts - mirroring ``PrefixAwareRouter`` - because
+    plain HF chat templates expect string content. ``None`` content (e.g.
+    assistant tool-call turns) becomes ``""``. Messages that already carry
+    string content pass through untouched, so template-relevant fields
+    (``role``, ``name``, ``tool_calls``, ...) are preserved. The input is
+    never mutated.
+    """
+    normalized = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            text_content = " ".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+            message = {**message, "content": text_content}
+        elif content is None:
+            message = {**message, "content": ""}
+        normalized.append(message)
+    return normalized
+
+
+def _extract_token_ids(tokenizer, request_json: Dict) -> List[int]:
+    """Token ids as the serving engine would see them for this request body.
+
+    Chat-completion bodies (``messages``) are tokenized through the model's
+    chat template with ``add_generation_prompt=True``: vLLM engines cache KV
+    for the token ids *after* template application, so encoding the raw
+    message text would never line up with the engine-side prefix. Completion
+    bodies keep the plain ``encode`` path, unchanged. May raise (e.g. the
+    tokenizer defines no chat template) - callers fall back to the engine's
+    ``/tokenize`` API.
+    """
+    if "messages" in request_json:
+        return tokenizer.apply_chat_template(
+            _normalize_chat_messages(request_json["messages"]),
+            add_generation_prompt=True,
+            tokenize=True,
+        )
+    return tokenizer.encode(request_json.get("prompt", ""))
+
+
+def _tokenize_request_payload(model: str, request_json: Dict) -> Dict:
+    """Request body for the engine's ``/tokenize`` fallback.
+
+    Chat bodies map to vLLM's ``TokenizeChatRequest`` (the engine applies its
+    own chat template, multimodal content included), completion bodies to
+    ``TokenizeCompletionRequest``. ``add_generation_prompt=True`` is vLLM's
+    chat-completions default; sent explicitly to pin the alignment.
+    """
+    if "messages" in request_json:
+        return {
+            "model": model,
+            "messages": request_json["messages"],
+            "add_generation_prompt": True,
+        }
+    return {"model": model, "prompt": request_json.get("prompt", "")}
+
+
 class RoutingInterface(metaclass=SingletonABCMeta):
     def _qps_routing(
         self, endpoints: List[EndpointInfo], request_stats: Dict[str, RequestStats]
@@ -387,21 +452,17 @@ class KvawareRouter(RoutingInterface):
         """
         token_ids = None
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
-        # TODO (Yuhan): Handle chat completions
         try:
             if self.tokenizer is None:
                 self.tokenizer = AutoTokenizer.from_pretrained(
                     endpoints[0].model_names[0]
                 )
-            token_ids = self.tokenizer.encode(request_json.get("prompt", ""))
+            token_ids = _extract_token_ids(self.tokenizer, request_json)
         except Exception:
             # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
             remote_url = endpoints[0].url + "/tokenize"
             headers = {"Content-Type": "application/json"}
-            data = {
-                "model": endpoints[0].model_names[0],
-                "prompt": request_json.get("prompt", ""),
-            }
+            data = _tokenize_request_payload(endpoints[0].model_names[0], request_json)
             body = requests.post(
                 remote_url, headers=headers, json=data, timeout=10
             ).json()
@@ -649,22 +710,21 @@ class LoadAwareRouter(KvawareRouter):
     ) -> List[int]:
         """Local-first tokenization with the remote `/tokenize` fallback.
 
-        The remote fallback is a blocking HTTP call, so it runs in an
-        executor rather than on the event loop.
+        Chat-completion bodies go through the chat template so the token ids
+        match what the engine caches KV for (see `_extract_token_ids`). The
+        remote fallback is a blocking HTTP call, so it runs in an executor
+        rather than on the event loop.
         """
         try:
             if self.tokenizer is None:
                 self.tokenizer = AutoTokenizer.from_pretrained(
                     endpoints[0].model_names[0]
                 )
-            return self.tokenizer.encode(request_json.get("prompt", ""))
+            return _extract_token_ids(self.tokenizer, request_json)
         except Exception:
             remote_url = endpoints[0].url + "/tokenize"
             headers = {"Content-Type": "application/json"}
-            data = {
-                "model": endpoints[0].model_names[0],
-                "prompt": request_json.get("prompt", ""),
-            }
+            data = _tokenize_request_payload(endpoints[0].model_names[0], request_json)
             loop = asyncio.get_running_loop()
             response = await loop.run_in_executor(
                 None,

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -130,17 +130,23 @@ def _extract_token_ids(tokenizer, request_json: Dict) -> List[int]:
     Chat-completion bodies (``messages``) are tokenized through the model's
     chat template with ``add_generation_prompt=True``: vLLM engines cache KV
     for the token ids *after* template application, so encoding the raw
-    message text would never line up with the engine-side prefix. Completion
+    message text would never line up with the engine-side prefix. The
+    template is rendered to TEXT and then encoded (``add_special_tokens=
+    False`` - the rendered template already carries its special tokens):
+    ``apply_chat_template(..., tokenize=True)``'s return type varies across
+    transformers versions (plain ids vs ``Encoding`` objects), and feeding
+    the non-id form to the KV lookup silently never matches. Completion
     bodies keep the plain ``encode`` path, unchanged. May raise (e.g. the
     tokenizer defines no chat template) - callers fall back to the engine's
     ``/tokenize`` API.
     """
     if "messages" in request_json:
-        return tokenizer.apply_chat_template(
+        text = tokenizer.apply_chat_template(
             _normalize_chat_messages(request_json["messages"]),
             add_generation_prompt=True,
-            tokenize=True,
+            tokenize=False,
         )
+        return tokenizer.encode(text, add_special_tokens=False)
     return tokenizer.encode(request_json.get("prompt", ""))
 
 


### PR DESCRIPTION
Fixes KV-aware/load-aware routing silently skipping chat-completions traffic: only `prompt`-form bodies were tokenized, so KV-aware placement never happened for `messages` bodies. Validated end-to-end on real hardware on BOTH tokenization paths — the remote `/tokenize` path at `3f498ff` (2× H200, model behind a vLLM served-name alias) and the local chat-template path at `c0c4a42` (1× H100, hub-known model; that run caught and fixed a real transformers-5.x bug pre-merge, see Validation below). Commits above `3f498ff`: hardening from five gemini-code-assist review rounds, a negative cache for failed tokenizer loads (downstream-deployment feedback), and the transformers fix with its test.

### Problem

`KvawareRouter.route_request` and `LoadAwareRouter.tokenize_prompt` only read
`request_json["prompt"]` (the `/v1/completions` shape). For
`/v1/chat/completions` bodies — `messages: [...]` — tokenization fails and the
router silently falls back to session/QPS routing: requests still succeed, so
nothing surfaces above debug level, but KV-aware placement never happens for
chat traffic. (Tutorial 17's test flow uses `/v1/completions`, which is why
this wasn't visible.)

### Fix

Tokenize chat bodies through the model's chat template so the router's token
ids match what the engine actually caches:
- local: render the template to text (`apply_chat_template(messages,
  add_generation_prompt=True, tokenize=False)`) and `encode(text,
  add_special_tokens=False)` — NOT `tokenize=True`, whose return type varies
  across transformers versions (`Encoding` objects on 5.x) and silently
  breaks the KV lookup; ids verified byte-identical to the engine's
  `/tokenize` output on vLLM v0.22.0 + transformers 5.9.0
- fallback: vLLM's `/tokenize` endpoint with a `TokenizeChatRequest` (supported since v0.5.3)

Prompt-form requests take exactly the old path. 16 unit tests added; the
full router test suite passes (236/236).

All gemini-code-assist review rounds are addressed (`2574697`,
`ec2becc`, `00fcf4d`, `113973c`, `a7fd571`, `d34db2c`, and `f6e243f`/`c0c4a42`
from the second hardware pass): blocking I/O (remote `/tokenize`,
tokenizer load) runs in executors, a total tokenization failure degrades to
the existing session/QPS fallback instead of a 500, tokenizer init is
single-flight behind an `asyncio.Lock`, and normalization drops null/empty
text parts, with the tokenizer logic shared via an `_ensure_tokenizer` helper. `d34db2c`
additionally negative-caches failed tokenizer loads: deployments serving
under a vLLM `--served-model-name` (not a hub id) can never load locally,
and previously paid a doomed hub lookup on every request before the remote
`/tokenize` fallback — now the failure is remembered per model name.

### End-to-end validation — both tokenization paths, real hardware

**Remote-path leg** (2x H200, gemma-4-31B FP8 under a vLLM `--served-model-name`, vLLM v0.22.0 engines + lmcache 0.4.5, 2026-08-22) and **local-path leg** (1x H100, hub-known Qwen2.5-1.5B via the repro kit below, transformers 5.9.0, 2026-08-24). The local leg caught a real bug pre-merge — `apply_chat_template(..., tokenize=True)` returns `Encoding` objects on transformers 5.x, so the lookup silently missed — fixed in `f6e243f` by rendering the template to text and encoding it (`add_special_tokens=False`); ids verified byte-identical to the engine's `/tokenize` output. At head `c0c4a42`: all 4 chat requests pin to the caching engine (4 kvaware decisions vs 1 unpatched), prompt-form unregressed.


<details>
<summary><b>Raw evidence — leg 1: remote /tokenize path (2× H200, Gemma-4-31B FP8 served as a vLLM alias, 2026-08-22)</b></summary>

Probe: 4 chat requests sharing a salted ~19.4k-token prefix; per-request engine
attribution via `vllm:prompt_tokens_total` deltas (the delta counts *submitted*
prompt tokens, so which engine moved is the attribution; wall-time shows
cache behavior). Served model name is not a hub id, so the router always used
the remote `/tokenize` fallback.

BEFORE (merge-base `58a0935`) — requests alternate; the same prefix is
full-prefilled on BOTH engines; zero kvaware decisions logged for chat:

```
req 1  wall 5.34s  engineA +19,434  engineB      0
req 2  wall 5.20s  engineA       0  engineB +19,434   <- full re-prefill
req 3  wall 1.25s  engineA +19,434  engineB      0
req 4  wall 1.22s  engineA       0  engineB +19,434
prompt-form pair: req2 kv-followed in 0.83s ("found by kvaware router") — the gap is chat-only
```

AFTER (patched) — requests 2–4 pin to the engine that served request 1:

```
req 1  wall 5.75s  engineA +19,434  engineB 0        (cold miss, QPS pick)
req 2  wall 1.56s  engineA +19,434  engineB 0        "found by kvaware router"
req 3  wall 1.53s  engineA +19,434  engineB 0        "found by kvaware router"
req 4  wall 1.44s  engineA +19,434  engineB 0        "found by kvaware router"
prompt-form pair: unchanged (kv-followed, 0.79s)
```

</details>

<details>
<summary><b>Raw evidence — leg 2: local chat-template path (1× H100, hub-known Qwen2.5-1.5B via the repro kit, transformers 5.9.0, 2026-08-24)</b></summary>

This leg is what caught the `Encoding`-vs-ids bug: at the pre-fix head the
AFTER run still showed the BEFORE signature (chat alternating A,B,A,B) because
`apply_chat_template(..., tokenize=True)` returned `Encoding` objects and the
lookup keyed on garbage. Diagnosis inside the router container:

```
local :  [Encoding(num_tokens=31, ...)]  len 2      <- tokenize=True on transformers 5.9.0
remote:  [151644, 8948, 198, 2610, ...]  len 31     <- engine /tokenize (ground truth)
MISMATCH
```

After `f6e243f` (render template to text, `encode(text, add_special_tokens=False)`)
the same comparison prints `MATCH`, and the probe at head `c0c4a42`:

```
== chat-completions (messages form) ==
req 1  wall 3.21s  engine0 +5,138  engine1 0        (cold miss)
req 2  wall 0.22s  engine0 +5,138  engine1 0        "found by kvaware router"
req 3  wall 0.27s  engine0 +5,138  engine1 0        "found by kvaware router"
req 4  wall 0.21s  engine0 +5,138  engine1 0        "found by kvaware router"
== completions (prompt form, regression) ==
req 1  wall 0.21s  engine1 +3,213   (QPS pick)
req 2  wall 0.18s  engine1 +3,213   "found by kvaware router"
kvaware decisions: 4 (unpatched baseline on the same box: 1 — prompt-form only)
```

BEFORE leg on the same box (merge-base): chat alternated engine0/engine1 with
the full 5,126-token prefix prefilled on both, zero chat kvaware decisions —
same signature as the H200 leg.

</details>

### Reproduce it yourself (minutes, any 2-GPU box — or 1 GPU split)

A self-contained kit lives on this fork:
**https://github.com/tyler2cr/production-stack/tree/kvaware-chat-repro/repro**
(compose + Dockerfile + a short probe; small ungated model
`Qwen/Qwen2.5-1.5B-Instruct`; no dependence on our infra).

```bash
git clone -b kvaware-chat-repro https://github.com/tyler2cr/production-stack repro-kit
cd repro-kit/repro

# BEFORE — merge-base router (unpatched):
export ROUTER_REF=58a0935955d5b29f615c784a3533ff2433075bdd   # needed by EVERY compose cmd
docker compose build && docker compose up -d
# wait for engines (curl :8100/v1/models, :8200/v1/models) and BOTH worker
# registrations (docker logs router | grep -c "Registered instance" → 2)
pip install httpx && python3 probe.py
# → chat requests ALTERNATE engines (same prefix prefilled on BOTH),
#   zero "found by kvaware router" lines; prompt-form pair DOES kv-follow.

# AFTER — this PR's head (immutable sha):
export ROUTER_REF=c0c4a42
docker compose rm -sf router
docker compose build router && docker compose up -d router
# recreated router = empty worker registry; wait for both re-registrations
# (grep -c "Registered instance" → 2, ~10-20s), then:
python3 probe.py
# → chat reqs 2–4 pin to req 1's engine, "found by kvaware router" logged;
#   prompt-form behavior unchanged.
```

The kit's compose/Dockerfile comments codify every wiring precondition we
tripped on (single shared image so the vLLM-rooted NONE_HASH matches,
matched lmcache versions, PYTHONHASHSEED, worker heartbeat env, host
networking, distinct worker ports) — see the notes below.

### Notes from standing the e2e up (possible follow-up issues)

These are pre-existing operational sharp edges we hit while validating —
happy to file separately:
1. The kvaware instance mapping (`QueryInstMsg`) keys engines by IP alone —
   two engines on one IP (e.g. one multi-GPU host) are indistinguishable,
   and a kv-followed request to the unmapped instance raises an unhandled
   `KeyError` → 500 (observed live). The durable fix is that a mapping miss
   should fall back to session/QPS routing rather than error; including the
   worker port in identity helps generic multi-engine hosts (topologies with
   one cache owner per IP, e.g. a per-node cache-server DaemonSet, are
   unaffected by the identity half).
2. The `[lmcache]` extra pinned lmcache 0.3.11, whose controller rejects a
   0.4.5 worker's `RegisterMsg` as an unknown type — router/engine lmcache
   versions must match exactly. **Now filed as #1060** (pins bumped +
   lockstep-versioning rationale documented at each pin site).
3. A router without vLLM installed derives `NONE_HASH=0` vs the engines'
   vLLM-derived root, so every kvaware lookup silently misses. Documented in
   #1060's `Dockerfile.kvaware` change; tutorial 17's text still doesn't
   mention it.
4. `PYTHONHASHSEED` must be set identically on router and engines for the
   builtin hash (lmcache warns, tutorial doesn't mention).
5. lmcache workers default to never sending heartbeats while the controller
   reaps silent workers after 30 s — the KV index silently empties shortly
   after startup. Still the default at lmcache 0.5.4 (called out in #1060);
   the root fix is an lmcache-side defaults change (confirmed biting a real
   deployment).
6. `LMCacheConnectorV1` does not subclass `SupportsHMA`, so configuring it
   makes vLLM silently disable the hybrid KV cache manager — on
   sliding-window models (Gemma-family and others) this inflates per-token
   KV roughly 10× with only a startup log line as warning. lmcache's newer
   `LMCacheMPConnector` (`KVConnectorBase_V1, SupportsHMA`, backed by the
   multiprocess cache server) is the HMA-capable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
