### PR TITLE
[Router][Bugfix] Cache KV-aware tokenizers per model

### DIFF
--- a/src/tests/test_kvaware_router.py
+++ b/src/tests/test_kvaware_router.py
@@ -100,7 +100,12 @@ async def test_kvaware_uses_tokenizer_for_each_model(monkeypatch):
         loaded_models.append(model_name)
         return tokenizers[model_name]
 
-    monkeypatch.setattr(routing_logic.AutoTokenizer, "from_pretrained", load_tokenizer)
+    monkeypatch.setattr(
+        routing_logic,
+        "AutoTokenizer",
+        SimpleNamespace(from_pretrained=load_tokenizer),
+        raising=False,
+    )
 
     router = KvawareRouter.__new__(KvawareRouter)
     router.tokenizers = {}

--- a/src/tests/test_kvaware_router.py
+++ b/src/tests/test_kvaware_router.py
@@ -22,9 +22,9 @@ def lmcache_message_stubs(monkeypatch):
 
 
 class EndpointInfo:
-    def __init__(self, url):
+    def __init__(self, url, model_name="test-model"):
         self.url = url
-        self.model_names = ["test-model"]
+        self.model_names = [model_name]
 
 
 class Tokenizer:
@@ -44,7 +44,7 @@ async def test_kvaware_routes_to_longest_reported_prefix(threshold):
     url_a = "http://10.0.0.1:8000"
     url_b = "http://10.0.0.2:8000"
     router = KvawareRouter.__new__(KvawareRouter)
-    router.tokenizer = Tokenizer()
+    router.tokenizers = {"test-model": Tokenizer()}
     router.threshold = threshold
     router.session_key = "x-session-id"
     router.hash_ring = routing_logic.HashRing()
@@ -79,6 +79,58 @@ async def test_kvaware_routes_to_longest_reported_prefix(threshold):
     assert selected == url_b
 
 
