### PR TITLE
[Bugfix][Router] Update average decoding duration stats

### DIFF
--- a/src/tests/test_request_stats.py
+++ b/src/tests/test_request_stats.py
@@ -1,0 +1,23 @@
+import pytest
+
+from vllm_router.stats.request_stats import RequestStatsMonitor, SingletonMeta
+
+
+@pytest.fixture(autouse=True)
+def reset_request_stats_monitor():
+    SingletonMeta._instances.pop(RequestStatsMonitor, None)
+    yield
+    SingletonMeta._instances.pop(RequestStatsMonitor, None)
+
+
+def test_avg_decoding_length_tracks_decode_duration():
+    monitor = RequestStatsMonitor(sliding_window_size=60)
+    engine_url = "http://engine"
+
+    monitor.on_new_request(engine_url, "request-1", 100.0)
+    monitor.on_request_response(engine_url, "request-1", 101.0)
+    assert monitor.get_request_stats(101.0)[engine_url].avg_decoding_length == -1
+
+    monitor.on_request_complete(engine_url, "request-1", 105.0)
+    assert monitor.get_request_stats(105.0)[engine_url].avg_decoding_length == 4.0
+    assert monitor.get_request_stats(166.0)[engine_url].avg_decoding_length == -1

--- a/src/tests/test_request_stats.py
+++ b/src/tests/test_request_stats.py
@@ -20,4 +20,5 @@ def test_avg_decoding_length_tracks_decode_duration():
 
     monitor.on_request_complete(engine_url, "request-1", 105.0)
     assert monitor.get_request_stats(105.0)[engine_url].avg_decoding_length == 4.0
+    assert (engine_url, "request-1") not in monitor.first_token_time
     assert monitor.get_request_stats(166.0)[engine_url].avg_decoding_length == -1

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -216,7 +216,7 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
         )
         self.finished_requests[engine_url] += 1
 
-        first_token_time = self.first_token_time.get((engine_url, request_id))
+        first_token_time = self.first_token_time.pop((engine_url, request_id), None)
         if first_token_time is not None:
             if engine_url not in self.decoding_length_monitors:
                 self.decoding_length_monitors[engine_url] = MovingAverageMonitor(

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -216,6 +216,16 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
         )
         self.finished_requests[engine_url] += 1
 
+        first_token_time = self.first_token_time.get((engine_url, request_id))
+        if first_token_time is not None:
+            if engine_url not in self.decoding_length_monitors:
+                self.decoding_length_monitors[engine_url] = MovingAverageMonitor(
+                    self.sliding_window_size
+                )
+            self.decoding_length_monitors[engine_url].update(
+                timestamp, timestamp - first_token_time
+            )
+
         if request_start_time := self.request_start_time.get((engine_url, request_id)):
             self.latency_monitors[engine_url].update(
                 timestamp, time.time() - request_start_time
@@ -272,6 +282,7 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
             finished = self.finished_requests.get(engine_url, 0)
 
             if engine_url in self.decoding_length_monitors:
+                self.decoding_length_monitors[engine_url].update_no_value(current_time)
                 avg_dec_len = self.decoding_length_monitors[engine_url].get_average()
             else:
                 avg_dec_len = -1


### PR DESCRIPTION
## Summary

- update `decoding_length_monitors` when a request completes
- measure decoding duration as completion time minus first-token time, matching the existing `RequestStats.avg_decoding_length` definition
- expire decoding-duration samples outside the configured sliding window
- add a regression test covering pre-completion, completed, and expired samples

## Problem

`decoding_length_monitors` was initialized and read by `get_request_stats()`, but never updated, so `avg_decoding_length` remained `-1` after successfully completed requests. The existing source definition describes this value as the time from first token to completion, and `first_token_time` was already recorded but otherwise unused.

## Testing

- `pytest -q src/tests/test_request_stats.py src/tests/test_singleton.py src/tests/test_stale_metrics.py src/tests/test_metrics.py src/tests/test_instance_failover.py src/tests/test_request_validation.py src/tests/test_transcription_streaming.py` (32 passed)
- Router regression selection (68 passed)
- `black --check`
- `isort --check-only`
- `ruff check src/tests/test_request_stats.py`
- `codespell`
- `git diff --check`