### PR TITLE
fix: Use per-model tokenizer in KvawareRouter for multi-model setups

### DIFF
--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -388,34 +388,7 @@ class KvawareRouter(RoutingInterface):
         token_ids = None
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         # TODO (Yuhan): Handle chat completions
-        model_name = request_json.get("model", "")
-        # Find the endpoint serving this model
-        model_endpoint = next(
-            (ep for ep in endpoints if model_name in ep.model_names),
-            endpoints[0] if endpoints else None,
-        )
-        try:
-            if model_name not in self.tokenizers:
-                self.tokenizers[model_name] = AutoTokenizer.from_pretrained(
-                    model_name
-                )
-            token_ids = self.tokenizers[model_name].encode(
-                request_json.get("prompt", "")
-            )
-        except Exception:
-            # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
-            if model_endpoint is None:
-                raise
-            remote_url = model_endpoint.url + "/tokenize"
-            headers = {"Content-Type": "application/json"}
-            data = {
-                "model": model_name,
-                "prompt": request_json.get("prompt", ""),
-            }
-            body = requests.post(
-                remote_url, headers=headers, json=data, timeout=10
-            ).json()
-            token_ids = body["tokens"]
+        token_ids = await self.tokenize_prompt(endpoints, request_json)
 
         event_id = "Lookup" + str(uuid.uuid4())
         msg = LookupMsg(tokens=token_ids, event_id=event_id)
@@ -662,17 +635,29 @@ class LoadAwareRouter(KvawareRouter):
         The remote fallback is a blocking HTTP call, so it runs in an
         executor rather than on the event loop.
         """
+        model_name = request_json.get("model", "")
+        if not model_name:
+            raise ValueError("Missing 'model' in request body")
+        # Find the endpoint serving this model
+        model_endpoint = next(
+            (ep for ep in endpoints if model_name in ep.model_names),
+            endpoints[0] if endpoints else None,
+        )
         try:
-            if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
+            if model_name not in self.tokenizers:
+                self.tokenizers[model_name] = AutoTokenizer.from_pretrained(
+                    model_name
                 )
-            return self.tokenizer.encode(request_json.get("prompt", ""))
+            return self.tokenizers[model_name].encode(
+                request_json.get("prompt", "")
+            )
         except Exception:
-            remote_url = endpoints[0].url + "/tokenize"
+            if model_endpoint is None:
+                raise
+            remote_url = model_endpoint.url + "/tokenize"
             headers = {"Content-Type": "application/json"}
             data = {
-                "model": endpoints[0].model_names[0],
+                "model": model_name,
                 "prompt": request_json.get("prompt", ""),
             }
             loop = asyncio.get_running_loop()

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -326,7 +326,7 @@ class KvawareRouter(RoutingInterface):
         self.instance_id_to_ip = {}
         self.session_key = session_key
         self.hash_ring = HashRing()
-        self.tokenizer = None
+        self.tokenizers: Dict[str, AutoTokenizer] = {}
         self.threshold = kv_aware_threshold
 
     def start_kv_manager(self):
@@ -388,18 +388,28 @@ class KvawareRouter(RoutingInterface):
         token_ids = None
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         # TODO (Yuhan): Handle chat completions
+        model_name = request_json.get("model", "")
+        # Find the endpoint serving this model
+        model_endpoint = next(
+            (ep for ep in endpoints if model_name in ep.model_names),
+            endpoints[0] if endpoints else None,
+        )
         try:
-            if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
+            if model_name not in self.tokenizers:
+                self.tokenizers[model_name] = AutoTokenizer.from_pretrained(
+                    model_name
                 )
-            token_ids = self.tokenizer.encode(request_json.get("prompt", ""))
+            token_ids = self.tokenizers[model_name].encode(
+                request_json.get("prompt", "")
+            )
         except Exception:
             # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
-            remote_url = endpoints[0].url + "/tokenize"
+            if model_endpoint is None:
+                raise
+            remote_url = model_endpoint.url + "/tokenize"
             headers = {"Content-Type": "application/json"}
             data = {
-                "model": endpoints[0].model_names[0],
+                "model": model_name,
                 "prompt": request_json.get("prompt", ""),
             }
             body = requests.post(


### PR DESCRIPTION
### Description

Fixes #1052

`KvawareRouter` keeps a single `self.tokenizer` that is initialized from `endpoints[0].model_names[0]` on the first request and reused for every later request. When the router serves multiple base models, requests for model B are tokenized with model A's tokenizer, causing incorrect token IDs to be sent to the LMCache KV-aware lookup.

### Changes

1. Replaced `self.tokenizer` (single) with `self.tokenizers: Dict[str, AutoTokenizer]` (per-model cache)
2. In `route_request()`, extract the model name from `request_json["model"]` and load the corresponding tokenizer on demand
3. The remote `/tokenize` fallback now uses the correct endpoint for the requested model

### Testing

Behavior change verified by the reproducer in the issue:
- Before: `loaded tokenizers: ["model-a"]`, `lookup tokens: [[1], [1]]`
- After: `loaded tokenizers: ["model-a", "model-b"]`, `lookup tokens: [[1], [2]]`