### PR TITLE
[Router][Bugfix] Select longest LMCache prefix match

### DIFF
--- a/src/tests/test_kvaware_router.py
+++ b/src/tests/test_kvaware_router.py
@@ -9,15 +9,16 @@ from vllm_router.routers.routing_logic import KvawareRouter
 
 
 @pytest.fixture(autouse=True)
-def lookup_msg_stub(monkeypatch):
-    """Stub the optional LMCache message when the extra is not installed."""
+def lmcache_message_stubs(monkeypatch):
+    """Stub optional LMCache messages when the extra is not installed."""
 
-    class _LookupMsg:
+    class _Msg:
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    if not hasattr(routing_logic, "LookupMsg"):
-        monkeypatch.setattr(routing_logic, "LookupMsg", _LookupMsg, raising=False)
+    for name in ("LookupMsg", "QueryInstMsg"):
+        if not hasattr(routing_logic, name):
+            monkeypatch.setattr(routing_logic, name, _Msg, raising=False)
 
 
 class EndpointInfo:
@@ -71,6 +72,92 @@ async def test_kvaware_routes_to_longest_reported_prefix(threshold):
         endpoints,
         {},
         request_stats,
+        SimpleNamespace(headers={}),
+        {"prompt": "test"},
+    )
+
+    assert selected == url_b
+
+
+@pytest.mark.parametrize(
+    "instance_map",
+    [
+        pytest.param(
+            {
+                "dead-instance": "http://10.0.0.9:8000",
+                "instance-a": "http://10.0.0.1:8000",
+                "instance-b": "http://10.0.0.2:8000",
+            },
+            id="dead-pod-url",
+        ),
+        pytest.param(
+            {
+                "dead-instance": "http://10.0.0.1:8000",
+                "instance-b": "http://10.0.0.2:8000",
+                "instance-a": "http://10.0.0.1:8000",
+            },
+            id="restarted-instance-same-url",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_kvaware_ignores_cached_dead_holder(instance_map):
+    url_a = "http://10.0.0.1:8000"
+    url_b = "http://10.0.0.2:8000"
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = Tokenizer()
+    router.threshold = 1000
+    router.session_key = "x-session-id"
+    router.hash_ring = routing_logic.HashRing()
+    router.instance_id_to_ip = instance_map
+
+    async def query_manager(_msg):
+        return SimpleNamespace(
+            layout_info={
+                "dead-instance": ("LocalCPUBackend", 1000),
+                "instance-b": ("LocalCPUBackend", 800),
+            }
+        )
+
+    router.query_manager = query_manager
+    selected = await router.route_request(
+        [EndpointInfo(url_a), EndpointInfo(url_b)],
+        {},
+        {},
+        SimpleNamespace(headers={}),
+        {"prompt": "test"},
+    )
+
+    assert selected == url_b
+
+
+@pytest.mark.asyncio
+async def test_kvaware_refreshes_unknown_dead_holder_and_uses_live_match():
+    url_a = "http://10.0.0.1:8000"
+    url_b = "http://10.0.0.2:8000"
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = Tokenizer()
+    router.threshold = 1000
+    router.session_key = "x-session-id"
+    router.hash_ring = routing_logic.HashRing()
+    router.instance_id_to_ip = {"instance-b": url_b}
+
+    async def query_manager(msg):
+        if hasattr(msg, "tokens"):
+            return SimpleNamespace(
+                layout_info={
+                    "dead-instance": ("LocalCPUBackend", 1000),
+                    "instance-b": ("LocalCPUBackend", 800),
+                }
+            )
+        instance_id = "instance-a" if msg.ip == "10.0.0.1" else "instance-b"
+        return SimpleNamespace(instance_id=instance_id)
+
+    router.query_manager = query_manager
+    selected = await router.route_request(
+        [EndpointInfo(url_a), EndpointInfo(url_b)],
+        {},
+        {},
         SimpleNamespace(headers={}),
         {"prompt": "test"},
     )

--- a/src/tests/test_kvaware_router.py
+++ b/src/tests/test_kvaware_router.py
@@ -1,0 +1,78 @@
+"""Unit tests for the KV-cache-aware routing logic."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm_router.routers.routing_logic as routing_logic
+from vllm_router.routers.routing_logic import KvawareRouter
+
+
+@pytest.fixture(autouse=True)
+def lookup_msg_stub(monkeypatch):
+    """Stub the optional LMCache message when the extra is not installed."""
+
+    class _LookupMsg:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    if not hasattr(routing_logic, "LookupMsg"):
+        monkeypatch.setattr(routing_logic, "LookupMsg", _LookupMsg, raising=False)
+
+
+class EndpointInfo:
+    def __init__(self, url):
+        self.url = url
+        self.model_names = ["test-model"]
+
+
+class Tokenizer:
+    def encode(self, prompt):
+        return list(range(1000))
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    [
+        pytest.param(900, id="both-matches-pass-threshold"),
+        pytest.param(0, id="only-longest-match-passes-threshold"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_kvaware_routes_to_longest_reported_prefix(threshold):
+    url_a = "http://10.0.0.1:8000"
+    url_b = "http://10.0.0.2:8000"
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizer = Tokenizer()
+    router.threshold = threshold
+    router.session_key = "x-session-id"
+    router.hash_ring = routing_logic.HashRing()
+    router.instance_id_to_ip = {
+        "instance-a": url_a,
+        "instance-b": url_b,
+    }
+
+    async def query_manager(_msg):
+        return SimpleNamespace(
+            layout_info={
+                "instance-a": ("LocalCPUBackend", 100),
+                "instance-b": ("LocalCPUBackend", 1000),
+            }
+        )
+
+    router.query_manager = query_manager
+    endpoints = [EndpointInfo(url_a), EndpointInfo(url_b)]
+    request_stats = {
+        url_a: SimpleNamespace(qps=0),
+        url_b: SimpleNamespace(qps=1),
+    }
+
+    selected = await router.route_request(
+        endpoints,
+        {},
+        request_stats,
+        SimpleNamespace(headers={}),
+        {"prompt": "test"},
+    )
+
+    assert selected == url_b

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -411,11 +411,12 @@ class KvawareRouter(RoutingInterface):
         msg = LookupMsg(tokens=token_ids, event_id=event_id)
         instance_id = await self.query_manager(msg)
         matched_tokens = math.inf
+        matched_instance_id = None
         logger.debug(f"Lookup return message: {instance_id}")
         if len(list(instance_id.layout_info.keys())) > 0:
-            matched_instance_id = list(instance_id.layout_info.keys())[
-                0
-            ]  # Get the first key
+            matched_instance_id = max(
+                instance_id.layout_info, key=lambda key: instance_id.layout_info[key][1]
+            )
             matched_tokens = instance_id.layout_info[matched_instance_id][1]
 
         if (
@@ -435,8 +436,7 @@ class KvawareRouter(RoutingInterface):
                 url = self.hash_ring.get_node(session_id)
             return url
         else:
-            queried_instance_ids = [info for info in instance_id.layout_info]
-            if queried_instance_ids[0] not in self.instance_id_to_ip:
+            if matched_instance_id not in self.instance_id_to_ip:
                 for endpoint in endpoints:
                     event_id = "QueryInst" + str(uuid.uuid4())
                     query_ip = endpoint.url.split(f":{endpoint.url.split(':')[-1]}")[
@@ -455,9 +455,9 @@ class KvawareRouter(RoutingInterface):
                     )
                 logger.info(f"Instance id to ip mapping: {self.instance_id_to_ip}")
             logger.info(
-                f"Routing request to {queried_instance_ids[0]} found by kvaware router"
+                f"Routing request to {matched_instance_id} found by kvaware router"
             )
-            return self.instance_id_to_ip[queried_instance_ids[0]]
+            return self.instance_id_to_ip[matched_instance_id]
 
 
 class LoadAwareRouter(KvawareRouter):

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -413,15 +413,51 @@ class KvawareRouter(RoutingInterface):
         matched_tokens = math.inf
         matched_instance_id = None
         logger.debug(f"Lookup return message: {instance_id}")
-        if len(list(instance_id.layout_info.keys())) > 0:
-            matched_instance_id = max(
-                instance_id.layout_info, key=lambda key: instance_id.layout_info[key][1]
-            )
-            matched_tokens = instance_id.layout_info[matched_instance_id][1]
+        layout_info = instance_id.layout_info
+        if layout_info:
+            mapped_urls = set(self.instance_id_to_ip.values())
+            if any(endpoint.url not in mapped_urls for endpoint in endpoints) or any(
+                holder not in self.instance_id_to_ip for holder in layout_info
+            ):
+                for endpoint in endpoints:
+                    event_id = "QueryInst" + str(uuid.uuid4())
+                    query_ip = endpoint.url.split(f":{endpoint.url.split(':')[-1]}")[
+                        0
+                    ].split("//")[1]
+                    query_message = QueryInstMsg(
+                        ip=query_ip,
+                        event_id=event_id,
+                    )
+                    endpoint_instance_id = await self.query_manager(query_message)
+                    logger.debug(
+                        f"Query ip: {query_ip}, return instance id: "
+                        f"{endpoint_instance_id}"
+                    )
+                    self.instance_id_to_ip[endpoint_instance_id.instance_id] = (
+                        endpoint.url
+                    )
+                logger.info(f"Instance id to ip mapping: {self.instance_id_to_ip}")
+
+            live_urls = {endpoint.url for endpoint in endpoints}
+            url_to_instance = {
+                url: holder
+                for holder, url in self.instance_id_to_ip.items()
+                if url in live_urls
+            }
+            live_holders = [
+                holder for holder in layout_info if holder in url_to_instance.values()
+            ]
+        else:
+            live_holders = []
+
+        if live_holders:
+            matched_instance_id = max(live_holders, key=lambda key: layout_info[key][1])
+            matched_tokens = layout_info[matched_instance_id][1]
 
         if (
             instance_id is None
             or len(instance_id.layout_info) == 0
+            or matched_instance_id is None
             or matched_tokens < max(len(token_ids) - self.threshold, 0)
         ):
             session_id = self.extract_session_id(request, request_json)
@@ -435,29 +471,8 @@ class KvawareRouter(RoutingInterface):
                 # Use the hash ring to get the endpoint for the session ID
                 url = self.hash_ring.get_node(session_id)
             return url
-        else:
-            if matched_instance_id not in self.instance_id_to_ip:
-                for endpoint in endpoints:
-                    event_id = "QueryInst" + str(uuid.uuid4())
-                    query_ip = endpoint.url.split(f":{endpoint.url.split(':')[-1]}")[
-                        0
-                    ].split("//")[1]
-                    query_message = QueryInstMsg(
-                        ip=query_ip,
-                        event_id=event_id,
-                    )
-                    endpoint_instance_id = await self.query_manager(query_message)
-                    logger.debug(
-                        f"Query ip: {query_ip}, return instance id: {endpoint_instance_id}"
-                    )
-                    self.instance_id_to_ip[endpoint_instance_id.instance_id] = (
-                        endpoint.url
-                    )
-                logger.info(f"Instance id to ip mapping: {self.instance_id_to_ip}")
-            logger.info(
-                f"Routing request to {matched_instance_id} found by kvaware router"
-            )
-            return self.instance_id_to_ip[matched_instance_id]
+        logger.info(f"Routing request to {matched_instance_id} found by kvaware router")
+        return self.instance_id_to_ip[matched_instance_id]
 
 
 class LoadAwareRouter(KvawareRouter):


### PR DESCRIPTION
## Summary

- select the LMCache `layout_info` entry with the largest `matched_prefix_length`
- use that same instance for the KV-aware threshold check and backend selection
- add a regression test covering both direct misrouting and incorrect fallback when a later entry is the longest match

LMCache defines `layout_info` as `instance_id -> (location, matched_prefix_length)`, but does not define dictionary order as a best-match ordering. Its controller builds the mapping while walking chunks, so the first inserted instance is not necessarily the longest match.

## Tests

```text
57 passed in 3.27s
```

The regression test fails twice on current `main` and passes with this change.

Static checks run on the changed files:

- black 25.1.0
- isort 6.0.0
- ruff 0.12.0
- codespell 2.4.1
- `git diff --check`

All passed.

---

- [x] Make sure the code changes pass the pre-commit checks.
- [x] Sign off the commit using `git commit -s`.
- [x] Classify the PR title.