### PR TITLE
[Doc][Bugfix] Pin KubeRay pipeline-parallel tutorial to a vLLM image that ships the ray CLI

### DIFF
--- a/docs/source/use_cases/pipeline-parallelism-kuberay.rst
+++ b/docs/source/use_cases/pipeline-parallelism-kuberay.rst
@@ -52,8 +52,8 @@ Explanation of Key Items in ``values-15-a-minimal-pipeline-parallel-example-rayc
   - **requestGPU**: Defines the number of GPUs to allocate for the KubeRay head pod. Currently, the Ray head node must also participate in both tensor parallelism and pipeline parallelism. This requirement exists because the ``vllm serve ...`` command is executed on the Ray head node, and vLLM mandates that the pod where this command is run must have at least one visible GPU.
 
 - **name**: The unique identifier for your model deployment.
-- **repository**: The Docker repository containing the model's serving engine image. RayCluster images must include both the Ray Python package and the ``ray`` CLI because KubeRay uses them to start the head and worker nodes. The example uses ``lmcache/vllm-openai``, which includes the Ray runtime.
-- **tag**: Specifies the version of the model image to use.
+- **repository**: The Docker repository containing the model's serving engine image. RayCluster images must include both the Ray Python package and the ``ray`` CLI because KubeRay starts the head and worker containers with a generated ``ray start`` command. The example uses ``vllm/vllm-openai``.
+- **tag**: Specifies the version of the model image to use. This must stay pinned to ``v0.17.1``, the last ``vllm/vllm-openai`` tag that ships Ray: vLLM removed Ray from the image's CUDA dependencies in v0.18.0, so newer tags (including ``latest``) do not contain the ``ray`` executable. Current ``lmcache/vllm-openai`` tags do not contain it either. If you substitute your own image, verify it first with ``docker run --rm --entrypoint /bin/bash <image> -c "command -v ray"``.
 - **modelURL**: The URL pointing to the model on Hugging Face or another hosting service.
 - **replicaCount**: The number of total Kuberay worker pods.
 - **requestCPU**: The amount of CPU resources requested per Kuberay worker pod.
@@ -89,8 +89,8 @@ In the following example, we configure a total of two Ray nodes each equipped wi
      runtimeClassName: ""
      modelSpec:
      - name: "distilgpt2"
-       repository: "lmcache/vllm-openai"
-       tag: "latest"
+       repository: "vllm/vllm-openai"
+       tag: "v0.17.1"
        modelURL: "distilbert/distilgpt2"
 
        replicaCount: 1

--- a/tutorials/15-basic-pipeline-parallel.md
+++ b/tutorials/15-basic-pipeline-parallel.md
@@ -46,8 +46,8 @@ This tutorial provides a step-by-step guide for configuring and deploying the vL
   - **`requestMemory`**: Memory allocation for Kuberay head pod. Sufficient memory is required to load the model.
   - **`requestGPU`**: Defines the number of GPUs to allocate for the KubeRay head pod. Currently, the Ray head node must also participate in both tensor parallelism and pipeline parallelism. This requirement exists because the `vllm serve ...` command is executed on the Ray head node, and vLLM mandates that the pod where this command is run must have at least one visible GPU.
 - **`name`**: The unique identifier for your model deployment.
-- **`repository`**: The Docker repository containing the model's serving engine image. RayCluster images must include both the Ray Python package and the `ray` CLI because KubeRay uses them to start the head and worker nodes. The example uses `lmcache/vllm-openai`, which includes the Ray runtime.
-- **`tag`**: Specifies the version of the model image to use.
+- **`repository`**: The Docker repository containing the model's serving engine image. RayCluster images must include both the Ray Python package and the `ray` CLI because KubeRay starts the head and worker containers with a generated `ray start` command. The example uses `vllm/vllm-openai`.
+- **`tag`**: Specifies the version of the model image to use. This must stay pinned to `v0.17.1`, the last `vllm/vllm-openai` tag that ships Ray: vLLM removed Ray from the image's CUDA dependencies in v0.18.0, so newer tags (including `latest`) do not contain the `ray` executable. Current `lmcache/vllm-openai` tags do not contain it either. If you substitute your own image, verify it first with `docker run --rm --entrypoint /bin/bash <image> -c "command -v ray"`.
 - **`modelURL`**: The URL pointing to the model on Hugging Face or another hosting service.
 - **`replicaCount`**: The number of total Kuberay worker pods.
 - **`requestCPU`**: The amount of CPU resources requested per Kuberay worker pod.
