### PR TITLE
[Feat] Support command and args on servingEngineSpec.modelSpec

### DIFF
--- a/helm/templates/deployment-vllm-multi.yaml
+++ b/helm/templates/deployment-vllm-multi.yaml
@@ -124,6 +124,9 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if $modelSpec.command }}
+          command: {{ toYaml $modelSpec.command | nindent 12 }}
+          {{- else }}
           command:
           {{- if eq $modelSpec.repository "lmcache/vllm-openai" }}
           - "/opt/venv/bin/vllm"
@@ -218,6 +221,10 @@ spec:
           {{- if $modelSpec.chatTemplate }}
           - "--chat-template"
           - "/templates/{{ $modelSpec.chatTemplate }}"
+          {{- end }}
+          {{- end }}
+          {{- if $modelSpec.args }}
+          args: {{ toYaml $modelSpec.args | nindent 12 }}
           {{- end }}
           imagePullPolicy: "{{ .Values.servingEngineSpec.imagePullPolicy }}"
           env:

--- a/helm/tests/deployment-vllm-multi_test.yaml
+++ b/helm/tests/deployment-vllm-multi_test.yaml
@@ -413,3 +413,42 @@ tests:
       notContains:
         path: spec.template.spec.containers[0].command
         content: "--revision"
+
+  - it: should use custom command and args on the main container
+    release:
+      name: vllm
+    set:
+      servingEngineSpec:
+        enableEngine: true
+        modelSpec:
+        - name: "opt125m"
+          repository: "lmcache/vllm-openai"
+          tag: "latest"
+          modelURL: "facebook/opt-125m"
+          replicaCount: 1
+          requestCPU: 6
+          requestMemory: "16Gi"
+          requestGPU: 1
+          pvcStorage: "50Gi"
+          command:
+            - "sh"
+            - "-c"
+          args:
+            - "mkdir -p /tmp/lmcache_prometheus && exec vllm serve facebook/opt-125m --host 0.0.0.0 --port 8000"
+    asserts:
+    - documentIndex: 0
+      equal:
+        path: spec.template.spec.containers[0].command
+        value:
+          - "sh"
+          - "-c"
+    - documentIndex: 0
+      equal:
+        path: spec.template.spec.containers[0].args
+        value:
+          - "mkdir -p /tmp/lmcache_prometheus && exec vllm serve facebook/opt-125m --host 0.0.0.0 --port 8000"
+    - documentIndex: 0
+      notContains:
+        path: spec.template.spec.containers[0].command
+        content: "serve"
+

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1114,6 +1114,20 @@
                                 "description": "The annotations to add to the deployment",
                                 "type": "object"
                             },
+                            "args": {
+                                "description": "Optional container args for the main vLLM container. Used with command to override the default vllm serve invocation.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "command": {
+                                "description": "Optional container command for the main vLLM container. Replaces the default vllm serve invocation.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "enableLoRA": {
                                 "description": "Whether to enable LoRA",
                                 "type": "boolean"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -109,6 +109,14 @@ servingEngineSpec:
     extraVolumeMounts: []
       # - name: tmp-volume
       #   mountPath: /tmp
+    # -- Optional command for the main vLLM container. Replaces the default `vllm serve` invocation.
+    # command:
+    #   - "sh"
+    #   - "-c"
+    # -- Optional args for the main vLLM container. Use with command to wrap startup
+    # (for example mkdir before exec vllm serve).
+    # args:
+    #   - "mkdir -p /tmp/lmcache_prometheus && exec vllm serve MODEL --host 0.0.0.0 --port 8000"
     # -- The configuration for the init container to be run before the main container.
     initContainer:
     # -- The name of the init container


### PR DESCRIPTION
The main vLLM container currently hardcodes `vllm serve`. This adds optional `command` and `args` on each `servingEngineSpec.modelSpec[]` entry so startup can be wrapped the same way init containers already can (the Prometheus/LMCache mkdir case from the issue).

When `command` is unset, the default `vllm serve` invocation is unchanged. `vllmConfig.extraArgs` still applies only to that default path.

Fixes #682

- [ ] Make sure the code changes pass the pre-commit checks. Helm-only change; ran `helm lint` and `helm template`.
- [x] Sign-off your commit by using `-s` when doing `git commit`
- [x] Try to classify PRs (`[Feat]`)

## Testing

- `helm lint helm/` — pass (chart dependency warning only)
- `helm template` with chart defaults — main container command stays `vllm serve`
- `helm template` with `modelSpec.command` / `modelSpec.args` — custom `sh -c` wrapper, default `serve` is not in command
- Added a helm unittest case in `helm/tests/deployment-vllm-multi_test.yaml`
