### PR TITLE
[Bugfix][Router] Fix leaked in-flight counters in RequestStatsMonitor

### DIFF
--- a/src/tests/test_request_stats.py
+++ b/src/tests/test_request_stats.py
@@ -1,0 +1,132 @@
+import json
+import time
+import types
+
+import pytest
+
+from vllm_router.services.request_service.request import process_request
+from vllm_router.stats.request_stats import RequestStatsMonitor, SingletonMeta
+
+URL = "http://engine-1:8000"
+
+
+@pytest.fixture
+def monitor():
+    SingletonMeta._instances.pop(RequestStatsMonitor, None)
+    m = RequestStatsMonitor(sliding_window_size=10)
+    yield m
+    SingletonMeta._instances.pop(RequestStatsMonitor, None)
+
+
+def test_request_failing_during_prefill_releases_prefill_slot(monitor):
+    # No on_request_response call => the request never left the prefill phase.
+    now = time.time()
+    monitor.on_new_request(URL, "req-1", now)
+    monitor.on_request_complete(URL, "req-1", now + 1)
+
+    stats = monitor.get_request_stats(now + 2)
+    assert stats[URL].in_prefill_requests == 0
+    assert stats[URL].in_decoding_requests == 0
+    assert stats[URL].finished_requests == 1
+
+
+def test_on_request_complete_is_idempotent(monitor):
+    # Failover / the finally-block can fire on_request_complete twice for one request.
+    now = time.time()
+    monitor.on_new_request(URL, "req-1", now)
+    monitor.on_request_response(URL, "req-1", now + 0.5)
+    monitor.on_request_complete(URL, "req-1", now + 1)
+    monitor.on_request_complete(URL, "req-1", now + 1)
+
+    stats = monitor.get_request_stats(now + 2)
+    assert stats[URL].finished_requests == 1
+    assert stats[URL].in_decoding_requests == 0
+
+
+def test_completed_request_releases_per_request_bookkeeping(monitor):
+    # Per-request entries must not accumulate for the life of the process.
+    now = time.time()
+    monitor.on_new_request(URL, "req-1", now)
+    monitor.on_request_response(URL, "req-1", now + 0.5)
+    monitor.on_request_complete(URL, "req-1", now + 1)
+
+    assert monitor.request_start_time == {}
+    assert monitor.first_token_time == {}
+
+
+class _RaisingRequestCM:
+    async def __aenter__(self):
+        raise ConnectionError("backend down")
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeContent:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def iter_any(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _OkRequestCM:
+    async def __aenter__(self):
+        return types.SimpleNamespace(
+            status=200,
+            headers={"content-type": "application/json"},
+            content=_FakeContent([b'{"usage": {}}']),
+        )
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _fake_request(monitor, cm_factory):
+    state = types.SimpleNamespace(
+        otel_enabled=False,
+        semantic_cache_available=False,
+        request_stats_monitor=monitor,
+        aiohttp_client_wrapper=lambda: types.SimpleNamespace(
+            request=lambda **kw: cm_factory()
+        ),
+    )
+    return types.SimpleNamespace(
+        method="POST",
+        headers={"content-type": "application/json"},
+        app=types.SimpleNamespace(state=state),
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_request_releases_slot_when_backend_errors(monitor):
+    # Backend failure must still release the slot, or load-aware / priority
+    # routing sees the engine as permanently loaded.
+    request = _fake_request(monitor, _RaisingRequestCM)
+    body = json.dumps({"model": "test-model", "stream": False}).encode()
+
+    gen = process_request(request, body, URL, "req-1", "/v1/chat/completions", None)
+    with pytest.raises(ConnectionError):
+        async for _ in gen:
+            pass
+
+    stats = monitor.get_request_stats(time.time())
+    assert stats[URL].in_prefill_requests == 0
+    assert stats[URL].in_decoding_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_process_request_balances_counters_on_success(monitor):
+    request = _fake_request(monitor, _OkRequestCM)
+    body = json.dumps({"model": "test-model", "stream": False}).encode()
+
+    gen = process_request(request, body, URL, "req-1", "/v1/chat/completions", None)
+    async for _ in gen:
+        pass
+
+    stats = monitor.get_request_stats(time.time())
+    assert stats[URL].in_prefill_requests == 0
+    assert stats[URL].in_decoding_requests == 0
+    assert stats[URL].finished_requests == 1
+    assert monitor.request_start_time == {}

--- a/src/tests/test_request_stats.py
+++ b/src/tests/test_request_stats.py
@@ -3,6 +3,7 @@ import time
 import types
 
 import pytest
+from fastapi import HTTPException
 
 from vllm_router.services.request_service.request import process_request
 from vllm_router.stats.request_stats import RequestStatsMonitor, SingletonMeta
@@ -114,6 +115,24 @@ async def test_process_request_releases_slot_when_backend_errors(monitor):
     stats = monitor.get_request_stats(time.time())
     assert stats[URL].in_prefill_requests == 0
     assert stats[URL].in_decoding_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_process_request_releases_slot_on_unparsable_body(monitor):
+    # on_new_request runs before the body is parsed; a non-JSON body must still
+    # release the slot and surface as a 400.
+    request = _fake_request(monitor, _OkRequestCM)  # backend never reached
+    gen = process_request(
+        request, b"not json", URL, "req-1", "/v1/chat/completions", None
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        async for _ in gen:
+            pass
+    assert exc.value.status_code == 400
+
+    stats = monitor.get_request_stats(time.time())
+    assert stats[URL].in_prefill_requests == 0
 
 
 @pytest.mark.asyncio

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -337,11 +337,6 @@ async def process_request(
                     full_response.extend(chunk)
                 yield chunk
 
-        end_time = time.time()
-        request.app.state.request_stats_monitor.on_request_complete(
-            backend_url, request_id, end_time
-        )
-
         if http_status_code is not None and http_status_code >= 400:
             request_status = "error"
 
@@ -381,6 +376,11 @@ async def process_request(
         end_span(span, error=e) if tracing_active else None
         raise
     finally:
+        # In finally so backend-error and client-disconnect paths also release
+        # the in-flight slot; on_request_complete is idempotent.
+        request.app.state.request_stats_monitor.on_request_complete(
+            backend_url, request_id, time.time()
+        )
         request_latency_seconds.labels(
             server=backend_url, model=model_name, status=request_status
         ).observe(time.time() - start_time)

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -283,33 +283,39 @@ async def process_request(
     request.app.state.request_stats_monitor.on_new_request(
         backend_url, request_id, start_time
     )
-    # Check if this is a streaming request and extract model name
-    try:
-        request_json = json.loads(body)
-        is_streaming = request_json.get("stream", False)
-        model_name = request_json.get("model", "unknown")
-    except (JSONDecodeError, UnicodeDecodeError, ValueError):
-        # If we can't parse the body as JSON, assume it's not streaming
-        raise HTTPException(status=400, detail="Request body is not JSON parsable.")
 
-    # Add streaming info to span after parsing
-    if span is not None:
-        span.set_attribute("vllm.is_streaming", is_streaming)
-
-    # Sanitize the request headers
-    headers = _build_backend_request_headers(request, request_id)
-
-    # Inject trace context into outgoing headers
-    if tracing_active:
-        inject_context(headers, span_context)
-
-    # For non-streaming requests, collect the full response to cache it properly
-    full_response = bytearray()
-
-    request_status = "success"
+    model_name = "unknown"
+    request_status = "error"
     http_status_code = None
 
     try:
+        # Check if this is a streaming request and extract model name
+        try:
+            request_json = json.loads(body)
+            is_streaming = request_json.get("stream", False)
+            model_name = request_json.get("model", "unknown")
+        except (JSONDecodeError, UnicodeDecodeError, ValueError):
+            # If we can't parse the body as JSON, assume it's not streaming
+            raise HTTPException(
+                status_code=400, detail="Request body is not JSON parsable."
+            )
+
+        # Add streaming info to span after parsing
+        if span is not None:
+            span.set_attribute("vllm.is_streaming", is_streaming)
+
+        # Sanitize the request headers
+        headers = _build_backend_request_headers(request, request_id)
+
+        # Inject trace context into outgoing headers
+        if tracing_active:
+            inject_context(headers, span_context)
+
+        # For non-streaming requests, collect the full response to cache it properly
+        full_response = bytearray()
+
+        request_status = "success"
+
         async with request.app.state.aiohttp_client_wrapper().request(
             method=request.method,
             url=backend_url + endpoint,

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -209,17 +209,29 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
             request_id: The global request ID
             timestamp: The timestamp when the request was completed
         """
+        key = (engine_url, request_id)
+        
+        if key not in self.request_start_time:
+            return
+
         if engine_url not in self.finished_requests:
             self.finished_requests[engine_url] = 0
-        self.in_decoding_requests[engine_url] = max(
-            0, self.in_decoding_requests.get(engine_url, 1) - 1
-        )
+        
+        if key in self.first_token_time: # first_token_time is set, so the request reached decode stage
+            self.in_decoding_requests[engine_url] = max(
+                0, self.in_decoding_requests.get(engine_url, 1) - 1
+            )
+        else: # failed in prefill stage
+            self.in_prefill_requests[engine_url] = max(
+                0, self.in_prefill_requests.get(engine_url, 1) - 1
+            )
         self.finished_requests[engine_url] += 1
 
-        if request_start_time := self.request_start_time.get((engine_url, request_id)):
-            self.latency_monitors[engine_url].update(
-                timestamp, time.time() - request_start_time
-            )
+        request_start_time = self.request_start_time.pop(key)
+        self.first_token_time.pop(key, None)
+        self.latency_monitors[engine_url].update(
+            timestamp, time.time() - request_start_time
+        )
 
     def on_request_swapped(self, engine_url: str, request_id: str, timestamp: float):
         # This function should be called if a request is determined to be swapped from GPU to CPU.

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import time
 from collections import deque
 from dataclasses import dataclass
 from typing import Deque, Dict, Tuple

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -210,18 +210,20 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
             timestamp: The timestamp when the request was completed
         """
         key = (engine_url, request_id)
-        
+
         if key not in self.request_start_time:
             return
 
         if engine_url not in self.finished_requests:
             self.finished_requests[engine_url] = 0
-        
-        if key in self.first_token_time: # first_token_time is set, so the request reached decode stage
+
+        if (
+            key in self.first_token_time
+        ):  # first_token_time is set, so the request reached decode stage
             self.in_decoding_requests[engine_url] = max(
                 0, self.in_decoding_requests.get(engine_url, 1) - 1
             )
-        else: # failed in prefill stage
+        else:  # failed in prefill stage
             self.in_prefill_requests[engine_url] = max(
                 0, self.in_prefill_requests.get(engine_url, 1) - 1
             )

--- a/src/vllm_router/stats/request_stats.py
+++ b/src/vllm_router/stats/request_stats.py
@@ -232,7 +232,7 @@ class RequestStatsMonitor(metaclass=SingletonMeta):
         request_start_time = self.request_start_time.pop(key)
         self.first_token_time.pop(key, None)
         self.latency_monitors[engine_url].update(
-            timestamp, time.time() - request_start_time
+            timestamp, timestamp - request_start_time
         )
 
     def on_request_swapped(self, engine_url: str, request_id: str, timestamp: float):


### PR DESCRIPTION
## Issues

- **In-flight counters leak on failure**. `process_request` only called on_request_complete on the success path, so a backend error left the request permanently counted in `in_prefill_requests` / `in_decoding_requests`. loadaware and priority routing consume these and then treat the engine as permanently loaded.
- **Per-request bookkeeping grows unbounded**. `request_start_time` and `first_token_time` (one entry per request) were never removed, which causes steady memory growth for the life of the process.
- `on_request_complete` always decremented `in_decoding_requests`, even for a request that failed during prefill.

## What is changed
- moved `on_request_complete` from the success path into `process_request`'s finally, so it runs on every exit.
- decrement the phase the request was actually in (`in_decoding_requests` if it reached first token, else `in_prefill_requests`).
- pop `request_start_time` / `first_token_time` on completion.
- `on_request_complete` is now idempotent, so failover retries and the finally path can't double-count.

## Tests
- pre-commit check
- unit tests
---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/production-stack/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to production-stack! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of YuhanLiu11
, Shaoting-Feng or ApostaC.