@@ -76,8 +76,8 @@ servingEngineSpec:
   runtimeClassName: ""
   modelSpec:
   - name: "distilgpt2"
-    repository: "lmcache/vllm-openai"
-    tag: "latest"
+    repository: "vllm/vllm-openai"
+    tag: "v0.17.1"
     modelURL: "distilbert/distilgpt2"
 
     replicaCount: 1

--- a/tutorials/assets/values-15-a-minimal-pipeline-parallel-example-raycluster.yaml
+++ b/tutorials/assets/values-15-a-minimal-pipeline-parallel-example-raycluster.yaml
@@ -2,8 +2,12 @@ servingEngineSpec:
   runtimeClassName: ""
   modelSpec:
   - name: "distilgpt2-raycluster"
-    repository: "lmcache/vllm-openai"
-    tag: "latest"
+    # KubeRay starts the head and worker containers with a generated `ray start`
+    # command, so this image must ship the `ray` CLI. vllm/vllm-openai removed
+    # Ray from its image dependencies in v0.18.0; v0.17.1 is the last tag that
+    # includes it. Current lmcache/vllm-openai tags do not include Ray either.
+    repository: "vllm/vllm-openai"
+    tag: "v0.17.1"
     modelURL: "distilbert/distilgpt2"
 
     replicaCount: 1

--- a/tutorials/assets/values-15-b-minimal-pipeline-parallel-example-multiple-modelspec.yaml
+++ b/tutorials/assets/values-15-b-minimal-pipeline-parallel-example-multiple-modelspec.yaml
@@ -2,8 +2,12 @@ servingEngineSpec:
   runtimeClassName: ""
   modelSpec:
   - name: "distilgpt2-raycluster"
-    repository: "lmcache/vllm-openai"
-    tag: "latest"
+    # KubeRay starts the head and worker containers with a generated `ray start`
+    # command, so this image must ship the `ray` CLI. vllm/vllm-openai removed
+    # Ray from its image dependencies in v0.18.0; v0.17.1 is the last tag that
+    # includes it. Current lmcache/vllm-openai tags do not include Ray either.
+    repository: "vllm/vllm-openai"
+    tag: "v0.17.1"
     modelURL: "distilbert/distilgpt2"
 
     replicaCount: 1


### PR DESCRIPTION
## Summary

Tutorial 15 (pipeline parallelism with KubeRay) still fails with `ray: command not found` after #1000. This PR pins the RayCluster examples to `vllm/vllm-openai:v0.17.1`, the newest published vLLM image tag that ships the `ray` CLI, and documents the constraint so future image changes keep it.

Fixes #995

## Root cause

The chart passes `modelSpec.repository:tag` directly to both RayCluster container groups (`helm/templates/ray-cluster.yaml`, `vllm-ray-head` and `vllm-ray-worker`). The KubeRay operator then appends its generated startup command to the container command (`ray-operator/controllers/ray/common/pod.go` on kuberay master: `args = fmt.Sprintf("%s && %s", cmd, generatedCmd)` where `generatedCmd` is `ulimit -n ...; ray start ...`), so the image itself must provide `ray` on PATH.

#1000 switched the examples from `vllm/vllm-openai:latest` to `lmcache/vllm-openai:latest` on the premise that the LMCache image includes the Ray runtime. It does not:

