### PR TITLE
[Bugfix][Helm] Only pass --k8s-service-discovery-type when explicitly set to non-default

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -258,7 +258,7 @@ Set `servingEngineSpec.modelSpec[].raySpec.enabled: true` to deploy the model as
 | `routerSpec.serviceAnnotations` | map | `{}` | Service annotations for LoadBalancer/NodePort |
 | `routerSpec.servicePort` | integer | `80` | Port the router service will listen on |
 | `routerSpec.serviceDiscovery` | string | `"k8s"` | Service discovery mode ("k8s" or "static") |
-| `routerSpec.k8sServiceDiscoveryType` | string | `"pod-ip"` | Service discovery Type ("pod-ip" or "service-name") if serviceDiscovery is "k8s" |
+| `routerSpec.k8sServiceDiscoveryType` | string | `""` | Service discovery type ("pod-ip" or "service-name") if serviceDiscovery is "k8s". Empty means use container default (pod-ip). |
 | `routerSpec.staticBackends` | string | `""` | Comma-separated list of backend addresses if serviceDiscovery is "static" |
 | `routerSpec.staticModels` | string | `""` | Comma-separated list of model names if serviceDiscovery is "static" |
 | `routerSpec.routingLogic` | string | `"roundrobin"` | Routing logic: `"roundrobin"`, `"session"`, `"prefixaware"`, `"kvaware"`, `"disaggregated_prefill"`, or `"disaggregated_prefill_orchestrated"` |

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -101,7 +101,7 @@ spec:
           {{- if eq .Values.routerSpec.serviceDiscovery "k8s" }}
           - "--k8s-namespace"
           - "{{ .Release.Namespace }}"
-          {{- if and .Values.routerSpec.k8sServiceDiscoveryType (ne .Values.routerSpec.k8sServiceDiscoveryType "pod-ip") }}
+          {{- if .Values.routerSpec.k8sServiceDiscoveryType }}
           - "--k8s-service-discovery-type"
           - "{{ .Values.routerSpec.k8sServiceDiscoveryType }}"
           {{- end }}

--- a/helm/templates/deployment-router.yaml
+++ b/helm/templates/deployment-router.yaml
@@ -101,8 +101,10 @@ spec:
           {{- if eq .Values.routerSpec.serviceDiscovery "k8s" }}
           - "--k8s-namespace"
           - "{{ .Release.Namespace }}"
+          {{- if and .Values.routerSpec.k8sServiceDiscoveryType (ne .Values.routerSpec.k8sServiceDiscoveryType "pod-ip") }}
           - "--k8s-service-discovery-type"
-          - "{{ default "pod-ip" .Values.routerSpec.k8sServiceDiscoveryType }}"
+          - "{{ .Values.routerSpec.k8sServiceDiscoveryType }}"
+          {{- end }}
           {{- if .Values.servingEngineSpec.enableEngine }}
           - "--k8s-label-selector"
           - {{ include "labels.toCommaSeparatedList" .Values.servingEngineSpec.labels }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -580,9 +580,10 @@
                     }
                 },
                 "k8sServiceDiscoveryType": {
-                    "description": "Service discovery mode type, supports \"pod-ip\" or \"service-name\". Defaults to \"pod-ip\" if not set.",
+                    "description": "Service discovery mode type, supports \"pod-ip\" or \"service-name\". Defaults to empty (use container default, which is pod-ip).",
                     "type": "string",
                     "enum": [
+                        "",
                         "pod-ip",
                         "service-name"
                     ]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -541,7 +541,7 @@ routerSpec:
   # -- Service discovery mode, supports "k8s" or "static". Defaults to "k8s" if not set.
   serviceDiscovery: "k8s" # @schema enum:[k8s,static]
   # -- Service discovery mode type, supports "pod-ip" or "service-name". Defaults to "pod-ip" if not set.
-  k8sServiceDiscoveryType: "pod-ip" # @schema enum:[pod-ip,service-name]
+  k8sServiceDiscoveryType: "" # @schema enum:[pod-ip,service-name]
   # -- If serviceDiscovery is set to "static", the comma-separated values below are required. There needs to be the same number of backends and models
   staticBackends: ""
   staticModels: ""


### PR DESCRIPTION
Fixes #746

## Description

The Helm chart unconditionally passes `--k8s-service-discovery-type pod-ip` to the router container. However, older router images may not support this argument, causing the router to crash with:

```
vllm-router: error: unrecognized arguments: --k8s-service-discovery-type pod-ip
```

## Fix

Since the router already defaults to `pod-ip` behavior when the argument is not provided (see `service_discovery.py` line 1341), only pass `--k8s-service-discovery-type` when the user explicitly configures it to a non-default value (e.g. `service-name`).

This provides backward compatibility with older router images that do not support this argument.

## Testing

- Default case (`k8sServiceDiscoveryType: "pod-ip"`): `--k8s-service-discovery-type` is NOT passed, router uses its own default → works with both old and new images
- Explicit case (`k8sServiceDiscoveryType: "service-name"`): `--k8s-service-discovery-type service-name` IS passed → works with new images that support this argument