### PR TITLE
[CI/Build][Router] Enable lmcache 0.5.4 for the kvaware router stack

### DIFF
--- a/docker/Dockerfile.kvaware
+++ b/docker/Dockerfile.kvaware
@@ -1,4 +1,9 @@
-FROM lmcache/vllm-openai:2025-05-27-v1
+# The base image supplies the lmcache + vllm pair the router runs with.
+# It MUST match the engines' image versions: lmcache's controller<->worker
+# ZMQ messages are version-locked, and kv-aware chunk hashes are rooted in
+# vLLM's NONE_HASH - a mismatch on either side makes every KV lookup miss
+# silently (routing degrades to session/QPS with no error).
+FROM lmcache/vllm-openai:v0.5.4
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,21 @@ semantic_cache = [
     "huggingface-hub==0.34.0",
 ]
 lmcache = [
-    "lmcache==0.3.11",
-    "vllm==0.13.0",
+    # lmcache's controller<->worker ZMQ messages are NOT a stable protocol
+    # across versions (a 0.3.x controller rejects a 0.4+/0.5+ worker's
+    # RegisterMsg as an unknown type), so the router-side lmcache MUST match
+    # the engines' lmcache exactly - keep this pin in lockstep with the
+    # engine images you deploy. vllm is required for hash parity: kv-aware
+    # chunk hashes are rooted in vLLM's NONE_HASH and hash fn, and a router
+    # without the engines' vllm derives a different chain (every lookup
+    # silently misses).
+    "lmcache==0.5.4",
+    "vllm==0.22.0",
 ]
 test = [
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.3",
-    "vllm==0.13.0"
+    "vllm==0.22.0"
 ]
 
 [build-system]

--- a/tutorials/assets/values-17-kv-aware.yaml
+++ b/tutorials/assets/values-17-kv-aware.yaml
@@ -3,7 +3,7 @@ servingEngineSpec:
   modelSpec:
   - name: "gpt-oss-20b"
     repository: "lmcache/vllm-openai"
-    tag: "v0.3.9post2"
+    tag: "v0.5.4"
     modelURL: "openai/gpt-oss-20b"
     replicaCount: 2
     requestCPU: 8


### PR DESCRIPTION
Enables the current lmcache release (0.5.4) across the kvaware router stack, as a standalone diff (3 files, +18/−5). Independent of the chat-tokenization fix in #1045 — mergeable in either order.

### What it changes

| pin | before | after |
|---|---|---|
| `[lmcache]` extra: `lmcache` | `0.3.11` | `0.5.4` (current stable) |
| `[lmcache]` / `[test]` extras: `vllm` | `0.13.0` | `0.22.0` |
| `docker/Dockerfile.kvaware` base | `lmcache/vllm-openai:2025-05-27-v1` | `lmcache/vllm-openai:v0.5.4` |
| tutorial-17 engine image | `v0.3.9post2` | `v0.5.4` |

Each pin site now carries a comment documenting **why the versions must move in lockstep** — two silent failure modes observed on real hardware while validating #1045:
1. lmcache's controller↔worker ZMQ messages are **not a stable protocol across versions**: a 0.3.x controller rejects a 0.4+/0.5+ worker's `RegisterMsg` as "unknown message type," and the worker never registers — every KV lookup misses, routing degrades to session/QPS with no error.
2. kv-aware chunk hashes are rooted in **vLLM's `NONE_HASH`** — a router whose vllm differs from the engines' derives a different hash chain, and again every lookup silently misses.

### Verification

- Router's full lmcache API surface probed against 0.5.4: `LMCacheControllerManager` constructor (unchanged signature + two new optional params), `handle_orchestration_message`, `start_all`, `LookupMsg`, `QueryInstMsg` — all construct and behave.
- Full router test suite: 220/220 at this branch.
- The 0.4.5 pairing of the same wiring was validated end-to-end on hardware (2×H200 + 1×H100 runs — see vllm-project/production-stack#1045's validation section).

### Engine-side pairing caveat (scope of this PR's verification)

This PR's 0.5.4 verification covers the **router path** (controller manager, orchestration messages, lookup/query types — probed directly against 0.5.4). The **engine-side** `LMCacheConnectorV1` integration is a separate axis: lmcache 0.5.x's vllm adapter tracks recent/nightly vLLM APIs, and a downstream deployment reports that **pip lmcache 0.5.4 does not communicate correctly through the v1 connector against a vLLM v0.22-class engine build** — while pip lmcache **0.4.5 + vLLM v0.22.0 through the same connector is validated end-to-end on hardware**. Practical guidance:

- The bundled `lmcache/vllm-openai:v0.5.4` image (what this PR pins for the tutorial and the kvaware router image) is **internally matched** — lmcache built against the vLLM it ships with.
- **Bring-your-own-vLLM engine builds** should pair pip lmcache to their vLLM generation (0.4.5 for v0.22-class is the validated pairing) rather than assuming the newest lmcache works — and the router's lmcache pin must then follow the engines (the lockstep rule above).

### One heads-up for 0.5.4 adopters

lmcache 0.5.4 still defaults `lmcache_worker_heartbeat_time: None` — **workers never send heartbeats by default, while the controller reaps silent workers after ~30s**, emptying the KV index shortly after startup ("misses that shouldn't be occurring"). The helm chart already maps `lmcacheConfig.workerHeartbeatTime` → `LMCACHE_LMCACHE_WORKER_HEARTBEAT_TIME` and tutorial-17's values set it to `"30"`, so chart-driven deployments are safe — but any hand-rolled engine config must set it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