+@pytest.mark.asyncio
+async def test_kvaware_uses_tokenizer_for_each_model(monkeypatch):
+    loaded_models = []
+    lookup_tokens = []
+
+    class ModelTokenizer:
+        def __init__(self, token_id):
+            self.token_id = token_id
+
+        def encode(self, _prompt):
+            return [self.token_id]
+
+    tokenizers = {
+        "model-a": ModelTokenizer(1),
+        "model-b": ModelTokenizer(2),
+    }
+
+    def load_tokenizer(model_name):
+        loaded_models.append(model_name)
+        return tokenizers[model_name]
+
+    monkeypatch.setattr(routing_logic.AutoTokenizer, "from_pretrained", load_tokenizer)
+
+    router = KvawareRouter.__new__(KvawareRouter)
+    router.tokenizers = {}
+    router.threshold = 0
+    router.session_key = "x-session-id"
+    router.hash_ring = routing_logic.HashRing()
+    router.instance_id_to_ip = {}
+
+    async def query_manager(msg):
+        lookup_tokens.append(msg.tokens)
+        return SimpleNamespace(layout_info={})
+
+    router.query_manager = query_manager
+
+    for model_name, url in (
+        ("model-a", "http://10.0.0.1:8000"),
+        ("model-b", "http://10.0.0.2:8000"),
+    ):
+        await router.route_request(
+            [EndpointInfo(url, model_name)],
+            {},
+            {},
+            SimpleNamespace(headers={}),
+            {"prompt": "test"},
+        )
+
+    assert loaded_models == ["model-a", "model-b"]
+    assert lookup_tokens == [[1], [2]]
+
+
 @pytest.mark.parametrize(
     "instance_map",
     [
@@ -105,7 +157,7 @@ async def test_kvaware_ignores_cached_dead_holder(instance_map):
     url_a = "http://10.0.0.1:8000"
     url_b = "http://10.0.0.2:8000"
     router = KvawareRouter.__new__(KvawareRouter)
-    router.tokenizer = Tokenizer()
+    router.tokenizers = {"test-model": Tokenizer()}
     router.threshold = 1000
     router.session_key = "x-session-id"
     router.hash_ring = routing_logic.HashRing()
@@ -136,7 +188,7 @@ async def test_kvaware_refreshes_unknown_dead_holder_and_uses_live_match():
     url_a = "http://10.0.0.1:8000"
     url_b = "http://10.0.0.2:8000"
     router = KvawareRouter.__new__(KvawareRouter)
-    router.tokenizer = Tokenizer()
+    router.tokenizers = {"test-model": Tokenizer()}
     router.threshold = 1000
     router.session_key = "x-session-id"
     router.hash_ring = routing_logic.HashRing()

--- a/src/tests/test_loadaware_router.py
+++ b/src/tests/test_loadaware_router.py
@@ -53,8 +53,9 @@ PROMPT_TOKENS = 2048
 
 
 class EndpointInfo:
-    def __init__(self, url: str):
+    def __init__(self, url: str, model_name: str = "test-model"):
         self.url = url
+        self.model_names = [model_name]
 
 
 class RequestStats:
@@ -309,7 +310,7 @@ async def test_route_request_scores_and_routes_to_the_argmax():
         def encode(self, _prompt):
             return list(range(PROMPT_TOKENS))
 
-    router.tokenizer = Tokenizer()
+    router.tokenizers = {"test-model": Tokenizer()}
 
     async def query_manager(_msg):
         return LookupRet({INST_A: (LOCAL, PROMPT_TOKENS)})
@@ -334,7 +335,7 @@ async def test_no_cached_prefix_anywhere_falls_back_to_qps():
         def encode(self, _prompt):
             return list(range(PROMPT_TOKENS))
 
-    router.tokenizer = Tokenizer()
+    router.tokenizers = {"test-model": Tokenizer()}
 
     async def query_manager(_msg):
         return LookupRet({})
@@ -351,6 +352,46 @@ async def test_no_cached_prefix_anywhere_falls_back_to_qps():
         endpoints(URL_A, URL_B), {}, stats, Request(), {"prompt": "x"}
     )
     assert url == URL_B
+
+
+@pytest.mark.asyncio
+async def test_tokenize_prompt_uses_tokenizer_for_each_model(monkeypatch):
+    loaded_models = []
+
+    class ModelTokenizer:
+        def __init__(self, token_id):
+            self.token_id = token_id
+
+        def encode(self, _prompt):
+            return [self.token_id]
+
+    tokenizers = {
+        "model-a": ModelTokenizer(1),
+        "model-b": ModelTokenizer(2),
+    }
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(model_name):
+            loaded_models.append(model_name)
+            return tokenizers[model_name]
+
+    monkeypatch.setattr(
+        routing_logic, "AutoTokenizer", FakeAutoTokenizer, raising=False
+    )
+    router = make_router()
+    router.tokenizers = {}
+
+    token_ids = []
+    for model_name in ("model-a", "model-b", "model-a"):
+        token_ids.append(
+            await router.tokenize_prompt(
+                [EndpointInfo(URL_A, model_name)], {"prompt": "test"}
+            )
+        )
+
+    assert loaded_models == ["model-a", "model-b"]
+    assert token_ids == [[1], [2], [1]]
 
 
 @pytest.mark.asyncio

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -928,9 +928,9 @@ class PriorityRouter(RoutingInterface):
         Args:
             endpoints (List[EndpointInfo]): The list of engine URLs
             engine_stats (Dict[str, EngineStats]): The engine stats indicating
-               the 'physical' load of each engine
+                the 'physical' load of each engine
             request_stats (Dict[str, RequestStats]): The request stats
-               indicating the request-level performance of each engine
+                indicating the request-level performance of each engine
             request (Request): The incoming request
             request_json (Dict): The request body; the resolved priority is
                 injected back into this dict so it can be forwarded to the

--- a/src/vllm_router/routers/routing_logic.py
+++ b/src/vllm_router/routers/routing_logic.py
@@ -326,8 +326,14 @@ class KvawareRouter(RoutingInterface):
         self.instance_id_to_ip = {}
         self.session_key = session_key
         self.hash_ring = HashRing()
-        self.tokenizer = None
+        self.tokenizers = {}
         self.threshold = kv_aware_threshold
+
+    def _get_tokenizer(self, endpoints: List[EndpointInfo]):
+        model_name = endpoints[0].model_names[0]
+        if model_name not in self.tokenizers:
+            self.tokenizers[model_name] = AutoTokenizer.from_pretrained(model_name)
+        return self.tokenizers[model_name]
 
     def start_kv_manager(self):
         """
@@ -389,11 +395,8 @@ class KvawareRouter(RoutingInterface):
         # Local-first tokenization, fall back to remote "/tokenize" API on failure
         # TODO (Yuhan): Handle chat completions
         try:
-            if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
-                )
-            token_ids = self.tokenizer.encode(request_json.get("prompt", ""))
+            tokenizer = self._get_tokenizer(endpoints)
+            token_ids = tokenizer.encode(request_json.get("prompt", ""))
         except Exception:
             # Remote /tokenize fallback (let errors bubble up to keep behavior simple)
             remote_url = endpoints[0].url + "/tokenize"
@@ -668,11 +671,8 @@ class LoadAwareRouter(KvawareRouter):
         executor rather than on the event loop.
         """
         try:
-            if self.tokenizer is None:
-                self.tokenizer = AutoTokenizer.from_pretrained(
-                    endpoints[0].model_names[0]
-                )
-            return self.tokenizer.encode(request_json.get("prompt", ""))
+            tokenizer = self._get_tokenizer(endpoints)
+            return tokenizer.encode(request_json.get("prompt", ""))
         except Exception:
             remote_url = endpoints[0].url + "/tokenize"
             headers = {"Content-Type": "application/json"}
@@ -928,9 +928,9 @@ class PriorityRouter(RoutingInterface):
         Args:
             endpoints (List[EndpointInfo]): The list of engine URLs
             engine_stats (Dict[str, EngineStats]): The engine stats indicating
-                the 'physical' load of each engine
+               the 'physical' load of each engine
             request_stats (Dict[str, RequestStats]): The request stats
-                indicating the request-level performance of each engine
+               indicating the request-level performance of each engine
             request (Request): The incoming request
             request_json (Dict): The request body; the resolved priority is
                 injected back into this dict so it can be forwarded to the


### PR DESCRIPTION
## Summary

- cache locally loaded KV-aware tokenizers by model name instead of keeping one tokenizer for the router
- use the same model-specific cache in both `KvawareRouter` and `LoadAwareRouter`
- add a regression test that routes two base models through one router and verifies the token IDs sent to LMCache lookup

Fixes #1052.

## Problem

`route_general_request()` filters endpoints for the requested model, but `KvawareRouter` currently initializes one `self.tokenizer` from the first model it sees and reuses it for later requests.

With model A -> `[1]` and model B -> `[2]`, current `main` loads only model A and sends:

```text
[[1], [1]]
```

The expected lookup tokens are:

```text
[[1], [2]]
```

`LoadAwareRouter` has the same singleton-tokenizer path.

## Relation to #1045

#1045 improves chat tokenization and tokenizer initialization, but its current `_ensure_tokenizer()` still stores one successfully loaded `router.tokenizer`. This fix is independent: it makes the cache model-specific. If #1045 lands first, this can be rebased onto that helper.

## Testing

- deterministic two-model regression: model A and model B load independently and LMCache lookup sees `[[1], [2]]`
- existing KV-aware tests updated to use the model-specific tokenizer cache

---

- [x] Make sure the code changes pass the relevant checks.
- [x] Sign off the commit using `git commit -s`.
- [x] Classify the PR title.