### PR TITLE
fix: Replace exec liveness probe with tcpSocket for LMCache cache server

### DIFF
--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -78,7 +78,7 @@ spec:
             failureThreshold: {{ .Values.cacheserverSpec.livenessProbe.failureThreshold | default 3 }}
             timeoutSeconds: {{ .Values.cacheserverSpec.livenessProbe.timeoutSeconds | default 5 }}
             tcpSocket:
-              port: {{ .Values.cacheserverSpec.containerPort }}
+              port: caserver-cport
           {{- end }}
           {{- with .Values.cacheserverSpec.containerSecurityContext }}
           securityContext:

--- a/helm/templates/deployment-cache-server.yaml
+++ b/helm/templates/deployment-cache-server.yaml
@@ -77,12 +77,8 @@ spec:
             periodSeconds: {{ .Values.cacheserverSpec.livenessProbe.periodSeconds | default 10 }}
             failureThreshold: {{ .Values.cacheserverSpec.livenessProbe.failureThreshold | default 3 }}
             timeoutSeconds: {{ .Values.cacheserverSpec.livenessProbe.timeoutSeconds | default 5 }}
-            exec:
-              command:
-              - "/opt/venv/bin/python3"
-              - "/workspace/LMCache/examples/kubernetes/health_probe.py"
-              - "127.0.0.1"
-              - "{{ .Values.cacheserverSpec.containerPort }}"
+            tcpSocket:
+              port: {{ .Values.cacheserverSpec.containerPort }}
           {{- end }}
           {{- with .Values.cacheserverSpec.containerSecurityContext }}
           securityContext:

--- a/helm/tests/cacheserver_test.yaml
+++ b/helm/tests/cacheserver_test.yaml
@@ -172,12 +172,8 @@ tests:
           periodSeconds: 20
           failureThreshold: 6
           timeoutSeconds: 10
-          exec:
-            command:
-            - "/opt/venv/bin/python3"
-            - "/workspace/LMCache/examples/kubernetes/health_probe.py"
-            - "127.0.0.1"
-            - "8000"
+          tcpSocket:
+            port: 8000
     - equal:
         path: spec.template.spec.containers[0].securityContext
         value:

--- a/helm/tests/cacheserver_test.yaml
+++ b/helm/tests/cacheserver_test.yaml
@@ -173,7 +173,7 @@ tests:
           failureThreshold: 6
           timeoutSeconds: 10
           tcpSocket:
-            port: 8000
+            port: caserver-cport
     - equal:
         path: spec.template.spec.containers[0].securityContext
         value:


### PR DESCRIPTION
### Description

The LMCache cache server livenessProbe uses an exec probe that runs `/workspace/LMCache/examples/kubernetes/health_probe.py`, but this script does not exist in the LMCache v0.5.4 Docker image. The cache server communicates via TCP socket protocol, not HTTP.

### Changes

- Changed the liveness probe from `exec` to `tcpSocket` in `deployment-cache-server.yaml`
- Updated the corresponding Helm test in `cacheserver_test.yaml`

A `tcpSocket` probe is more appropriate because:
1. The LMCache cache server uses a TCP socket protocol
2. No external script is required - Kubernetes can check the port directly
3. Works with all LMCache versions without depending on a specific script

Closes #1057