### PR TITLE
[Doc] Tutorial 17: troubleshooting the silent-miss preconditions of kvaware routing

### DIFF
--- a/tutorials/17-kv-aware-routing.md
+++ b/tutorials/17-kv-aware-routing.md
@@ -105,7 +105,9 @@ in order (each was hit in a real deployment):
    (lmcache logs a warning about this at startup; it is easy to miss.)
 4. **Worker heartbeats must be enabled** (`lmcacheConfig.workerHeartbeatTime`
    in this tutorial's values, mapping to
-   `LMCACHE_LMCACHE_WORKER_HEARTBEAT_TIME`). lmcache workers default to
+   `LMCACHE_LMCACHE_WORKER_HEARTBEAT_TIME`; the chart consumes the key via a
+   `hasKey` guard in `helm/templates/deployment-vllm-multi.yaml`, so it does
+   not appear in `values.yaml` defaults). lmcache workers default to
    never sending heartbeats while the controller reaps silent workers after
    ~30 seconds - with the default, the KV index silently empties shortly
    after startup and hits stop "for no reason". Hand-rolled engine configs

--- a/tutorials/17-kv-aware-routing.md
+++ b/tutorials/17-kv-aware-routing.md
@@ -82,6 +82,49 @@ To clean up the deployment:
 helm uninstall vllm
 ```
 
+## Troubleshooting: the silent-miss preconditions
+
+KV-aware routing fails **silently**: when any precondition below is violated,
+requests still succeed - the router just falls back to session/QPS placement
+and every KV lookup misses. If routing never reports cache hits, check these
+in order (each was hit in a real deployment):
+
+1. **Same lmcache version on router and engines.** The controller<->worker
+   ZMQ messages are not a stable protocol across lmcache versions - an old
+   controller rejects a newer worker's `RegisterMsg` as an unknown message
+   type, the worker never registers, and every lookup misses. The router
+   image and engine images must carry the same lmcache.
+2. **The router needs the engines' vLLM installed.** KV chunk hashes are
+   rooted in vLLM's `NONE_HASH` and hash function. A router without vLLM
+   falls back to `NONE_HASH=0` and a plain Python hash - a different hash
+   chain from the engines', so no lookup can ever match. This is why
+   `docker/Dockerfile.kvaware` builds the router FROM a vLLM image.
+3. **Set `PYTHONHASHSEED` identically on router and engines** when the
+   builtin hash is in use - Python's `hash()` is seed-randomized per
+   process, and unseeded processes can never agree on chunk hashes.
+   (lmcache logs a warning about this at startup; it is easy to miss.)
+4. **Worker heartbeats must be enabled** (`lmcacheConfig.workerHeartbeatTime`
+   in this tutorial's values, mapping to
+   `LMCACHE_LMCACHE_WORKER_HEARTBEAT_TIME`). lmcache workers default to
+   never sending heartbeats while the controller reaps silent workers after
+   ~30 seconds - with the default, the KV index silently empties shortly
+   after startup and hits stop "for no reason". Hand-rolled engine configs
+   must set this explicitly.
+5. **One cache-owning instance per IP.** The controller attributes
+   instances to endpoints by IP alone (`QueryInstMsg`), so several engines
+   sharing one IP (e.g. one multi-GPU host with host networking) are
+   indistinguishable and requests kv-followed to the unmapped ones fall
+   back (older routers crashed with a 500 - see the fix in the router
+   changelog). Give each engine a distinct routable IP.
+6. **Sliding-window / hybrid-attention models pay a hidden KV cost.**
+   `LMCacheConnectorV1` does not support vLLM's hybrid KV cache manager,
+   so configuring it makes vLLM silently disable that manager - on models
+   with sliding-window layers (Gemma-family and others) this inflates
+   per-token KV usage several-fold, shrinking the effective KV budget by
+   as much as ~10x. Only a startup log line warns about it. lmcache's
+   `LMCacheMPConnector` (multiprocess cache server) is the HMA-capable
+   path for such models.
+
 ## Conclusion
 
 In this tutorial, we've demonstrated how to:


### PR DESCRIPTION
KV-aware routing fails **silently** — when a wiring precondition is violated, requests still succeed and the router just falls back to session/QPS, so every KV lookup misses with nothing above a debug line to explain why. This adds a troubleshooting section to tutorial 17 documenting the six preconditions, each one hit in a real deployment while validating #1045/#1060/#1061:

1. same lmcache version on router and engines (ZMQ messages are version-locked)
2. vLLM installed in the router (`NONE_HASH` roots the chunk-hash chain — a vllm-less router can never match)
3. `PYTHONHASHSEED` parity (builtin hash is process-seed-randomized)
4. worker heartbeats enabled (workers default to never sending them; the controller reaps silent workers at ~30s and the KV index silently empties)
5. one cache-owning instance per IP (`QueryInstMsg` attributes by IP alone)
6. the hidden hybrid-KV-manager cost of `LMCacheConnectorV1` on sliding-window models (vLLM silently disables HMA — up to ~10× per-token KV inflation; `LMCacheMPConnector` is the HMA-capable path)

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)