### PR TITLE
fix: Use broad except clause for k8s config loading to avoid TypeError

### DIFF
--- a/src/vllm_router/service_discovery.py
+++ b/src/vllm_router/service_discovery.py
@@ -448,7 +448,7 @@ class K8sPodIPServiceDiscovery(ServiceDiscovery):
         # Init kubernetes watcher
         try:
             config.load_incluster_config()
-        except config.ConfigException:
+        except Exception:
             config.load_kube_config()
 
         self.k8s_api = client.CoreV1Api()
@@ -957,7 +957,7 @@ class K8sServiceNameServiceDiscovery(ServiceDiscovery):
         # Init kubernetes watcher
         try:
             config.load_incluster_config()
-        except config.ConfigException:
+        except Exception:
             config.load_kube_config()
 
         self.k8s_api = client.CoreV1Api()


### PR DESCRIPTION
### Description

When initializing `K8sPodIPServiceDiscovery` or `K8sServiceNameServiceDiscovery`, catching `config.ConfigException` can raise a `TypeError` on some kubernetes client versions (e.g. 32.0.0) where `ConfigException` may not inherit from `BaseException` in certain environments.

### Changes

Replaced `except config.ConfigException:` with `except Exception:` in both:
- `K8sPodIPServiceDiscovery.__init__()`
- `K8sServiceNameServiceDiscovery.__init__()`

This is more robust because:
- `ConfigException` inherits from `Exception`, so the behavior is identical in normal cases
- A broad `except Exception` handles edge cases where the exception class itself may not be a valid BaseException subclass
- The intent of the code is to fall back to kube config when in-cluster config fails for any reason

Closes #660