### PR TITLE
[Helm] Allow setting extra env vars on the LMCache cache server container

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -339,6 +339,7 @@ Set `servingEngineSpec.modelSpec[].raySpec.enabled: true` to deploy the model as
 | `cacheserverSpec.serviceType` | string | `"ClusterIP"` | Kubernetes service type for the cache server |
 | `cacheserverSpec.servicePort` | integer | `80` | Port the cache server service will listen on |
 | `cacheserverSpec.resources` | map | `{}` | Resource requests and limits |
+| `cacheserverSpec.env` | list | `[]` | Extra environment variables for the cache server container, e.g. to configure LMCache's eviction policy via `LMCACHE_CACHE_POLICY` and `LMCACHE_MAX_LOCAL_CPU_SIZE` |
 | `cacheserverSpec.labels` | map | `{environment: "cache", release: "cache"}` | Customized labels for the cache server deployment |
 | `cacheserverSpec.strategy` | map | `{}` | Deployment strategy for the cache server pods |
 | `cacheserverSpec.livenessProbe` | map | `{initialDelaySeconds: 15, periodSeconds: 10, failureThreshold: 3, httpGet: {path: /health, port: 8000}}` | Configuration for the liveness probe |

--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -63,6 +63,10 @@ spec:
           - "/opt/venv/bin/lmcache_server"
           - "0.0.0.0"
           - "{{ .Values.cacheserverSpec.containerPort }}"
+          {{- with .Values.cacheserverSpec.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.cacheserverSpec.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/tests/cacheserver_test.yaml
+++ b/helm/tests/cacheserver_test.yaml
@@ -36,6 +36,11 @@ tests:
           requests:
             cpu: "0.5"
             memory: "512Mi"
+        env:
+          - name: LMCACHE_CACHE_POLICY
+            value: "LRU"
+          - name: LMCACHE_MAX_LOCAL_CPU_SIZE
+            value: "16"
         annotations:
           annotation-key: annotation-value
         labels:
@@ -164,6 +169,14 @@ tests:
     - equal:
         path: spec.template.spec.containers[0].imagePullPolicy
         value: "Always"
+
+    - equal:
+        path: spec.template.spec.containers[0].env
+        value:
+          - name: LMCACHE_CACHE_POLICY
+            value: "LRU"
+          - name: LMCACHE_MAX_LOCAL_CPU_SIZE
+            value: "16"
 
     - equal:
         path: spec.template.spec.containers[0].livenessProbe

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -26,6 +26,10 @@
                     "description": "Whether to enable the cache server",
                     "type": "boolean"
                 },
+                "env": {
+                    "description": "Extra environment variables for the cache server container, e.g. to configure LMCache's eviction policy via `LMCACHE_CACHE_POLICY` and `LMCACHE_MAX_LOCAL_CPU_SIZE` (https://docs.lmcache.ai/api_reference/configurations.html)",
+                    "type": "array"
+                },
                 "image": {
                     "description": "Image configuration for the cache Server",
                     "type": "object",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -814,6 +814,10 @@ cacheserverSpec:
   serviceAnnotations: {}
   # -- Resource requests and limits for the cache server container
   resources: {}
+  # -- Extra environment variables for the cache server container, e.g. to
+  # configure LMCache's eviction policy via `LMCACHE_CACHE_POLICY` and
+  # `LMCACHE_MAX_LOCAL_CPU_SIZE` (https://docs.lmcache.ai/api_reference/configurations.html)
+  env: []
   # -- Customized annotations for the cache server deployment
   annotations: {}
   # -- Customized labels for the cache server deployment and service


### PR DESCRIPTION
[Helm] Allow setting extra env vars on the LMCache cache server container

FIX #923 (*link existing issues this PR will resolve*)

The LMCache cache server `Deployment` template had no `env:` block at all, so
there was no way to pass any environment variable to the cache-server
container through Helm values. Issue #923 reports the cache server getting
OOMKilled, and several commenters converged on the workaround of setting
`LMCACHE_CACHE_POLICY` / `LMCACHE_MAX_LOCAL_CPU_SIZE` (LMCache's own eviction
knobs) — but nobody could actually do that through this chart.

This PR does **not** pick an eviction policy or fix OOM behavior by default.
It only adds a generic, empty-by-default `cacheserverSpec.env` values field
(mirroring the existing `env` pattern used for `routerSpec.env` /
`$container.env` elsewhere in the chart) so users can self-configure LMCache's
eviction env vars, or any other env var, themselves. Default rendering is
byte-for-byte unchanged when `cacheserverSpec.env` is left unset.

Also updated `helm/values.schema.json` and `helm/README.md` to document the
new field, and extended the existing `helm/tests/cacheserver_test.yaml` suite
to cover it.

**Validation**
- `helm unittest helm -f 'tests/cacheserver_test.yaml'`: 2/2 pass.
- `helm unittest helm` (full suite): 142 passed, 2 failed. Both failures
  (`tests/deployment-vllm-multi_test.yaml` `asserts[3]`;
  `tests/ray-cluster_test.yaml` `asserts[1..3]`) are pre-existing and
  unrelated to this change — reproduced identically with this diff stashed
  out against unmodified `main`.
- `helm lint helm`: passes (only pre-existing unrelated warnings).
- `helm template` with no `cacheserverSpec.env` set renders the container
  with no `env:` key at all (unchanged default behavior); with
  `--set-json 'cacheserverSpec.env=[{"name":"LMCACHE_CACHE_POLICY","value":"LRU"}]'`
  it renders the env block correctly.
- Installed the `helm-values-schema-json` plugin and ran the exact
  `helm-schema` pre-commit hook this repo wires up in
  `.pre-commit-config.yaml` — it passed with zero additional diff, confirming
  `values.schema.json` is byte-identical to the tool's own generated output.
- Ran the repo's non-manual pre-commit hooks (check-json, check-yaml,
  end-of-file-fixer, trailing-whitespace, markdownlint, codespell) on all
  changed files: all passed.
- Could **not** run this repo's live-cluster "Functionality test for helm
  chart" GitHub Actions jobs (self-hosted minikube runners) — not available
  in this sandbox. Mitigated by the default-rendering check above: since this
  change is purely additive behind an empty-by-default list, it cannot affect
  any existing `tests/assets/values-*.yaml` file used by that workflow.
- Base branch CI (`Functionality test for helm chart` on `main`) is currently
  green.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
</details>