### PR TITLE
[CI/Build] Scope Shaoting-Feng's code ownership to router, observability, and benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,6 @@
 # Default owners for everything in the repo
 * @ApostaC @YuhanLiu11 @ruizhang0101
 
-# Area-specific owners. The last matching pattern takes precedence, so the
-# default owners are re-listed here to keep their coverage on these paths.
-
 # Router
 /src/vllm_router/ @ApostaC @YuhanLiu11 @Shaoting-Feng @ruizhang0101
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,16 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo
-* @ApostaC @YuhanLiu11 @Shaoting-Feng @ruizhang0101
+* @ApostaC @YuhanLiu11 @ruizhang0101
+
+# Area-specific owners. The last matching pattern takes precedence, so the
+# default owners are re-listed here to keep their coverage on these paths.
+
+# Router
+/src/vllm_router/ @ApostaC @YuhanLiu11 @Shaoting-Feng @ruizhang0101
+
+# Observability
+/observability/ @ApostaC @YuhanLiu11 @Shaoting-Feng @ruizhang0101
+
+# Benchmarks
+/benchmarks/ @ApostaC @YuhanLiu11 @Shaoting-Feng @ruizhang0101


### PR DESCRIPTION
## Summary

Scopes `@Shaoting-Feng`'s code ownership to the router, observability, and benchmarks areas instead of the repo-wide default introduced in #1011.

## Changes

- Remove `@Shaoting-Feng` from the default `*` owners line
- Add `@Shaoting-Feng` as an owner of `/src/vllm_router/`, `/observability/`, and `/benchmarks/`
- The default owners are re-listed on those three paths because the last matching CODEOWNERS pattern takes precedence, so their coverage is unchanged

## Testing

Verified by visual inspection: the three paths exist in the repo, and the file has no trailing whitespace and ends with a single newline (the pre-commit hooks that apply to this file).

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.
