### PR TITLE
[Bugfix] Use TCP liveness probe for LMCache server

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -341,7 +341,7 @@ Set `servingEngineSpec.modelSpec[].raySpec.enabled: true` to deploy the model as
 | `cacheserverSpec.resources` | map | `{}` | Resource requests and limits |
 | `cacheserverSpec.labels` | map | `{environment: "cache", release: "cache"}` | Customized labels for the cache server deployment |
 | `cacheserverSpec.strategy` | map | `{}` | Deployment strategy for the cache server pods |
-| `cacheserverSpec.livenessProbe` | map | `{initialDelaySeconds: 15, periodSeconds: 10, failureThreshold: 3, httpGet: {path: /health, port: 8000}}` | Configuration for the liveness probe |
+| `cacheserverSpec.livenessProbe` | map | `{initialDelaySeconds: 30, periodSeconds: 10, failureThreshold: 3, timeoutSeconds: 5}` | Timing configuration for the TCP socket liveness probe on `cacheserverSpec.containerPort` |
 | `cacheserverSpec.tolerations` | list | `[]` | Tolerations configuration for the cache server pods |
 | `cacheserverSpec.runtimeClassName` | string | `""` | RuntimeClassName configuration for the cache server pods |
 | `cacheserverSpec.schedulerName` | string | `""` | SchedulerName configuration for the cache server pods |

--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -77,12 +77,8 @@ spec:
             periodSeconds: {{ .Values.cacheserverSpec.livenessProbe.periodSeconds | default 10 }}
             failureThreshold: {{ .Values.cacheserverSpec.livenessProbe.failureThreshold | default 3 }}
             timeoutSeconds: {{ .Values.cacheserverSpec.livenessProbe.timeoutSeconds | default 5 }}
-            exec:
-              command:
-              - "/opt/venv/bin/python3"
-              - "/workspace/LMCache/examples/kubernetes/health_probe.py"
-              - "127.0.0.1"
-              - "{{ .Values.cacheserverSpec.containerPort }}"
+            tcpSocket:
+              port: {{ .Values.cacheserverSpec.containerPort }}
           {{- end }}
           {{- with .Values.cacheserverSpec.containerSecurityContext }}
           securityContext:

--- a/helm/tests/cacheserver_test.yaml
+++ b/helm/tests/cacheserver_test.yaml
@@ -172,12 +172,8 @@ tests:
           periodSeconds: 20
           failureThreshold: 6
           timeoutSeconds: 10
-          exec:
-            command:
-            - "/opt/venv/bin/python3"
-            - "/workspace/LMCache/examples/kubernetes/health_probe.py"
-            - "127.0.0.1"
-            - "8000"
+          tcpSocket:
+            port: 8000
     - equal:
         path: spec.template.spec.containers[0].securityContext
         value:


### PR DESCRIPTION
Fixes #1057

## What changed

- replace the cache server exec liveness probe with a Kubernetes TCP socket probe on `cacheserverSpec.containerPort`
- update the focused Helm assertion for the rendered probe
- correct the cache server probe documentation and defaults

## Why

The current LMCache image does not contain the referenced `health_probe.py` script. The cache server exposes a TCP protocol, not an HTTP health endpoint, so probing its listening socket avoids restart loops caused by an image-specific script path.

## Validation

- `helm lint helm`
- focused cache server Helm unit suite: 2 tests passed
- rendered the cache server deployment and verified `tcpSocket.port: 8000`
- repository YAML, EOF, trailing-whitespace, and codespell hooks on touched files
- markdownlint-cli 0.44.0 on `helm/README.md`
- `git diff --check` and `git show --check HEAD`

## Limitations

The full Helm unit suite reported 142 passing tests and two unrelated failures in the existing chat-template and RayCluster suites under the local Helm/plugin versions. No live Kubernetes or LMCache image test was run.

- [x] Relevant pre-commit checks pass
- [x] Commit is signed off for DCO
- [x] PR title is classified

This draft was prepared with AI assistance and has not yet been human-reviewed.