- `lmcache/vllm-openai:latest` (amd64, inspected 2026-08-26): its Dockerfile RUN line (visible in the image history) installs `vllm[runai,tensorizer,flashinfer]` plus `lmcache` into `/opt/venv`. None of these pull in Ray. A streamed listing of that layer shows the complete `opt/venv/bin/` directory (66 entries, alphabetical): it contains `vllm`, `lmcache`, `torchrun`, etc. and no `ray` entry. This matches the reproduction in #995: the deployed pod image was confirmed as `lmcache/vllm-openai:latest` and still failed with `ray: command not found`.
- Reverting to `vllm/vllm-openai:latest` would not help either: vLLM removed `ray[cgraph]` from `requirements/cuda.txt` in v0.18.0. It is present at v0.17.1 and absent at every minor release tag from v0.18.0 through v0.27.1 and at the commit `latest` (v0.28.0) was built from (`2cf0a6915`). `vllm==0.27.1` on PyPI has no ray requirement and no ray extra.

So both image choices fail today. The newest `vllm/vllm-openai` tag that still ships Ray is `v0.17.1`.

## Changes

- `tutorials/assets/values-15-a-...raycluster.yaml`, `values-15-b-...multiple-modelspec.yaml`: pin the RayCluster modelSpec to `vllm/vllm-openai:v0.17.1`, with a comment stating the constraint. The non-Ray `opt125m-deployment` modelSpec in 15-b is untouched (plain Deployment, no `ray` involved).
- `tutorials/15-basic-pipeline-parallel.md`, `docs/source/use_cases/pipeline-parallelism-kuberay.rst`: update the `repository`/`tag` explanations, state why the pin exists, and give a one-line `docker run` command to vet substitute images.

## Validation

Image contents (verified from Docker Hub layer blobs, no assertion from memory):

- `vllm/vllm-openai:v0.17.1` amd64: `requirements/cuda.txt` at tag v0.17.1 contains `ray[cgraph]>=2.48.0`, and streaming the layer created by `uv pip install --system -r /tmp/requirements-cuda.txt` (`sha256:b78f068475de...`) yields:

  ```text
  -rwxr-xr-x  0 0      0         301 Mar 11 03:02 usr/local/bin/ray
  ```

  The image config's `PATH` includes `/usr/local/bin`, and its entrypoint is `["vllm", "serve"]`.

- `lmcache/vllm-openai:latest` amd64: streaming the venv install layer (`sha256:7d74ca5d78be...`) lists all 66 `opt/venv/bin/` entries; there is no `ray` entry (excerpt around where it would sort: `py.test, pybase64, pygmentize, pytest, readelf.py, run-iket`).

Chart render (helm v4.2.4):

```console
$ helm template vllm ./helm -f tutorials/assets/values-15-a-minimal-pipeline-parallel-example-raycluster.yaml
...
          - name: vllm-ray-head
            image: "vllm/vllm-openai:v0.17.1"
            imagePullPolicy: "Always"
...
            - name: vllm-ray-worker
              image: "vllm/vllm-openai:v0.17.1"
              imagePullPolicy: "Always"
```

Same result for values-15-b (head and worker pinned; the non-Ray Deployment keeps `vllm/vllm-openai:latest`).

Compatibility of the pinned tag with the chart's entrypoint: at v0.17.1 the `ray` distributed executor backend is present (`vllm/v1/executor/ray_distributed_executor.py`, `DistributedExecutorBackend = Literal["ray", "mp", ...]`), and the chart-injected `VLLM_USE_V1` env var is ignored (zero references in the v0.17.1 source tree).

`pre-commit run` on the four changed files: check yaml, fix end of files, trim trailing whitespace, markdownlint, codespell all Passed.

Not run: a full multi-GPU KubeRay E2E deployment. Validation here is at the image-contents and chart-render level.

cc @ruizhang0101 who reopened

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using `-s` when doing `git commit`
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
