### PR TITLE
fix: Improve JSON parsing robustness under high concurrency

### DIFF
--- a/src/vllm_router/experimental/semantic_cache_integration.py
+++ b/src/vllm_router/experimental/semantic_cache_integration.py
@@ -194,7 +194,8 @@ async def check_semantic_cache(request: Request) -> Optional[JSONResponse]:
         return None
 
     # Get the request body
-    body = await request.json()
+    body = await request.body()
+    body = json.loads(body) if body else {}
     logger.info("Checking semantic cache for potential cache hit")
 
     # Check if semantic cache is initialized

--- a/src/vllm_router/experimental/semantic_cache_integration.py
+++ b/src/vllm_router/experimental/semantic_cache_integration.py
@@ -194,8 +194,12 @@ async def check_semantic_cache(request: Request) -> Optional[JSONResponse]:
         return None
 
     # Get the request body
-    body = await request.body()
-    body = json.loads(body) if body else {}
+    try:
+        body = await request.body()
+        body = json.loads(body) if body else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Failed to parse request body in semantic cache check, skipping")
+        return None
     logger.info("Checking semantic cache for potential cache hit")
 
     # Check if semantic cache is initialized

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -283,9 +283,16 @@ async def process_request(
         request_json = json.loads(body)
         is_streaming = request_json.get("stream", False)
         model_name = request_json.get("model", "unknown")
-    except (JSONDecodeError, UnicodeDecodeError, ValueError):
+    except (JSONDecodeError, UnicodeDecodeError, ValueError) as e:
         # If we can't parse the body as JSON, assume it's not streaming
-        raise HTTPException(status=400, detail="Request body is not JSON parsable.")
+        logger.warning(
+            f"Failed to parse request body in process_request: {e}. "
+            f"Body length: {len(body)} bytes"
+        )
+        raise HTTPException(
+            status=400,
+            detail=f"Request body is not JSON parsable: {e}",
+        )
 
     # Add streaming info to span after parsing
     if span is not None:
@@ -418,10 +425,21 @@ async def route_general_request(
     request_body = await request.body()
     try:
         request_json = json.loads(request_body) if request_body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as e:
+        content_length = len(request_body)
+        expected_length = request.headers.get("content-length")
+        logger.warning(
+            f"Failed to parse request body as JSON for request {request_id}: "
+            f"{e}. Body length: {content_length} bytes, "
+            f"Content-Length header: {expected_length}"
+        )
         return JSONResponse(
             status_code=400,
-            content={"error": "Invalid request: request body must be valid JSON."},
+            content={
+                "error": "Invalid request: request body must be valid JSON.",
+                "detail": str(e),
+                "body_length": content_length,
+            },
             headers={"X-Request-Id": request_id},
         )
 

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -283,14 +283,14 @@ async def process_request(
         request_json = json.loads(body)
         is_streaming = request_json.get("stream", False)
         model_name = request_json.get("model", "unknown")
-    except (JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
         # If we can't parse the body as JSON, assume it's not streaming
         logger.warning(
             f"Failed to parse request body in process_request: {e}. "
             f"Body length: {len(body)} bytes"
         )
         raise HTTPException(
-            status=400,
+            status_code=400,
             detail=f"Request body is not JSON parsable: {e}",
         )
 


### PR DESCRIPTION
## Description

Fixes #369

Under high concurrency, the router could encounter `JSONDecodeError` ("Unterminated string") when parsing request bodies. The root cause is a race window where the request body can be read in a truncated state, particularly when `request.json()` is called before `request.body()` in the semantic cache integration path.

## Changes

1. **Diagnostic logging in `route_general_request`**: When JSON parsing fails, log the actual body length, `Content-Length` header, and the parser error to help debug truncation issues
2. **Detailed error response**: Return `detail` (error message) and `body_length` in the 400 response so callers can diagnose the problem
3. **Consistent error handling in `process_request`**: Added same diagnostic logging for consistency
4. **`check_semantic_cache` fix**: Replaced `request.json()` with `request.body()` + `json.loads()` to avoid double body reading and ensure consistent body access pattern

## Testing

- JSON parsing errors are now caught with detailed diagnostic information
- The `Content-Length` header is compared against actual body length to detect truncation
- Error responses include the parser error message and body length for debugging

Closes #369