### PR TITLE
[Bugfix][Router] Default transcription language to None (auto-detect)

### DIFF
--- a/src/tests/test_multipart_proxy.py
+++ b/src/tests/test_multipart_proxy.py
@@ -165,7 +165,8 @@ async def test_audio_transcription_preserves_plain_text_response():
         received.update(
             model=form["model"],
             response_format=form["response_format"],
-            language=form["language"],
+            # absent by default so the backend auto-detects; None documents that
+            language=form.get("language"),
             filename=upload.filename,
             content_type=upload.content_type,
             content=upload.file.read(),
@@ -186,7 +187,7 @@ async def test_audio_transcription_preserves_plain_text_response():
     assert received == {
         "model": AUDIO_MODEL,
         "response_format": "text",
-        "language": "en",
+        "language": None,
         "filename": "speech.wav",
         "content_type": "audio/wav",
         "content": b"fake-audio",

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1161,7 +1161,7 @@ async def route_general_transcriptions(
         temperature: Optional[float] = (
             float(temperature_str) if temperature_str is not None else None
         )
-        language: Optional[str] = form.get("language", "en")
+        language: Optional[str] = form.get("language")
         stream: bool = form.get("stream", "false").lower() == "true"
     except KeyError as e:
         return JSONResponse(
@@ -1191,7 +1191,10 @@ async def route_general_transcriptions(
     payload_bytes = await file.read()
     files = {"file": (file.filename, payload_bytes, file.content_type)}
 
-    data = {"model": model, "language": language}
+    data = {"model": model}
+
+    if language:
+        data["language"] = language
 
     if prompt:
         data["prompt"] = prompt

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1195,7 +1195,11 @@ async def route_general_transcriptions(
 
     if isinstance(language, str):
         language_stripped = language.strip()
-        if language_stripped and language_stripped.lower() not in ("none", "null", "undefined"):
+        if language_stripped and language_stripped.lower() not in (
+            "none",
+            "null",
+            "undefined",
+        ):
             data["language"] = language_stripped
 
     if prompt:

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -1193,8 +1193,10 @@ async def route_general_transcriptions(
 
     data = {"model": model}
 
-    if language:
-        data["language"] = language
+    if isinstance(language, str):
+        language_stripped = language.strip()
+        if language_stripped and language_stripped.lower() not in ("none", "null", "undefined"):
+            data["language"] = language_stripped
 
     if prompt:
         data["prompt"] = prompt


### PR DESCRIPTION
## Summary
`route_general_transcriptions` was defaulting the transcription `language` to `"en"` when the client did not supply one. This forced the backend to transcribe in English even when the model could auto-detect the language.

vLLM's own default for `language` is `None`, which leaves language detection to the model. This change aligns the router with that behavior.

## Changes
- `src/vllm_router/services/request_service/request.py`
  - Default `language` to `None` (`form.get("language")` instead of `form.get("language", "en")`).
  - Only include the `language` field in the outbound multipart form data when it is set. When absent, `aiohttp.FormData` would otherwise encode `None` as the literal string `"None"` and send it to the backend as an invalid language.
- `src/tests/test_multipart_proxy.py`
  - Update the audio transcription tests to assert the field is absent/`None` by default.

## Testing
`src/tests/test_multipart_proxy.py` — 4 passed.
