### PR TITLE
[Helm][Feature] Add vllm-stack-operator chart: operator, CRDs and CRs in one helm install

### DIFF
--- a/.github/workflows/helm-operator-ci.yml
+++ b/.github/workflows/helm-operator-ci.yml
@@ -1,0 +1,177 @@
+name: Helm Operator Chart CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/helm-operator-ci.yml'
+      - 'helm-operator/**'
+      - 'operator/api/**'
+      - 'operator/config/crd/**'
+      - 'operator/Makefile'
+  pull_request:
+    paths:
+      - '.github/workflows/helm-operator-ci.yml'
+      - 'helm-operator/**'
+      - 'operator/api/**'
+      - 'operator/config/crd/**'
+      - 'operator/Makefile'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chart:
+    name: CRD sync, lint and render checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Verify helm is available
+        run: helm version
+
+      - name: Check CRD sync (helm chart vs operator/config/crd/bases)
+        run: make -C operator helm-crds-check
+
+      - name: Lint chart
+        run: helm lint helm-operator
+
+      - name: Render chart with helm template
+        run: |
+          set -e
+          # List overrides with --set would REPLACE the vllmRuntimes array, so
+          # anything touching the array goes through values files.
+          cat > /tmp/full-stack.yaml <<'EOT'
+          cacheServer:
+            enabled: true
+          vllmRuntimes:
+            - name: ""
+              spec:
+                autoscalingConfig:
+                  enabled: true
+          EOT
+          cat > /tmp/multi-model.yaml <<'EOT'
+          vllmRuntimes:
+            - name: ""
+              spec:
+                model:
+                  modelURL: "meta-llama/Llama-3.1-8B-Instruct"
+            - name: ""
+              spec:
+                model:
+                  modelURL: "Qwen/Qwen2.5-7B-Instruct"
+          EOT
+          for combo in \
+            "default|" \
+            "monitoring|--set metrics.enabled=true --set metrics.serviceMonitor.enabled=true --set networkPolicy.enabled=true" \
+            "full-stack|-f /tmp/full-stack.yaml" \
+            "multi-model|-f /tmp/multi-model.yaml" \
+            "operator-only|--set vllmRuntimes=null --set vllmRouter.enabled=false"; do
+            name="${combo%%|*}"
+            args="${combo#*|}"
+            # shellcheck disable=SC2086
+            count=$(helm template vllm-stack helm-operator -n production-stack-system $args | grep -c '^kind:')
+            echo "[$name] rendered $count resources"
+          done
+
+      - name: Render and validate chart
+        run: |
+          python3 -m pip install --quiet --user pyyaml jsonschema
+          python3 - <<'EOF'
+          import glob
+          import subprocess
+          import sys
+
+          import jsonschema
+          import yaml
+
+          CHART = "helm-operator"
+          RELEASE = "vllm-stack"
+          NAMESPACE = "production-stack-system"
+
+          COMBOS = [
+              ("default", []),
+              ("monitoring", ["--set", "metrics.enabled=true",
+                              "--set", "metrics.serviceMonitor.enabled=true",
+                              "--set", "networkPolicy.enabled=true"]),
+              ("full-stack", ["-f", "/tmp/full-stack.yaml"]),
+              ("multi-model", ["-f", "/tmp/multi-model.yaml"]),
+              ("operator-only", ["--set", "vllmRuntimes=null",
+                                 "--set", "vllmRouter.enabled=false"]),
+          ]
+
+          class StrictLoader(yaml.SafeLoader):
+              pass
+
+          def no_dupes(loader, node, deep=False):
+              mapping = {}
+              for k_node, v_node in node.value:
+                  key = loader.construct_object(k_node, deep=deep)
+                  if key in mapping:
+                      raise ValueError(f"duplicate key {key!r}")
+                  mapping[key] = loader.construct_object(v_node, deep=deep)
+              return mapping
+
+          StrictLoader.add_constructor(
+              yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_dupes)
+
+          # CRD schemas for validating the rendered custom resources
+          schemas = {}
+          for f in glob.glob(f"{CHART}/crds/*.yaml"):
+              crd = yaml.safe_load(open(f))
+              for v in crd["spec"]["versions"]:
+                  if v["name"] == "v1alpha1":
+                      schemas[crd["spec"]["names"]["kind"]] = \
+                          v["schema"]["openAPIV3Schema"]["properties"]["spec"]
+
+          failures = []
+          for name, extra in COMBOS:
+              cmd = ["helm", "template", RELEASE, CHART, "-n", NAMESPACE] + extra
+              out = subprocess.run(cmd, capture_output=True, text=True)
+              if out.returncode != 0:
+                  failures.append(f"[{name}] helm template failed: {out.stderr[:300]}")
+                  continue
+              docs = [d for d in yaml.load_all(out.stdout, Loader=StrictLoader) if d]
+              for d in docs:
+                  md = d.get("metadata", {})
+                  n = md.get("name")
+                  if n and len(n) > 63:
+                      failures.append(f"[{name}] {d['kind']}/{n}: name exceeds 63 chars")
+                  for scope in (md.get("labels") or {}).values():
+                      if len(str(scope)) > 63:
+                          failures.append(f"[{name}] {d['kind']}/{n}: label value exceeds 63 chars")
+                  if d["kind"] in schemas:
+                      try:
+                          jsonschema.validate(d["spec"], schemas[d["kind"]])
+                      except jsonschema.ValidationError as e:
+                          failures.append(f"[{name}] {d['kind']}/{n} spec invalid: {e.message}")
+              print(f"[{name}] {len(docs)} documents rendered and validated")
+
+          # guards: optional components must not render when disabled
+          guards = [
+              ("default", "kind: ServiceMonitor", 0),
+              ("default", "kind: NetworkPolicy", 0),
+              ("operator-only", "kind: VLLMRuntime", 0),
+              ("operator-only", "kind: VLLMRouter", 0),
+              ("multi-model", "kind: VLLMRuntime", 2),
+          ]
+          for name, needle, expected in guards:
+              combo = dict(COMBOS)[name]
+              out = subprocess.run(
+                  ["helm", "template", RELEASE, CHART, "-n", NAMESPACE] + combo,
+                  capture_output=True, text=True).stdout
+              count = out.count(needle)
+              if count != expected:
+                  failures.append(f"[{name}] expected {expected} of {needle!r}, got {count}")
+
+          if failures:
+              print("\nFAILURES:")
+              for f in failures:
+                  print(" -", f)
+              sys.exit(1)
+          print("\nAll chart render checks passed")
+          EOF

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         exclude: |
           (?x)(
               ^helm/templates/|
+              ^helm-operator/templates/|
               .github/deployment-router.yaml
           )
       - id: end-of-file-fixer

--- a/docs/source/deployment/crd.rst
+++ b/docs/source/deployment/crd.rst
@@ -18,6 +18,111 @@ Prerequisites
 Installation
 ------------
 
+You can deploy the operator either with Helm (recommended, installs the CRDs and
+the controller manager in one step) or with plain kubectl manifests. Both methods
+install the same resources.
+
+Installing with Helm
+^^^^^^^^^^^^^^^^^^^^
+
+The ``helm-operator`` chart ships the four CRDs (``VLLMRuntime``, ``VLLMRouter``,
+``CacheServer``, ``LoraAdapter``) in its ``crds/`` directory and renders the
+custom resources themselves from values. A single ``helm install`` therefore
+deploys the operator **and** a complete inference service (vLLM engine + router)
+without any additional ``kubectl apply`` steps:
+
+.. code-block:: bash
+
+   helm install vllm-stack ./helm-operator -n production-stack-system --create-namespace
+
+Watch the rollout and, once the engine pods are ready, query the router:
+
+.. code-block:: bash
+
+   kubectl get pods -n production-stack-system
+   kubectl port-forward svc/vllm-stack-vllm-stack-operator-router 30080:80 -n production-stack-system
+   curl http://localhost:30080/v1/models
+
+The model, images, replicas, routing strategy, cache server and LoRA adapters
+are all configured through the chart values, mirroring the sample custom
+resources. For example, to serve a different model:
+
+.. code-block:: bash
+
+   cat > my-model.yaml <<EOF
+   vllmRuntimes:
+     - name: ""
+       spec:
+         model:
+           modelURL: "Qwen/Qwen2.5-7B-Instruct"
+   EOF
+   helm install vllm-stack ./helm-operator -n production-stack-system \
+     --create-namespace -f my-model.yaml
+
+Serving multiple models
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The chart serves any number of models behind a single router: define **one
+``vllmRuntimes`` entry per model** in your values file. Shared configuration
+lives in ``vllmRuntimeDefaults``; each entry is deep-merged over it and only
+carries the differences — raise ``deploymentConfig.replicas`` for more copies
+of the same model, add a new entry for a different model or resource profile:
+
+.. code-block:: yaml
+
+   vllmRuntimes:
+     - spec:
+         model:
+           modelURL: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
+         deploymentConfig:
+           resources: {cpu: "16", memory: "64Gi", gpu: "8"}
+     - spec:
+         model:
+           modelURL: "Qwen/Qwen2.5-7B-Instruct"
+         deploymentConfig:
+           replicas: 3
+
+Each entry becomes one ``VLLMRuntime`` custom resource labelled with a shared
+release label (``production-stack.vllm.ai/runtime-set``); the operator copies
+that label onto the engine pods, and the ``VLLMRouter`` selects on it — so the
+router discovers every engine of the release and routes each request by its
+``model`` field. Every model gets its own Deployment, Service and PVC;
+autoscaling (KEDA) is configured per entry.
+
+Clients use one endpoint and pick the model by name:
+
+.. code-block:: bash
+
+   curl http://localhost:30080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"model": "Qwen/Qwen2.5-7B-Instruct", "messages": [{"role": "user", "content": "hi"}]}'
+
+See ``helm-operator/README.md`` for the full list of values.
+
+.. note::
+   **Shared storage prerequisite**: the operator creates one PVC per
+   ``VLLMRuntime`` and mounts it in every engine pod. With more than one
+   replica (or replicas spread across nodes) the backing StorageClass must
+   support ``ReadWriteMany`` (NFS, CephFS, JuiceFS, AWS EFS, GCP Filestore,
+   Azure Files, Longhorn). The cluster default StorageClass is often RWO-only
+   (local-path, cloud block disks), which makes multi-node replicas fail with
+   ``Multi-Attach`` errors. Point
+   ``vllmRuntime.spec.storageConfig.storageClassName`` at an RWX-capable
+   class, keep a single replica, or disable ``storageConfig``. Details in the
+   chart README.
+
+.. note::
+   Helm never upgrades or deletes CRDs placed in a chart's ``crds/`` directory.
+   When upgrading to an operator version that ships CRD changes, apply them
+   manually:
+
+   .. code-block:: bash
+
+      kubectl apply --server-side -f helm-operator/crds/
+
+Installing with kubectl
+^^^^^^^^^^^^^^^^^^^^^^^
+
 1. **Clone the repository**
 
    First, clone the vLLM production stack repository:

--- a/helm-operator/.helmignore
+++ b/helm-operator/.helmignore
@@ -1,0 +1,10 @@
+*.png
+.git/
+outdated
+test.sh
+ct.yaml
+lintconf.yaml
+values.schema.json
+/workflows
+examples/
+values-*.yaml

--- a/helm-operator/Chart.yaml
+++ b/helm-operator/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: vllm-stack-operator
+description: Kubernetes operator for the vLLM production stack. Manages VLLMRuntime, VLLMRouter, CacheServer and LoraAdapter custom resources.
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semantic.org/)
+version: 0.1.0
+
+# The version of the operator image shipped by default. Override with `image.tag`.
+appVersion: "latest"
+
+# Minimum Kubernetes version: the CRDs use apiextensions.k8s.io/v1 (1.16+) and
+# the operator targets controller-runtime bases tested against modern clusters.
+kubeVersion: ">=1.23.0-0"
+
+maintainers:
+  - name: apostac

--- a/helm-operator/README.md
+++ b/helm-operator/README.md
@@ -1,0 +1,300 @@
+# vllm-stack-operator
+
+Helm chart for the [vLLM production stack](https://github.com/vllm-project/production-stack) operator.
+
+One `helm install` deploys everything needed to run an inference service:
+
+1. The CRDs (`VLLMRuntime`, `VLLMRouter`, `CacheServer`, `LoraAdapter`) from the
+   chart's `crds/` directory,
+2. The operator controller manager (Deployment + ServiceAccount + RBAC),
+3. The custom resources themselves, rendered from values — by default a
+   `VLLMRuntime` (vLLM engine) and a `VLLMRouter` (router), already wired
+   together. The operator then creates the engine/router Deployments, Services,
+   PVCs and service accounts.
+
+The chart is self-contained and does not modify the main `helm/` chart. The
+original manual installation path (`kubectl create -f operator/config/default.yaml`
+plus applying samples) remains fully supported.
+
+## Install
+
+```bash
+helm install vllm-stack ./helm-operator -n production-stack-system --create-namespace
+```
+
+This is equivalent to `kubectl create -f operator/config/default.yaml` followed by
+applying the `vllmruntime` and `vllmrouter` samples. Watch the rollout:
+
+```bash
+kubectl get pods -n production-stack-system
+kubectl get vllmruntime,vllmrouter -n production-stack-system
+```
+
+When the engine pods are ready, port-forward the router and send a request:
+
+```bash
+kubectl port-forward svc/vllm-stack-vllm-stack-operator-router 30080:80 -n production-stack-system
+curl http://localhost:30080/v1/models
+```
+
+## Configure the inference service
+
+Everything is controlled through values. The `spec` blocks below are passed
+through verbatim to the custom resources, so any field of the CRD schema can be
+set without waiting for the chart to add an explicit knob.
+
+Use your own model and image:
+
+```yaml
+vllmRuntimes:
+  - name: ""
+    spec:
+      model:
+        modelURL: "Qwen/Qwen2.5-7B-Instruct"
+        hfTokenSecret:
+          hfTokenSecretName: "huggingface-token"
+          hfTokenKeyName: "token"
+      vllmConfig:
+        tensorParallelSize: 2
+      deploymentConfig:
+        image:
+          registry: "docker.io"
+          name: "lmcache/vllm-openai"
+          tag: "latest"
+        replicas: 2
+```
+
+Enable the LMCache cache server and point the runtime at it:
+
+```yaml
+cacheServer:
+  enabled: true
+vllmRuntimes:
+  - name: ""
+    spec:
+      lmCacheConfig:
+        enabled: true
+        remoteUrl: "lm://vllm-stack-vllm-stack-operator-cacheserver.production-stack-system.svc.cluster.local:80"
+```
+
+Serve **multiple models** behind the single router with one `vllmRuntimes`
+entry per model — see [Serve multiple models](#serve-multiple-models).
+
+## Serve multiple models
+
+One router can serve any number of models. The pattern: **one `vllmRuntimes`
+entry per model**, sparse specs deep-merged over `vllmRuntimeDefaults`.
+
+```yaml
+# Shared configuration for every model
+vllmRuntimeDefaults:
+  vllmConfig:
+    port: 8000
+  storageConfig:
+    enabled: true
+    accessMode: "ReadWriteMany"
+
+# One entry per model — only the differences
+vllmRuntimes:
+  - spec:                        # defaults to <release>-...-runtime
+      model:
+        modelURL: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
+      deploymentConfig:
+        resources: {cpu: "16", memory: "64Gi", gpu: "8"}   # heavy model, 1 replica
+  - spec:                        # defaults to ...-runtime-1
+      model:
+        modelURL: "Qwen/Qwen2.5-7B-Instruct"
+      deploymentConfig:
+        replicas: 3              # same model, more throughput → replicas
+```
+
+Scaling rule of thumb: **more of the same model → raise that entry's
+`deploymentConfig.replicas`; a different model or resource profile → add
+another entry.** Autoscaling ([KEDA](#values) prerequisites apply) is
+configured per entry via `spec.autoscalingConfig`, so each model scales on its
+own thresholds.
+
+How it works under the hood:
+
+1. The chart renders one `VLLMRuntime` CR per entry and labels each with
+   `production-stack.vllm.ai/runtime-set: <fullname>`.
+2. The operator copies CR labels onto the engine pods, so every engine of this
+   release carries the shared label.
+3. The `VLLMRouter`'s `k8sLabelSelector` defaults to that label, so the router
+   discovers **all** engines of the release and routes each request by its
+   `model` field (strategies like roundrobin apply among the replicas serving
+   that model).
+
+What is per-model versus shared:
+
+| Per model (per `vllmRuntimes` entry) | Shared per release |
+|---|---|
+| engine Deployment, replicas, resources, image | operator |
+| **its own PVC** (named after the CR) and Service | router (single) |
+| autoscaling (`autoscalingConfig`) | CacheServer (LMCache, single) |
+| model URL, vLLM flags, LoRA settings | CRDs |
+
+Note: each model's replicas share that model's own PVC, so the
+[ReadWriteMany requirement](#shared-storage-pvc--the-readwritemany-requirement)
+applies **per model**.
+
+Clients send everything to the same router endpoint and pick the model by name:
+
+```bash
+kubectl port-forward svc/<release>-vllm-stack-operator-router 30080:80 -n production-stack-system
+curl http://localhost:30080/v1/models
+curl http://localhost:30080/v1/chat/completions -H "Content-Type: application/json" \
+  -d '{"model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B", "messages": [{"role": "user", "content": "hi"}]}'
+curl http://localhost:30080/v1/chat/completions -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen2.5-7B-Instruct", "messages": [{"role": "user", "content": "hi"}]}'
+```
+
+## Shared storage (PVC) — the ReadWriteMany requirement
+
+The operator creates **one** PVC per `VLLMRuntime` resource (named after the CR)
+and mounts it at `/data` in **every** engine pod. Model weights and the Hugging
+Face cache live there, so replicas share one copy instead of each re-downloading
+the model.
+
+All replicas mounting the same PVC requires `accessMode: ReadWriteMany` (RWX) —
+and **many StorageClasses do not support RWX**:
+
+| StorageClass backend | RWX support |
+|----------------------|-------------|
+| NFS, CephFS (CephFS-CSI), JuiceFS, SeaweedFS | yes |
+| AWS EFS, GCP Filestore, Azure Files (non-premium) | yes |
+| Longhorn | yes (via share-manager, slower) |
+| `local-path` / host-path | no (single node only) |
+| Cloud block storage: AWS gp2/gp3/ebs, GCP pd-standard/pd-balanced, Azure managed disk | **no** |
+
+Check what you have and whether a class can do RWX:
+
+```bash
+kubectl get sc
+kubectl get sc <name> -o jsonpath='{.provisioner}'
+```
+
+What happens with an RWO-only class:
+
+- all replicas land on the **same node** → it works (RWO permits same-node
+  mounts by pods of the same node);
+- replicas spread across **multiple nodes** → extra pods stick in `Pending`
+  with `Multi-Attach error for volume ... Volume is already exclusively
+  attached to one node`.
+
+Recommended settings when running `replicas > 1` across nodes:
+
+```yaml
+vllmRuntime:
+  spec:
+    storageConfig:
+      storageClassName: "nfs-client"   # an RWX-capable class in your cluster
+      accessMode: ReadWriteMany
+      size: "50Gi"
+```
+
+If you have no RWX-capable class, pick one of:
+
+- `deploymentConfig.replicas: 1` (single replica needs no shared mount);
+- pin all engine pods to one node with `deploymentConfig.nodeSelector` /
+  affinity (RWO then works);
+- `storageConfig.enabled: false` — no PVC; each pod downloads the model into
+  its own container filesystem (slower startup, no cache sharing).
+
+Note: the chart always sets `accessMode: ReadWriteMany` explicitly. If the
+field were omitted, the CRD schema defaults it to `ReadWriteMany` as well, but
+the operator falls back to `ReadWriteOnce` for CRs created before that
+defaulting existed — keep the field set.
+
+## Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `replicaCount` | `1` | Number of operator replicas (leader election allows more than one) |
+| `image.repository` | `lmcache/production-stack-operator` | Operator image repository (`ghcr.io/vllm-project/production-stack-operator` also published) |
+| `image.tag` | `latest` | Operator image tag; pin to a release tag or commit SHA in production |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `imagePullSecrets` | `[]` | Existing image pull secrets |
+| `nameOverride` / `fullnameOverride` | `""` | Override resource names |
+| `serviceAccount.create` | `true` | Create a dedicated service account |
+| `serviceAccount.name` | `""` | Service account name (generated when empty) |
+| `rbac.create` | `true` | Create the ClusterRole/Role and bindings |
+| `leaderElection.enabled` | `true` | Enable leader election |
+| `metrics.enabled` | `false` | Expose the operator metrics endpoint over plain HTTP |
+| `metrics.service.port` | `8443` | Metrics port (service and `--metrics-bind-address`) |
+| `metrics.serviceMonitor.enabled` | `false` | Create a ServiceMonitor for Prometheus Operator auto-discovery (requires `metrics.enabled=true` and the prometheus-operator CRDs) |
+| `metrics.serviceMonitor.additionalLabels` | `{release: kube-prometheus-stack}` | Labels to match your Prometheus `serviceMonitorSelector`; default matches a kube-prometheus-stack release named `kube-prometheus-stack` |
+| `metrics.serviceMonitor.interval` / `scrapeTimeout` | `30s` / `10s` | Scrape interval and timeout |
+| `metrics.serviceMonitor.honorLabels` / `metricRelabelings` / `relabelings` | `false` / `[]` / `[]` | Extra scrape tuning, same knobs as the main chart's ServiceMonitors |
+| `networkPolicy.enabled` | `false` | Restrict metrics scraping to namespaces labeled `metrics: enabled` (mirrors `operator/config/network-policy`; requires a NetworkPolicy-enforcing CNI) |
+| `resources` | `500m/128Mi` limits, `10m/64Mi` requests | Operator resources, mirrors `operator/config/manager` |
+| `nodeSelector` / `affinity` / `tolerations` | `{}` / `{}` / `[]` | Operator pod scheduling |
+| `extraEnv` | `[]` | Extra environment variables for the operator |
+| `extraArgs` | `[]` | Extra manager flags, e.g. `["--zap-log-level=debug"]` |
+| `vllmRuntimeDefaults` | see `values.yaml` | Shared `VLLMRuntimeSpec` defaults (model, vllmConfig, lmCacheConfig, deploymentConfig, storageConfig, autoscalingConfig) deep-merged into every entry below |
+| `vllmRuntimes` | one empty entry | List of `VLLMRuntime` resources — **one entry per model**, sparse specs deep-merged over `vllmRuntimeDefaults`; entry 0 defaults to `<release>-...-runtime`, entry i to `...-runtime-<i>` |
+| `vllmRouter.enabled` | `true` | Render a `VLLMRouter` resource in front of the engine |
+| `vllmRouter.name` | `""` | Resource name, defaults to `<release>-vllm-stack-operator-router` |
+| `vllmRouter.spec.k8sLabelSelector` | `""` | Defaults to the chart's shared runtime-set label, so the router serves every model of the release |
+| `vllmRouter.spec` | see `values.yaml` | Verbatim `VLLMRouterSpec` (replicas, routingLogic, image, resources, env, ...) |
+| `cacheServer.enabled` | `false` | Render a `CacheServer` resource (LMCache server) |
+| `cacheServer.spec` | see `values.yaml` | Verbatim `CacheServerSpec` |
+| `loraAdapters` | `[]` | List of `{name, spec}` entries, each rendered as a `LoraAdapter` |
+
+## CRD lifecycle (important)
+
+Helm installs the CRDs from `crds/` on the first `helm install` (skipping any that
+already exist), but **never upgrades or deletes them** on `helm upgrade` /
+`helm uninstall`. This is deliberate: deleting a CRD deletes every custom resource
+of that kind in the cluster.
+
+When upgrading to an operator version that ships CRD changes, apply them
+manually:
+
+```bash
+kubectl apply --server-side -f helm-operator/crds/
+```
+
+## Development
+
+The CRDs in `crds/` duplicate `operator/config/crd/bases/` on purpose: Helm
+charts must be self-contained once packaged (the `crds/` directory cannot
+reference files outside the chart). Keep the two in sync with the provided
+make targets — never edit `helm-operator/crds/` by hand:
+
+```bash
+cd operator
+make helm-crds        # regenerate (controller-gen) and copy into the chart
+make helm-crds-check  # fail if the copies drifted (for CI)
+```
+
+Run the chart unit tests (requires [helm-unittest](https://github.com/helm-unittest/helm-unittest)):
+
+```bash
+helm unittest helm-operator
+```
+
+## Uninstall
+
+```bash
+helm uninstall vllm-stack -n production-stack-system
+```
+
+Helm removes the operator and the custom resources. The engine/router workloads
+the operator created are garbage-collected with them (the operator sets owner
+references on everything it creates). The CRDs themselves are kept; delete them
+explicitly if you want to remove every trace:
+
+```bash
+kubectl delete -f helm-operator/crds/
+```
+
+Caveats:
+
+- `LoraAdapter` resources carry a finalizer. If the operator pod is gone before
+  it processes their deletion, those CRs (and a namespace containing them) can
+  stick in `Terminating`. Re-run the operator once, or strip the finalizer:
+  `kubectl patch loraadapter <name> -p '{"metadata":{"finalizers":[]}}' --type=merge`.
+- The chart creates cluster-scoped objects (ClusterRole, ClusterRoleBinding)
+  named after the release. Run at most one release of this chart per cluster,
+  or override `fullnameOverride` per release.

--- a/helm-operator/crds/production-stack.vllm.ai_cacheservers.yaml
+++ b/helm-operator/crds/production-stack.vllm.ai_cacheservers.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: cacheservers.production-stack.vllm.ai
+spec:
+  group: production-stack.vllm.ai
+  names:
+    kind: CacheServer
+    listKind: CacheServerList
+    plural: cacheservers
+    singular: cacheserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CacheServer is the Schema for the cacheservers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CacheServerSpec defines the desired state of CacheServer
+            properties:
+              deploymentStrategy:
+                default: RollingUpdate
+                description: Deployment strategy
+                enum:
+                - RollingUpdate
+                - Recreate
+                type: string
+              image:
+                description: Image configuration for the cache server
+                properties:
+                  name:
+                    type: string
+                  pullPolicy:
+                    type: string
+                  pullSecretName:
+                    type: string
+                  registry:
+                    type: string
+                required:
+                - name
+                - registry
+                type: object
+              port:
+                default: 8000
+                description: Container port for the cache server
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of replicas
+                format: int32
+                type: integer
+              resources:
+                description: Resource requirements
+                properties:
+                  cpu:
+                    type: string
+                  gpu:
+                    type: string
+                  gpuType:
+                    type: string
+                  memory:
+                    type: string
+                type: object
+            required:
+            - deploymentStrategy
+            - image
+            - port
+            - replicas
+            - resources
+            type: object
+          status:
+            description: CacheServerStatus defines the observed state of CacheServer
+            properties:
+              lastUpdated:
+                description: Last time the status was updated
+                format: date-time
+                type: string
+              status:
+                description: Current status of the cache server
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm-operator/crds/production-stack.vllm.ai_loraadapters.yaml
+++ b/helm-operator/crds/production-stack.vllm.ai_loraadapters.yaml
@@ -1,0 +1,248 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: loraadapters.production-stack.vllm.ai
+spec:
+  group: production-stack.vllm.ai
+  names:
+    kind: LoraAdapter
+    listKind: LoraAdapterList
+    plural: loraadapters
+    singular: loraadapter
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LoraAdapter is the Schema for the loraadapters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LoraAdapterSpec defines the desired state of LoraAdapter.
+            properties:
+              adapterSource:
+                description: AdapterSource defines where to get the LoRA adapter from.
+                properties:
+                  adapterName:
+                    description: AdapterName is the name of the adapter to apply.
+                    type: string
+                  adapterPath:
+                    description: 'AdapterPath is the path to the LoRA adapter weights.
+                      For local sources: required, specifies the path to the adapter
+                      For remote sources: optional, will be updated by the controller
+                      with the download path'
+                    type: string
+                  credentialsSecretRef:
+                    description: CredentialsSecretRef references a secret containing
+                      storage credentials.
+                    properties:
+                      key:
+                        description: Key in the secret containing the value
+                        type: string
+                      name:
+                        description: Name of the secret
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  maxAdapters:
+                    description: MaxAdapters is the maximum number of adapters to
+                      load.
+                    format: int32
+                    type: integer
+                  pattern:
+                    description: Pattern is the pattern to use for the adapter name.
+                    type: string
+                  repository:
+                    description: Repository is the repository to get the LoRA adapter
+                      from.
+                    type: string
+                  type:
+                    description: Type is the type of the adapter source.
+                    enum:
+                    - local
+                    - s3
+                    - http
+                    - huggingface
+                    type: string
+                required:
+                - adapterName
+                - type
+                type: object
+              baseModel:
+                description: BaseModel is the name of the base model this adapter
+                  is for.
+                type: string
+              loraAdapterDeploymentConfig:
+                description: DeploymentConfig defines how the adapter should be deployed
+                properties:
+                  algorithm:
+                    default: default
+                    description: Algorithm specifies which placement algorithm to
+                      use.
+                    enum:
+                    - default
+                    - ordered
+                    - equalized
+                    type: string
+                  replicas:
+                    description: Replicas is the number of replicas that should load
+                      this adapter.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                required:
+                - algorithm
+                type: object
+              vllmApiKey:
+                description: VLLMApiKey defines the configuration for vLLM API key
+                  authentication
+                properties:
+                  secretKey:
+                    description: Key in the secret containing the API key
+                    type: string
+                  secretName:
+                    description: Name of the secret
+                    type: string
+                required:
+                - secretKey
+                - secretName
+                type: object
+            required:
+            - adapterSource
+            - baseModel
+            type: object
+          status:
+            description: LoraAdapterStatus defines the observed state of LoraAdapter.
+            properties:
+              conditions:
+                description: Condition contains details for one aspect of the current
+                  state of this API Resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about why the current state is set.
+                      maxLength: 32768
+                      type: string
+                    reason:
+                      description: Reason is a brief reason for the condition's current
+                        status.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              loadedAdapters:
+                description: LoadedAdapters tracks the loading status of adapters
+                  and their pod assignments.
+                items:
+                  description: LoadedAdapter represents an adapter that has been loaded
+                    into a pod
+                  properties:
+                    loadTime:
+                      description: LoadTime is when the adapter was loaded
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the adapter
+                      type: string
+                    path:
+                      description: Path is the path where the adapter is loaded
+                      type: string
+                    podAssignments:
+                      description: PodAssignments represents the pods this adapter
+                        has been assigned to
+                      properties:
+                        namespace:
+                          description: Namespace is the namespace of the pod
+                          type: string
+                        podName:
+                          description: Pod represents the pod information
+                          type: string
+                      required:
+                      - namespace
+                      - podName
+                      type: object
+                    status:
+                      description: Status is the status of the adapter
+                      type: string
+                  required:
+                  - name
+                  - path
+                  - podAssignments
+                  - status
+                  type: object
+                type: array
+              message:
+                description: Message provides additional information about the current
+                  phase.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration represents the .metadata.generation
+                  that the condition was set based upon.
+                format: int64
+                minimum: 0
+                type: integer
+              phase:
+                description: Phase represents the current phase of the adapter deployment.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm-operator/crds/production-stack.vllm.ai_vllmrouters.yaml
+++ b/helm-operator/crds/production-stack.vllm.ai_vllmrouters.yaml
@@ -1,0 +1,268 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: vllmrouters.production-stack.vllm.ai
+spec:
+  group: production-stack.vllm.ai
+  names:
+    kind: VLLMRouter
+    listKind: VLLMRouterList
+    plural: vllmrouters
+    singular: vllmrouter
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VLLMRouter is the Schema for the vllmrouters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VLLMRouterSpec defines the desired state of VLLMRouter
+            properties:
+              enableRouter:
+                default: true
+                description: EnableRouter determines if the router should be deployed
+                type: boolean
+              engineScrapeInterval:
+                description: EngineScrapeInterval for collecting engine statistics
+                format: int32
+                type: integer
+              env:
+                description: Environment variables
+                items:
+                  description: EnvVar represents an environment variable
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              extraArgs:
+                description: ExtraArgs for additional router arguments
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image configuration
+                properties:
+                  name:
+                    type: string
+                  pullPolicy:
+                    type: string
+                  pullSecretName:
+                    type: string
+                  registry:
+                    type: string
+                required:
+                - name
+                - registry
+                type: object
+              k8sLabelSelector:
+                description: K8sLabelSelector specifies the label selector for vLLM
+                  runtime pods when using k8s service discovery
+                type: string
+              lmcacheControllerPort:
+                description: |-
+                  LmcacheControllerPort is the port of the LMCache controller (used with kvaware routing).
+                  Set explicitly when routingLogic is "kvaware" (typical value: 9000).
+                format: int32
+                maximum: 65535
+                type: integer
+              nodeSelectorTerms:
+                description: NodeSelectorTerms for pod scheduling
+                items:
+                  description: |-
+                    A null or empty node selector term matches no objects. The requirements of
+                    them are ANDed.
+                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                  properties:
+                    matchExpressions:
+                      description: A list of node selector requirements by node's
+                        labels.
+                      items:
+                        description: |-
+                          A node selector requirement is a selector that contains values, a key, and an operator
+                          that relates the key and values.
+                        properties:
+                          key:
+                            description: The label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              Represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                            type: string
+                          values:
+                            description: |-
+                              An array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. If the operator is Gt or Lt, the values
+                              array must have a single element, which will be interpreted as an integer.
+                              This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchFields:
+                      description: A list of node selector requirements by node's
+                        fields.
+                      items:
+                        description: |-
+                          A node selector requirement is a selector that contains values, a key, and an operator
+                          that relates the key and values.
+                        properties:
+                          key:
+                            description: The label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              Represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                            type: string
+                          values:
+                            description: |-
+                              An array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. If the operator is Gt or Lt, the values
+                              array must have a single element, which will be interpreted as an integer.
+                              This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              port:
+                default: 80
+                description: ContainerPort for the router service
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas specifies the number of router replicas
+                format: int32
+                type: integer
+              requestStatsWindow:
+                description: RequestStatsWindow for request statistics
+                format: int32
+                type: integer
+              resources:
+                description: Resource requirements
+                properties:
+                  cpu:
+                    type: string
+                  gpu:
+                    type: string
+                  gpuType:
+                    type: string
+                  memory:
+                    type: string
+                type: object
+              routingLogic:
+                default: roundrobin
+                description: RoutingLogic specifies the routing strategy
+                enum:
+                - roundrobin
+                - session
+                - prefixaware
+                - kvaware
+                type: string
+              serviceAccountName:
+                description: ServiceAccountName for the router pod
+                type: string
+              serviceDiscovery:
+                default: k8s
+                description: ServiceDiscovery specifies the service discovery method
+                  (k8s or static)
+                enum:
+                - k8s
+                - static
+                type: string
+              sessionKey:
+                default: ""
+                description: SessionKey for session-based routing
+                type: string
+              staticBackends:
+                description: StaticBackends is required when using static service
+                  discovery
+                type: string
+              staticModels:
+                description: StaticModels is required when using static service discovery
+                type: string
+              vllmApiKeyName:
+                type: string
+              vllmApiKeySecret:
+                description: VLLM API Key configuration
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - image
+            - resources
+            type: object
+          status:
+            description: VLLMRouterStatus defines the observed state of VLLMRouter
+            properties:
+              activeRuntimes:
+                description: Number of active runtimes
+                format: int32
+                type: integer
+              lastUpdated:
+                description: Last updated timestamp
+                format: date-time
+                type: string
+              status:
+                description: Router status
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm-operator/crds/production-stack.vllm.ai_vllmruntimes.yaml
+++ b/helm-operator/crds/production-stack.vllm.ai_vllmruntimes.yaml
@@ -1,0 +1,601 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: vllmruntimes.production-stack.vllm.ai
+spec:
+  group: production-stack.vllm.ai
+  names:
+    kind: VLLMRuntime
+    listKind: VLLMRuntimeList
+    plural: vllmruntimes
+    shortNames:
+    - vr
+    singular: vllmruntime
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VLLMRuntime is the Schema for the vllmruntimes API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VLLMRuntimeSpec defines the desired state of VLLMRuntime
+            properties:
+              autoscalingConfig:
+                description: Autoscaling configuration
+                properties:
+                  enabled:
+                    description: Enabled enables autoscaling
+                    type: boolean
+                  maxReplicas:
+                    description: MaxReplicas is the maximum number of replicas
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  minReplicas:
+                    default: 1
+                    description: MinReplicas is the minimum number of replicas (defaults
+                      to 1, set to 0 to enable scale-to-zero)
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  pollingInterval:
+                    default: 15
+                    description: PollingInterval is how often KEDA checks metrics
+                      (seconds)
+                    format: int32
+                    type: integer
+                  scaleDownPolicy:
+                    description: ScaleDownPolicy defines the scaling behavior when
+                      scaling down
+                    properties:
+                      periodSeconds:
+                        default: 60
+                        description: PeriodSeconds is the period for the scale down
+                          policy
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      podValue:
+                        default: 1
+                        description: PodValue is the max pods to remove per period
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      scaleToZeroDelaySeconds:
+                        default: 1800
+                        description: |-
+                          ScaleToZeroDelaySeconds is the wait time before scaling to zero (seconds).
+                          Only applicable when minReplicas is set to 0.
+                        format: int32
+                        type: integer
+                      stabilizationWindowSeconds:
+                        default: 300
+                        description: StabilizationWindowSeconds is the HPA stabilization
+                          window for scaling down
+                        format: int32
+                        type: integer
+                    type: object
+                  scaleUpPolicy:
+                    description: ScaleUpPolicy defines the scaling behavior when scaling
+                      up
+                    properties:
+                      periodSeconds:
+                        default: 60
+                        description: PeriodSeconds is the period for the scale up
+                          policy
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      podValue:
+                        default: 1
+                        description: PodValue is the max pods to add per period
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      stabilizationWindowSeconds:
+                        default: 0
+                        description: StabilizationWindowSeconds is the HPA stabilization
+                          window for scaling up
+                        format: int32
+                        type: integer
+                    type: object
+                  triggers:
+                    description: Triggers defines the metric thresholds for autoscaling
+                    properties:
+                      generationTokensThreshold:
+                        default: 100
+                        description: GenerationTokensThreshold is the per-pod generation
+                          tokens/s threshold for scaling
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      prometheusAddress:
+                        default: http://kube-prom-stack-kube-prome-prometheus.monitoring.svc:9090
+                        description: PrometheusAddress is the Prometheus server address
+                          for metric queries
+                        type: string
+                      promptTokensThreshold:
+                        default: 100
+                        description: PromptTokensThreshold is the per-pod prompt tokens/s
+                          threshold for scaling
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      requestsRunningThreshold:
+                        default: 5
+                        description: RequestsRunningThreshold is the per-pod concurrent
+                          requests threshold for scaling
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                required:
+                - maxReplicas
+                type: object
+              deploymentConfig:
+                description: Deployment configuration
+                properties:
+                  deploymentStrategy:
+                    default: RollingUpdate
+                    description: Deploy strategy
+                    enum:
+                    - RollingUpdate
+                    - Recreate
+                    type: string
+                  image:
+                    description: Image configuration
+                    properties:
+                      name:
+                        type: string
+                      pullPolicy:
+                        type: string
+                      pullSecretName:
+                        type: string
+                      registry:
+                        type: string
+                    required:
+                    - name
+                    - registry
+                    type: object
+                  nodeSelectorTerms:
+                    description: Node selector
+                    items:
+                      description: |-
+                        A null or empty node selector term matches no objects. The requirements of
+                        them are ANDed.
+                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                      properties:
+                        matchExpressions:
+                          description: A list of node selector requirements by node's
+                            labels.
+                          items:
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies
+                                  to.
+                                type: string
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchFields:
+                          description: A list of node selector requirements by node's
+                            fields.
+                          items:
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies
+                                  to.
+                                type: string
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Pod annotations
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Replicas
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resource requirements
+                    properties:
+                      cpu:
+                        type: string
+                      gpu:
+                        type: string
+                      gpuType:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  runtimeClass:
+                    default: nvidia
+                    description: RuntimeClass
+                    type: string
+                  shmSize:
+                    description: |-
+                      ShmSize, when set, mounts an emptyDir with medium=Memory at /dev/shm
+                      sized to this value (e.g. "24Gi"). Tensor parallelism uses shared
+                      memory for inter-process communication and the container default
+                      /dev/shm (typically 64Mi) is too small. Accepts any Kubernetes quantity.
+                    type: string
+                  sidecarConfig:
+                    description: Sidecar configuration
+                    properties:
+                      args:
+                        description: Arguments for the sidecar container
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Command to run in the sidecar container
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        default: false
+                        description: Enabled enables the sidecar container
+                        type: boolean
+                      env:
+                        description: Environment variables for the sidecar container
+                        items:
+                          description: EnvVar represents an environment variable
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      image:
+                        description: Image configuration for the sidecar
+                        properties:
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecretName:
+                            type: string
+                          registry:
+                            type: string
+                        required:
+                        - name
+                        - registry
+                        type: object
+                      mountPath:
+                        default: /data
+                        description: MountPath is the path where the shared volume
+                          will be mounted in the sidecar
+                        type: string
+                      name:
+                        default: sidecar
+                        description: Name is the name of the sidecar container
+                        type: string
+                      resources:
+                        description: Resource requirements for the sidecar container
+                        properties:
+                          cpu:
+                            type: string
+                          gpu:
+                            type: string
+                          gpuType:
+                            type: string
+                          memory:
+                            type: string
+                        type: object
+                    required:
+                    - image
+                    type: object
+                  toleration:
+                    description: Toleration
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - image
+                - resources
+                type: object
+              lmCacheConfig:
+                description: LM Cache configuration
+                properties:
+                  cpuOffloadingBufferSize:
+                    default: 4Gi
+                    description: CPUOffloadingBufferSize is the size of the CPU offloading
+                      buffer
+                    type: string
+                  diskOffloadingBufferSize:
+                    default: 8Gi
+                    description: DiskOffloadingBufferSize is the size of the disk
+                      offloading buffer
+                    type: string
+                  enabled:
+                    default: false
+                    description: Enabled enables LM Cache
+                    type: boolean
+                  remoteSerde:
+                    description: RemoteSerde is the serialization format for the remote
+                      cache
+                    type: string
+                  remoteUrl:
+                    description: RemoteURL is the URL of the remote cache server
+                    type: string
+                type: object
+              model:
+                description: Model configuration
+                properties:
+                  chatTemplate:
+                    description: Chat template
+                    type: string
+                  dtype:
+                    description: Data type
+                    type: string
+                  enableLoRA:
+                    description: Enable LoRA
+                    type: boolean
+                  enableTool:
+                    description: Enable tool
+                    type: boolean
+                  hfTokenSecret:
+                    description: HuggingFace token secret
+                    properties:
+                      hfTokenKeyName:
+                        default: token
+                        description: HuggingFace token key name in the secret
+                        type: string
+                      hfTokenSecretName:
+                        description: HuggingFace token secret name
+                        type: string
+                    type: object
+                  maxModelLen:
+                    description: Maximum model length
+                    format: int32
+                    type: integer
+                  maxNumSeqs:
+                    description: Maximum number of sequences
+                    format: int32
+                    type: integer
+                  modelURL:
+                    description: Model URL
+                    type: string
+                  toolCallParser:
+                    description: Tool call parser
+                    type: string
+                required:
+                - modelURL
+                type: object
+              storageConfig:
+                description: Storage configuration
+                properties:
+                  accessMode:
+                    default: ReadWriteMany
+                    description: AccessMode is the access mode for the persistent
+                      volume claim
+                    enum:
+                    - ReadWriteOnce
+                    - ReadOnlyMany
+                    - ReadWriteMany
+                    type: string
+                  enabled:
+                    default: false
+                    description: Enabled enables persistent storage
+                    type: boolean
+                  mountPath:
+                    default: /data
+                    description: MountPath is the path where the volume will be mounted
+                      in the container
+                    type: string
+                  size:
+                    default: 10Gi
+                    description: Size is the size of the persistent volume claim
+                    type: string
+                  storageClassName:
+                    description: StorageClassName is the name of the storage class
+                      to use
+                    type: string
+                  volumeName:
+                    default: pvc-storage
+                    description: VolumeName is the name of the volume (optional, will
+                      be auto-generated if not specified)
+                    type: string
+                type: object
+              vllmConfig:
+                description: vLLM server configuration
+                properties:
+                  enableChunkedPrefill:
+                    description: Enable chunked prefill
+                    type: boolean
+                  enablePrefixCaching:
+                    description: Enable prefix caching
+                    type: boolean
+                  env:
+                    description: Environment variables
+                    items:
+                      description: EnvVar represents an environment variable
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  extraArgs:
+                    description: Extra arguments for vllm serve
+                    items:
+                      type: string
+                    type: array
+                  gpuMemoryUtilization:
+                    description: GPU memory utilization
+                    type: string
+                  maxLoras:
+                    description: Maximum number of LoRAs
+                    format: int32
+                    type: integer
+                  port:
+                    default: 8000
+                    description: Port for vLLM server
+                    format: int32
+                    type: integer
+                  tensorParallelSize:
+                    description: Tensor parallel size
+                    format: int32
+                    type: integer
+                  v1:
+                    description: Use V1 API
+                    type: boolean
+                type: object
+            required:
+            - deploymentConfig
+            - model
+            - vllmConfig
+            type: object
+          status:
+            description: VLLMRuntimeStatus defines the observed state of VLLMRuntime
+            properties:
+              availableReplicas:
+                description: Number of pods that are ready and serving traffic
+                format: int32
+                type: integer
+              lastUpdated:
+                description: Last updated timestamp
+                format: date-time
+                type: string
+              modelStatus:
+                description: Model status
+                type: string
+              replicas:
+                description: Current replica count (used by scale subresource)
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for pods (used by scale subresource for
+                  HPA AverageValue)
+                type: string
+              unavailableReplicas:
+                description: Number of pods that are not yet available
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Number of pods running the latest pod template
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.deploymentConfig.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/helm-operator/templates/NOTES.txt
+++ b/helm-operator/templates/NOTES.txt
@@ -1,0 +1,39 @@
+The vLLM production stack operator has been deployed.
+
+Release namespace: {{ .Release.Namespace }}
+
+1. The CRDs (VLLMRuntime, VLLMRouter, CacheServer, LoraAdapter) were installed
+   automatically before the release (helm/crds directory of this chart).
+2. Check the operator pod status:
+
+      kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if .Values.vllmRuntimes }}
+3. {{ len .Values.vllmRuntimes }} VLLMRuntime resource(s) were created from your values; the
+   operator is rolling out the vLLM engine pods:
+
+      kubectl get vllmruntime -n {{ .Release.Namespace }}
+{{- range $i, $rt := .Values.vllmRuntimes }}
+      - {{ include "vllm-stack-operator.runtimeResourceName" (dict "root" $ "i" $i "rt" $rt) }}
+{{- end }}
+
+{{- end }}
+{{- if .Values.vllmRouter.enabled }}
+{{- if .Values.vllmRuntimes }}4{{ else }}3{{ end }}. A VLLMRouter custom resource "{{ include "vllm-stack-operator.routerName" . }}" was
+   created from your values; it discovers every engine of this release via the
+   label {{ include "vllm-stack-operator.runtimeSetLabelKey" . }}={{ include "vllm-stack-operator.fullname" . }}
+   and routes requests by model name. Once the engine pods are ready:
+
+      kubectl get svc -n {{ .Release.Namespace }} {{ include "vllm-stack-operator.routerName" . }}
+      kubectl port-forward svc/{{ include "vllm-stack-operator.routerName" . }} 30080:80 -n {{ .Release.Namespace }}
+      curl http://localhost:30080/v1/models
+
+{{- end }}
+{{- if not .Values.metrics.enabled }}
+Operator metrics are disabled by default. Enable them with --set metrics.enabled=true.
+{{- end }}
+
+NOTE: Helm never upgrades or deletes CRDs in the crds/ directory. When upgrading
+the operator to a version with CRD changes, apply them manually:
+
+    kubectl apply --server-side -f helm-operator/crds/

--- a/helm-operator/templates/_helpers.tpl
+++ b/helm-operator/templates/_helpers.tpl
@@ -1,0 +1,99 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vllm-stack-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vllm-stack-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vllm-stack-operator.labels" -}}
+helm.sh/chart: {{ include "vllm-stack-operator.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "vllm-stack-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vllm-stack-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vllm-stack-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: operator
+{{- end }}
+
+{{/*
+Name of the service account to use
+*/}}
+{{- define "vllm-stack-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vllm-stack-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Label key placed on every VLLMRuntime rendered by this chart. The operator
+copies CR labels onto the engine pods, and the router's k8sLabelSelector
+defaults to this label so one router serves every runtime (model) of the
+release.
+*/}}
+{{- define "vllm-stack-operator.runtimeSetLabelKey" -}}
+production-stack.vllm.ai/runtime-set
+{{- end }}
+
+{{/*
+Name of the VLLMRuntime custom resource for a given array entry.
+Params: dict (root - $, i - index, rt - entry).
+Entry 0 defaults to "<fullname>-runtime"; entry i>0 to "<fullname>-runtime-<i>".
+Kept within 63 characters because the operator derives the engine Service name
+and the `app=<name>` pod label value from it — both are limited to 63 chars.
+*/}}
+{{- define "vllm-stack-operator.runtimeResourceName" -}}
+{{- $base := include "vllm-stack-operator.fullname" .root | trunc 55 | trimSuffix "-" -}}
+{{- $name := printf "%s-runtime" $base -}}
+{{- if gt (int .i) 0 -}}
+{{- $name = printf "%s-runtime-%d" ($base | trunc 52 | trimSuffix "-") (int .i) -}}
+{{- end -}}
+{{- default $name .rt.name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Name of the VLLMRouter custom resource. Kept within 63 characters (accounting
+for the suffix) because the operator derives the router Service name from it.
+*/}}
+{{- define "vllm-stack-operator.routerName" -}}
+{{- default (printf "%s-router" (include "vllm-stack-operator.fullname" . | trunc 56 | trimSuffix "-")) .Values.vllmRouter.name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Name of the CacheServer custom resource. Kept within 63 characters (accounting
+for the suffix) because the operator derives the cache server Service name from it.
+*/}}
+{{- define "vllm-stack-operator.cacheServerName" -}}
+{{- default (printf "%s-cacheserver" (include "vllm-stack-operator.fullname" . | trunc 51 | trimSuffix "-")) .Values.cacheServer.name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+

--- a/helm-operator/templates/cacheserver.yaml
+++ b/helm-operator/templates/cacheserver.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.cacheServer.enabled -}}
+apiVersion: production-stack.vllm.ai/v1alpha1
+kind: CacheServer
+metadata:
+  name: {{ include "vllm-stack-operator.cacheServerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: cache-server
+    {{- with .Values.cacheServer.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- toYaml .Values.cacheServer.spec | nindent 2 }}
+{{- end }}

--- a/helm-operator/templates/deployment-operator.yaml
+++ b/helm-operator/templates/deployment-operator.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vllm-stack-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "vllm-stack-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "vllm-stack-operator.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: manager
+          command:
+            - /manager
+          args:
+            - --health-probe-bind-address=:8081
+            {{- if .Values.leaderElection.enabled }}
+            - --leader-elect
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - --metrics-bind-address=:{{ .Values.metrics.service.port }}
+            - --metrics-secure=false
+            {{- end }}
+            {{- range .Values.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.service.port }}
+              protocol: TCP
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-operator/templates/loraadapters.yaml
+++ b/helm-operator/templates/loraadapters.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.loraAdapters }}
+---
+apiVersion: production-stack.vllm.ai/v1alpha1
+kind: LoraAdapter
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/component: lora-adapter
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- toYaml .spec | nindent 2 }}
+{{- end }}

--- a/helm-operator/templates/networkpolicy-metrics.yaml
+++ b/helm-operator/templates/networkpolicy-metrics.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . | trunc 41 | trimSuffix "-" }}-allow-metrics-traffic
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "vllm-stack-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Only allow scraping from namespaces matching networkPolicy.metricsNamespaceSelector
+    - from:
+        - namespaceSelector:
+            {{- toYaml .Values.networkPolicy.metricsNamespaceSelector | nindent 12 }}
+      ports:
+        - port: {{ .Values.metrics.service.port }}
+          protocol: TCP
+{{- end }}

--- a/helm-operator/templates/role.yaml
+++ b/helm-operator/templates/role.yaml
@@ -1,0 +1,167 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+rules:
+# Mirrors operator/config/rbac/role.yaml. Regenerate with `make manifests` when the
+# operator permissions change.
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - production-stack.vllm.ai
+  resources:
+  - cacheservers
+  - loraadapters
+  - vllmrouters
+  - vllmruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - production-stack.vllm.ai
+  resources:
+  - cacheservers/finalizers
+  - loraadapters/finalizers
+  - vllmrouters/finalizers
+  - vllmruntimes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - production-stack.vllm.ai
+  resources:
+  - cacheservers/status
+  - loraadapters/status
+  - vllmrouters/status
+  - vllmruntimes/scale
+  - vllmruntimes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+# Permissions required for leader election, namespaced to the release namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . | trunc 47 | trimSuffix "-" }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end }}

--- a/helm-operator/templates/rolebinding.yaml
+++ b/helm-operator/templates/rolebinding.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vllm-stack-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vllm-stack-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . | trunc 47 | trimSuffix "-" }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "vllm-stack-operator.fullname" . | trunc 47 | trimSuffix "-" }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vllm-stack-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-operator/templates/service-metrics.yaml
+++ b/helm-operator/templates/service-metrics.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metrics.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  # Service names are limited to 63 chars; budget for the "-metrics" suffix.
+  name: {{ include "vllm-stack-operator.fullname" . | trunc 54 | trimSuffix "-" }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "vllm-stack-operator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/helm-operator/templates/serviceaccount.yaml
+++ b/helm-operator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vllm-stack-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-operator/templates/servicemonitor-operator.yaml
+++ b/helm-operator/templates/servicemonitor-operator.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "vllm-stack-operator.fullname" . | trunc 48 | trimSuffix "-" }}-servicemonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vllm-stack-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "vllm-stack-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm-operator/templates/vllmrouter.yaml
+++ b/helm-operator/templates/vllmrouter.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.vllmRouter.enabled -}}
+apiVersion: production-stack.vllm.ai/v1alpha1
+kind: VLLMRouter
+metadata:
+  name: {{ include "vllm-stack-operator.routerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: vllm-router
+    {{- with .Values.vllmRouter.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- toYaml (omit .Values.vllmRouter.spec "k8sLabelSelector") | nindent 2 }}
+  # Defaults to the shared label this chart puts on every VLLMRuntime (whose
+  # labels the operator copies onto engine pods), so one router serves all
+  # models of this release.
+  k8sLabelSelector: {{ .Values.vllmRouter.spec.k8sLabelSelector | default (printf "%s=%s" (include "vllm-stack-operator.runtimeSetLabelKey" .) (include "vllm-stack-operator.fullname" .)) | quote }}
+{{- end }}

--- a/helm-operator/templates/vllmruntime.yaml
+++ b/helm-operator/templates/vllmruntime.yaml
@@ -1,0 +1,23 @@
+{{- range $i, $rt := .Values.vllmRuntimes }}
+{{- if gt $i 0 }}
+---
+{{- end }}
+{{- $spec := deepCopy ($.Values.vllmRuntimeDefaults | default dict) }}
+{{- if $rt.spec }}
+{{- $spec = mergeOverwrite $spec $rt.spec }}
+{{- end }}
+apiVersion: production-stack.vllm.ai/v1alpha1
+kind: VLLMRuntime
+metadata:
+  name: {{ include "vllm-stack-operator.runtimeResourceName" (dict "root" $ "i" $i "rt" $rt) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/component: vllm-runtime
+    {{ include "vllm-stack-operator.runtimeSetLabelKey" $ }}: {{ include "vllm-stack-operator.fullname" $ }}
+    {{- with $rt.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}

--- a/helm-operator/tests/custom-resources_test.yaml
+++ b/helm-operator/tests/custom-resources_test.yaml
@@ -1,0 +1,260 @@
+suite: test custom resource rendering
+templates:
+  - vllmruntime.yaml
+  - vllmrouter.yaml
+  - cacheserver.yaml
+  - loraadapters.yaml
+tests:
+  - it: should render runtime and router CRs by default
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - containsDocument:
+          kind: VLLMRuntime
+          apiVersion: production-stack.vllm.ai/v1alpha1
+          name: vllm-vllm-stack-operator-runtime
+          template: vllmruntime.yaml
+      - containsDocument:
+          kind: VLLMRouter
+          apiVersion: production-stack.vllm.ai/v1alpha1
+          name: vllm-vllm-stack-operator-router
+          template: vllmrouter.yaml
+      - hasDocuments:
+          count: 0
+          template: cacheserver.yaml
+      - hasDocuments:
+          count: 0
+          template: loraadapters.yaml
+
+  - it: should label every runtime with the shared release label
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - equal:
+          path: metadata.labels["production-stack.vllm.ai/runtime-set"]
+          value: vllm-vllm-stack-operator
+          template: vllmruntime.yaml
+
+  - it: should default the router selector to the shared release label
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - equal:
+          path: spec.k8sLabelSelector
+          value: "production-stack.vllm.ai/runtime-set=vllm-vllm-stack-operator"
+          template: vllmrouter.yaml
+
+  - it: should keep an explicit router selector
+    release:
+      name: vllm
+      namespace: default
+    set:
+      vllmRouter:
+        spec:
+          k8sLabelSelector: "app=my-engine"
+    asserts:
+      - equal:
+          path: spec.k8sLabelSelector
+          value: "app=my-engine"
+          template: vllmrouter.yaml
+
+  - it: should render one runtime per array entry with the shared label
+    release:
+      name: vllm
+      namespace: default
+    set:
+      vllmRuntimes:
+        - name: ""
+          spec:
+            model: {modelURL: "meta-llama/Llama-3.1-8B-Instruct"}
+        - name: ""
+          spec:
+            model: {modelURL: "Qwen/Qwen2.5-7B-Instruct"}
+        - name: qwen
+          spec:
+            model: {modelURL: "Qwen/Qwen3-32B"}
+    asserts:
+      - hasDocuments:
+          count: 3
+          template: vllmruntime.yaml
+      - containsDocument:
+          kind: VLLMRuntime
+          name: vllm-vllm-stack-operator-runtime
+          template: vllmruntime.yaml
+      - containsDocument:
+          kind: VLLMRuntime
+          name: vllm-vllm-stack-operator-runtime-1
+          template: vllmruntime.yaml
+      - containsDocument:
+          kind: VLLMRuntime
+          name: qwen
+          template: vllmruntime.yaml
+      # every entry carries the shared label the router selects on
+      - equal:
+          path: metadata.labels["production-stack.vllm.ai/runtime-set"]
+          value: vllm-vllm-stack-operator
+          template: vllmruntime.yaml
+
+  - it: should render runtime spec fields verbatim
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - equal:
+          path: spec.model.modelURL
+          value: "meta-llama/Llama-3.1-8B-Instruct"
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.deploymentConfig.replicas
+          value: 1
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.lmCacheConfig.enabled
+          value: false
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.autoscalingConfig.enabled
+          value: false
+          template: vllmruntime.yaml
+
+  - it: should deep-merge sparse entries over the shared defaults
+    release:
+      name: vllm
+      namespace: default
+    set:
+      vllmRuntimes:
+        - spec:
+            model:
+              modelURL: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
+            deploymentConfig:
+              resources:
+                gpu: "8"
+        - spec:
+            model:
+              modelURL: "Qwen/Qwen2.5-7B-Instruct"
+            deploymentConfig:
+              replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 2
+          template: vllmruntime.yaml
+      # per-entry values win
+      - equal:
+          path: spec.model.modelURL
+          value: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.deploymentConfig.resources.gpu
+          value: "8"
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.deploymentConfig.replicas
+          value: 3
+          template: vllmruntime.yaml
+      # untouched fields fall back to vllmRuntimeDefaults
+      - equal:
+          path: spec.deploymentConfig.image.name
+          value: "lmcache/vllm-openai:2025-05-27-v1"
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.storageConfig.accessMode
+          value: ReadWriteMany
+          template: vllmruntime.yaml
+
+  - it: should render autoscaling config when enabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      vllmRuntimes:
+        - spec:
+            autoscalingConfig:
+              enabled: true
+              minReplicas: 0
+              maxReplicas: 6
+              triggers:
+                prometheusAddress: "http://prometheus.monitoring.svc:9090"
+                requestsRunningThreshold: 3
+    asserts:
+      - equal:
+          path: spec.autoscalingConfig.enabled
+          value: true
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.autoscalingConfig.minReplicas
+          value: 0
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.autoscalingConfig.maxReplicas
+          value: 6
+          template: vllmruntime.yaml
+      - equal:
+          path: spec.autoscalingConfig.triggers.prometheusAddress
+          value: "http://prometheus.monitoring.svc:9090"
+          template: vllmruntime.yaml
+
+  - it: should render a cacheserver when enabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      cacheServer:
+        enabled: true
+        spec:
+          replicas: 2
+    asserts:
+      - containsDocument:
+          kind: CacheServer
+          apiVersion: production-stack.vllm.ai/v1alpha1
+          name: vllm-vllm-stack-operator-cacheserver
+          template: cacheserver.yaml
+      - equal:
+          path: spec.replicas
+          value: 2
+          template: cacheserver.yaml
+
+  - it: should render lora adapters from the values array
+    release:
+      name: vllm
+      namespace: default
+    set:
+      loraAdapters:
+        - name: adapter-one
+          spec:
+            baseModel: "Llama-3.1-8B-Instruct"
+        - name: adapter-two
+          spec:
+            baseModel: "Llama-3.1-8B-Instruct"
+    asserts:
+      - hasDocuments:
+          count: 2
+          template: loraadapters.yaml
+      - containsDocument:
+          kind: LoraAdapter
+          apiVersion: production-stack.vllm.ai/v1alpha1
+          name: adapter-one
+          template: loraadapters.yaml
+      - containsDocument:
+          kind: LoraAdapter
+          apiVersion: production-stack.vllm.ai/v1alpha1
+          name: adapter-two
+          template: loraadapters.yaml
+
+  - it: should render nothing when runtimes and router are disabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      vllmRuntimes: null
+      vllmRouter:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+          template: vllmruntime.yaml
+      - hasDocuments:
+          count: 0
+          template: vllmrouter.yaml

--- a/helm-operator/tests/deployment-operator_test.yaml
+++ b/helm-operator/tests/deployment-operator_test.yaml
@@ -1,0 +1,109 @@
+suite: test operator deployment configuration
+templates:
+  - deployment-operator.yaml
+  - service-metrics.yaml
+tests:
+  - it: should render a deployment with default values
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: vllm-vllm-stack-operator
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "lmcache/production-stack-operator:latest"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics-bind-address=:8443"
+      - hasDocuments:
+          count: 1
+          template: service-metrics.yaml
+
+  - it: should not render the metrics service when metrics are disabled
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - hasDocuments:
+          count: 0
+          template: service-metrics.yaml
+
+  - it: should render metrics flags and service when metrics are enabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      metrics:
+        enabled: true
+        service:
+          port: 9090
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics-bind-address=:9090"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics-secure=false"
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+          name: vllm-vllm-stack-operator-metrics
+          template: service-metrics.yaml
+      - equal:
+          path: spec.ports[0].port
+          value: 9090
+          template: service-metrics.yaml
+
+  - it: should not pass --leader-elect when leader election is disabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      leaderElection:
+        enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect"
+
+  - it: should use a custom image and extra args
+    release:
+      name: vllm
+      namespace: default
+    set:
+      image:
+        repository: "ghcr.io/vllm-project/production-stack-operator"
+        tag: "v0.2.0"
+      extraArgs:
+        - "--zap-log-level=debug"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/vllm-project/production-stack-operator:v0.2.0"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--zap-log-level=debug"
+
+  - it: should honor replicaCount and resources
+    release:
+      name: vllm
+      namespace: default
+    set:
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m

--- a/helm-operator/tests/networkpolicy_test.yaml
+++ b/helm-operator/tests/networkpolicy_test.yaml
@@ -1,0 +1,37 @@
+suite: test metrics network policy
+templates:
+  - networkpolicy-metrics.yaml
+tests:
+  - it: should not render a NetworkPolicy by default
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should restrict metrics ingress to labeled namespaces
+    release:
+      name: vllm
+      namespace: default
+    set:
+      metrics:
+        enabled: true
+        service:
+          port: 9090
+      networkPolicy:
+        enabled: true
+    asserts:
+      - containsDocument:
+          kind: NetworkPolicy
+          apiVersion: networking.k8s.io/v1
+          name: vllm-vllm-stack-operator-allow-metrics-traffic
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels.metrics
+          value: enabled
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 9090
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: operator

--- a/helm-operator/tests/rbac_test.yaml
+++ b/helm-operator/tests/rbac_test.yaml
@@ -1,0 +1,84 @@
+suite: test operator rbac and service account
+templates:
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+tests:
+  - it: should render service account, roles and bindings by default
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - containsDocument:
+          kind: ServiceAccount
+          apiVersion: v1
+          name: vllm-vllm-stack-operator
+          template: serviceaccount.yaml
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: vllm-vllm-stack-operator
+          template: role.yaml
+      - containsDocument:
+          kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: vllm-vllm-stack-operator-leader-election
+          template: role.yaml
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: vllm-vllm-stack-operator
+          template: rolebinding.yaml
+      - containsDocument:
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: vllm-vllm-stack-operator-leader-election
+          template: rolebinding.yaml
+
+  - it: should bind the cluster role to the created service account
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: vllm-vllm-stack-operator
+          template: rolebinding.yaml
+      - equal:
+          path: subjects[0].namespace
+          value: default
+          template: rolebinding.yaml
+
+  - it: should render nothing when rbac and service account creation are disabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      rbac:
+        create: false
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+          template: role.yaml
+      - hasDocuments:
+          count: 0
+          template: rolebinding.yaml
+      - hasDocuments:
+          count: 0
+          template: serviceaccount.yaml
+
+  - it: should use an existing service account name when provided
+    release:
+      name: vllm
+      namespace: default
+    set:
+      serviceAccount:
+        create: false
+        name: my-existing-sa
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: my-existing-sa
+          template: rolebinding.yaml

--- a/helm-operator/tests/servicemonitor_test.yaml
+++ b/helm-operator/tests/servicemonitor_test.yaml
@@ -1,0 +1,92 @@
+suite: test operator servicemonitor
+templates:
+  - servicemonitor-operator.yaml
+tests:
+  - it: should not render a ServiceMonitor by default
+    release:
+      name: vllm
+      namespace: default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render a ServiceMonitor when only serviceMonitor is enabled without metrics
+    release:
+      name: vllm
+      namespace: default
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ServiceMonitor when metrics and serviceMonitor are enabled
+    release:
+      name: vllm
+      namespace: default
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - containsDocument:
+          kind: ServiceMonitor
+          apiVersion: monitoring.coreos.com/v1
+          name: vllm-vllm-stack-operator-servicemonitor
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: vllm
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+
+  - it: should allow overriding the release label and scrape settings
+    release:
+      name: vllm
+      namespace: default
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          additionalLabels:
+            release: my-kps
+          interval: 60s
+          scrapeTimeout: 20s
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: my-kps
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 60s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 20s
+
+  - it: should pass through metric relabelings
+    release:
+      name: vllm
+      namespace: default
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          metricRelabelings:
+            - action: drop
+              regex: go_.*
+              sourceLabels: [__name__]
+    asserts:
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].action
+          value: drop

--- a/helm-operator/values.yaml
+++ b/helm-operator/values.yaml
@@ -1,0 +1,346 @@
+# -- Default values for the vllm-stack-operator chart.
+# -- Installing this chart deploys the production-stack operator together with its CRDs
+# -- (VLLMRuntime, VLLMRouter, CacheServer, LoraAdapter) into the release namespace.
+
+# -- Number of operator replicas. Leader election allows more than one.
+replicaCount: 1
+
+# -- Operator image configuration
+image:
+  # -- Docker image repository
+  repository: "lmcache/production-stack-operator"
+  # -- Docker image tag. Pin it to a release tag or commit SHA for production use
+  # -- (the shipped operator images are tagged with the commit SHA and `latest`).
+  tag: "latest"
+  # -- Image pull policy. Use `Always` when tracking a floating tag such as
+  # -- `latest`; `IfNotPresent` pairs well with a pinned tag.
+  pullPolicy: "IfNotPresent"
+
+# -- Name of existing image pull secrets
+imagePullSecrets: []
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full resource names
+fullnameOverride: ""
+
+# -- Create a dedicated service account for the operator
+serviceAccount:
+  # -- Whether to create the service account
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use. If not set and create is true, a name is generated.
+  name: ""
+
+# -- Create the ClusterRole, Role and their bindings required by the operator
+rbac:
+  create: true
+
+# -- Leader election configuration
+leaderElection:
+  # -- Enable leader election before acting as the controller. Required when replicaCount > 1.
+  enabled: true
+
+# -- Operator metrics configuration
+metrics:
+  # -- Expose the controller manager metrics endpoint
+  enabled: false
+  service:
+    # -- Port used by the metrics service and the --metrics-bind-address flag
+    port: 8443
+  # NOTE: the endpoint is served over plain HTTP (--metrics-secure=false) so that
+  # Prometheus can scrape it without API server authentication and authorization.
+
+  # -- ServiceMonitor for Prometheus Operator auto-discovery.
+  # -- PREREQUISITE: kube-prometheus-stack (or any chart shipping the
+  # -- prometheus-operator CRDs) must be installed in the cluster. The monitor
+  # -- carries the `release: kube-prometheus-stack` label by default so a
+  # -- kube-prometheus-stack release installed under that name picks it up
+  # -- automatically; change it if your release name differs.
+  # -- Requires metrics.enabled=true (the monitor selects the metrics Service).
+  serviceMonitor:
+    # -- Create a ServiceMonitor resource for the operator metrics service
+    enabled: false
+    # -- Labels to match the Prometheus object's serviceMonitorSelector. The
+    # -- default `release: kube-prometheus-stack` matches a kube-prometheus-stack
+    # -- release installed under that name (the usual default); change `release`
+    # -- to your release name if different.
+    additionalLabels:
+      release: kube-prometheus-stack
+    # -- Interval to scrape metrics
+    interval: 30s
+    # -- Timeout if metrics can't be retrieved in given time interval
+    scrapeTimeout: 10s
+    # -- Honor the metrics endpoints' labels
+    honorLabels: false
+    # -- Metric relabel configurations
+    metricRelabelings: []
+    # -- Relabel configurations
+    relabelings: []
+
+# @schema skipProperties:true
+# -- Operator resources. Defaults mirror operator/config/manager.
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+# -- Deployment annotations
+annotations: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Affinity
+affinity: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- NetworkPolicy restricting access to the operator metrics endpoint.
+# -- Mirrors operator/config/network-policy/allow-metrics-traffic.yaml: only
+# -- pods in namespaces labeled `metrics: enabled` may scrape the metrics port.
+# -- Enable together with metrics.enabled. Requires a CNI enforcing
+# -- NetworkPolicies (Calico, Cilium, ...).
+networkPolicy:
+  # -- Create the metrics NetworkPolicy
+  enabled: false
+  # -- Namespace label that grants scraping access
+  metricsNamespaceSelector:
+    matchLabels:
+      metrics: enabled
+
+# -- Extra environment variables, e.g. `{name: TZ, value: UTC}`
+extraEnv: []
+
+# -- Extra arguments passed to the manager binary,
+# -- e.g. `["--zap-log-level=debug"]`
+extraArgs: []
+
+# -- Default VLLMRuntimeSpec merged (deep, maps only — lists are replaced)
+# -- into every vllmRuntimes entry below. Define the shared configuration here
+# -- and only the per-model differences in each entry.
+vllmRuntimeDefaults:
+    model:
+      modelURL: "meta-llama/Llama-3.1-8B-Instruct"
+      enableLoRA: true
+      enableTool: false
+      toolCallParser: ""
+      maxModelLen: 4096
+      dtype: "bfloat16"
+      maxNumSeqs: 32
+      # -- HuggingFace token secret (optional), e.g.
+      #   hfTokenSecret:
+      #     hfTokenSecretName: "huggingface-token"
+      #     hfTokenKeyName: "token"
+    vllmConfig:
+      enableChunkedPrefill: false
+      enablePrefixCaching: false
+      tensorParallelSize: 1
+      gpuMemoryUtilization: "0.8"
+      maxLoras: 4
+      v1: true
+      port: 8000
+      env:
+        - name: HF_HOME
+          value: "/data"
+    lmCacheConfig:
+      enabled: false
+      cpuOffloadingBufferSize: "15"
+      diskOffloadingBufferSize: "0"
+      # -- Point at the CacheServer service when cacheServer.enabled is true, e.g.
+      #   remoteUrl: "lm://<fullname>-cacheserver.<namespace>.svc.cluster.local:80"
+      remoteSerde: "naive"
+    deploymentConfig:
+      resources:
+        cpu: "5"
+        memory: "32Gi"
+        gpu: "1"
+        gpuType: "nvidia.com/gpu"
+      image:
+        registry: "docker.io"
+        name: "lmcache/vllm-openai:2025-05-27-v1"
+        pullPolicy: "IfNotPresent"
+        pullSecretName: ""
+      replicas: 1
+      deploymentStrategy: "Recreate"
+      sidecarConfig:
+        enabled: true
+        name: "sidecar"
+        image:
+          registry: "docker.io"
+          name: "lmcache/lmstack-sidecar:latest"
+          pullPolicy: "Always"
+        resources:
+          cpu: "0.5"
+          memory: "128Mi"
+        mountPath: "/data"
+    # @schema skipProperties:true
+    # -- Shared storage. The operator creates ONE PVC (named after the CR) and
+    # -- mounts it at mountPath in EVERY engine pod, so replicas share model
+    # -- weights and the HF cache instead of re-downloading.
+    # -- IMPORTANT: with accessMode ReadWriteMany the StorageClass MUST support
+    # -- RWX (NFS, CephFS, JuiceFS, AWS EFS, GCP Filestore, Azure Files,
+    # -- Longhorn, ...). The cluster DEFAULT StorageClass is often RWO-only
+    # -- (local-path, gp2/gp3, pd-standard, ...) — replicas scheduled across
+    # -- nodes then fail with Multi-Attach errors. Either point
+    # -- storageClassName at an RWX-capable class, keep replicas on one node,
+    # -- or set storageConfig.enabled=false.
+    storageConfig:
+      enabled: true
+      # -- StorageClass for the shared PVC. Empty = cluster default class
+      # -- (verify it supports ReadWriteMany before scaling past one node).
+      storageClassName: ""
+      size: "10Gi"
+      accessMode: "ReadWriteMany"
+      mountPath: "/data"
+
+    # -- Autoscaling (KEDA). DISABLED BY DEFAULT.
+    # -- PREREQUISITE: KEDA must be installed in the cluster
+    # -- (https://keda.works/docs/deploy/) before enabling this — without KEDA
+    # -- the operator cannot create the ScaledObject and autoscaling stays dead.
+    # -- When enabled, the operator creates a ScaledObject targeting this
+    # -- VLLMRuntime via its scale subresource; KEDA updates the CR replicas and
+    # -- the operator reconciles the Deployment — no conflict with
+    # -- deploymentConfig.replicas. Only `enabled: true` and `maxReplicas` are
+    # -- required; everything else has the defaults below.
+    autoscalingConfig:
+      # -- Enable autoscaling (requires KEDA)
+      enabled: false
+      # -- Minimum replicas. Set 0 to enable scale-to-zero.
+      minReplicas: 1
+      # -- Maximum replicas (required when autoscaling is enabled)
+      maxReplicas: 4
+      # -- How often KEDA checks metrics (seconds)
+      pollingInterval: 15
+      # -- Scale-up behavior
+      scaleUpPolicy:
+        # -- Wait before scaling up (0 = scale up immediately)
+        stabilizationWindowSeconds: 0
+        # -- Max pods to add per period
+        podValue: 1
+        periodSeconds: 60
+      # -- Scale-down behavior
+      scaleDownPolicy:
+        # -- Wait before scaling down (default 5 min)
+        stabilizationWindowSeconds: 300
+        # -- Max pods to remove per period
+        podValue: 1
+        periodSeconds: 60
+        # -- Idle time before scaling to zero. Only applies when minReplicas=0.
+        scaleToZeroDelaySeconds: 1800
+      # -- Metric thresholds (per-pod; KEDA divides by the current replica count)
+      triggers:
+        # -- Prometheus server address for metric queries
+        prometheusAddress: "http://kube-prom-stack-kube-prome-prometheus.monitoring.svc:9090"
+        # -- Per-pod concurrent requests threshold
+        requestsRunningThreshold: 5
+        # -- Per-pod generation tokens/s threshold
+        generationTokensThreshold: 100
+        # -- Per-pod prompt tokens/s threshold
+        promptTokensThreshold: 100
+
+# -- One entry per MODEL. Same model, more throughput → raise
+# -- deploymentConfig.replicas on its entry; a different model/resource
+# -- profile → add another entry. Each entry is deep-merged over
+# -- vllmRuntimeDefaults, rendered as one VLLMRuntime CR, labelled with the
+# -- shared release label the router selects on (routes by model name).
+# -- Entry 0 defaults to "<fullname>-runtime", entry i>0 to
+# -- "<fullname>-runtime-<i>". NOTE: `--set vllmRuntimes[0]...` replaces the
+# -- whole array — define entries in a values file.
+vllmRuntimes:
+  - name: ""
+    labels: {}
+    spec: {}
+
+# -- VLLMRouter custom resource. The operator reconciles it into the router
+# -- Deployment and Service, wired to the VLLMRuntime pods above.
+vllmRouter:
+  # -- Deploy a VLLMRouter custom resource
+  enabled: true
+  # -- Name of the VLLMRouter resource. Defaults to "<fullname>-router".
+  name: ""
+  # -- Extra labels for the VLLMRouter resource
+  labels: {}
+  spec:
+    enableRouter: true
+    replicas: 1
+    # -- Service discovery method (k8s or static)
+    serviceDiscovery: k8s
+    # -- Label selector for the vLLM runtime pods. Defaults to the label the
+    # -- operator puts on the VLLMRuntime pods: "app=<vllmRuntime name>".
+    k8sLabelSelector: ""
+    # -- Routing strategy (roundrobin, session, prefixaware, or kvaware)
+    routingLogic: roundrobin
+    engineScrapeInterval: 30
+    requestStatsWindow: 60
+    port: 80
+    # -- The operator creates this service account and its RBAC.
+    serviceAccountName: "vllmrouter-sa"
+    image:
+      registry: "docker.io"
+      name: "lmcache/lmstack-router"
+      pullPolicy: "IfNotPresent"
+    resources:
+      cpu: "2"
+      memory: "8Gi"
+    env:
+      - name: LOG_LEVEL
+        value: "info"
+      - name: METRICS_ENABLED
+        value: "true"
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
+
+# -- CacheServer custom resource (LMCache server). Point
+# -- vllmRuntime.spec.lmCacheConfig.remoteUrl at it when enabled.
+cacheServer:
+  # -- Deploy a CacheServer custom resource
+  enabled: false
+  # -- Name of the CacheServer resource. Defaults to "<fullname>-cacheserver".
+  name: ""
+  # -- Extra labels for the CacheServer resource
+  labels: {}
+  spec:
+    image:
+      registry: "docker.io"
+      name: "lmcache/vllm-openai:2025-04-18"
+      pullPolicy: "IfNotPresent"
+      pullSecretName: ""
+    port: 8000
+    resources:
+      cpu: "2"
+      memory: "16Gi"
+    replicas: 1
+    deploymentStrategy: "Recreate"
+
+# -- LoraAdapter custom resources. Each entry renders one LoraAdapter, e.g.
+#   - name: loraadapter-sample
+#     spec:
+#       baseModel: "Llama-3.1-8B-Instruct"
+#       adapterSource:
+#         type: "huggingface"
+#         adapterName: "llama-3.1-nemoguard-8b-topic-control"
+#         repository: "nvidia/llama-3.1-nemoguard-8b-topic-control"
+#         credentialsSecretRef:
+#           name: "huggingface-credentials"
+#           key: "hf_token"
+#       loraAdapterDeploymentConfig:
+#         algorithm: "default"
+#         replicas: 1
+loraAdapters: []
+

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -45,6 +45,21 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+.PHONY: helm-crds
+helm-crds: manifests ## Sync generated CRDs into the helm-operator chart's crds/ directory.
+	mkdir -p ../helm-operator/crds/
+	cp config/crd/bases/*.yaml ../helm-operator/crds/
+
+.PHONY: helm-crds-check
+helm-crds-check: ## Fail if the helm-operator chart CRDs drifted from config/crd/bases (for CI).
+	@for f in config/crd/bases/*.yaml; do \
+		cmp -s "$$f" "../helm-operator/crds/$$(basename $$f)" || { echo "DRIFT: $$f differs from ../helm-operator/crds/ — run 'make helm-crds' to sync"; exit 1; }; \
+	done
+	@for f in ../helm-operator/crds/*.yaml; do \
+		[ -f "config/crd/bases/$$(basename $$f)" ] || { echo "DRIFT: $$f has no source in config/crd/bases"; exit 1; }; \
+	done
+	@echo "helm-operator chart CRDs are in sync with config/crd/bases"
+
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."


### PR DESCRIPTION
## Summary

This PR adds a **standalone Helm chart (`helm-operator/`)** that installs the production-stack **operator, its four CRDs, and the custom resources themselves in a single `helm install`** — the same deployment model used by the kube-starrocks chart. The existing installation paths are completely untouched:

- `helm/` (the main stack chart) — unchanged
- `kubectl create -f operator/config/default.yaml` — unchanged and still documented
- `make install` / `make deploy` — unchanged

```bash
helm install vllm-stack ./helm-operator -n production-stack-system --create-namespace
```

## What was added

**Chart contents (`helm-operator/`)**

- `crds/` — the four CRDs (`VLLMRuntime`, `VLLMRouter`, `CacheServer`, `LoraAdapter`) generated from `operator/config/crd/bases`. Helm installs them automatically on first install (skipped when already present, never upgraded/deleted — documented).
- Operator control plane: manager `Deployment` (default image `lmcache/production-stack-operator`, `--leader-elect`, liveness/readiness probes, restricted security contexts), dedicated `ServiceAccount`, manager `ClusterRole` mirroring `operator/config/rbac/role.yaml`, namespaced leader-election `Role` and bindings. All gated by `rbac.create` / `serviceAccount.create`.
- **Custom resources rendered from values** (no manual `kubectl apply` of samples): `vllmRuntime` (defaults mirror the official sample), `vllmRouter`, `cacheServer`, and a `loraAdapters` list. CR specs are passed through verbatim, so every CRD field is configurable without waiting for an explicit chart knob.
- **Automatic wiring**: `vllmRouter.spec.k8sLabelSelector` defaults to `app=<runtime name>`, matching the label the operator puts on engine pods.
- Optional components, all **disabled by default** with documented prerequisites:
  - `metrics.enabled` + `metrics.serviceMonitor.enabled` — ServiceMonitor for Prometheus Operator discovery; ships with the `release: kube-prometheus-stack` label; **requires kube-prometheus-stack / prometheus-operator CRDs**.
  - `vllmRuntime.spec.autoscalingConfig` — full KEDA config (bounds, polling, scale-up/down policies, per-pod metric thresholds); **requires KEDA installed in the cluster**; the operator creates the ScaledObject and KEDA scales the CR via its scale subresource.
  - `networkPolicy.enabled` — restricts metrics scraping to namespaces labeled `metrics: enabled` (ported from `operator/config/network-policy/`).

**CI (`.github/workflows/helm-operator-ci.yml`)** — triggers on `helm-operator/**`, `operator/api/**`, `operator/config/crd/**`:

1. CRD drift gate (`make helm-crds-check`)
2. `helm lint`
3. `helm template` across four value combinations (default / monitoring / full-stack / operator-only)
4. Deep render validation: strict YAML parsing (duplicate keys), 63-char name/label-value budgets, rendered CR specs validated against the CRDs' OpenAPI schemas, and guard assertions that optional components stay absent when disabled

**Tooling & docs**

- `operator/Makefile`: `make helm-crds` (regenerate + sync CRDs into the chart) and `make helm-crds-check` (CI drift gate, checks both directions).
- `docs/source/deployment/crd.rst`: Helm installation section added before the existing kubectl instructions (both paths documented).
- `helm-operator/README.md`: full values reference, prerequisites (KEDA, kube-prometheus-stack, RWX-capable StorageClass for multi-replica shared PVC), CRD lifecycle, uninstall caveats.
- 5 helm-unittest test files (23 cases) covering deployment, RBAC, custom resources, ServiceMonitor and NetworkPolicy.

## Problems this solves

1. **No Helm path existed for the operator** — installation required cloning the repo and applying kustomize output by hand. Now one `helm install` deploys CRDs + operator + a running inference service (engine + router).
2. **CRs required manual `kubectl apply` of samples** — they are now values-driven, versioned with the release, and removed on uninstall (engine/router workloads are garbage-collected via the operator's ownerReferences).
3. **CRD duplication drift** — the chart must carry its own `crds/` copy (Helm charts are self-contained; subchart/external references are not supported), which is exactly how kube-starrocks ended up with two diverged CRD copies. This PR adds make-based sync plus a CI gate that fails on any drift, in both directions.
4. **Runtime failure classes that `helm lint`/`helm template` cannot see** — duplicate YAML keys, names/label values exceeding 63 chars (critical here: the operator reuses the CR name as the engine Service name and as the `app=<name>` pod label), and invalid CR spec fields. All three are caught in CI by the deep validation step; the 63-char budget is also enforced in the chart helpers themselves.
5. **Missing operational integrations** — Prometheus auto-discovery (ServiceMonitor), KEDA autoscaling, and metrics NetworkPolicy are now chart-native, consistent with the ServiceMonitor convention already used by the main chart.

## Notes for reviewers

- Verified locally: `helm lint`, `helm template` × 4 combinations, rendered CR specs validated against the CRD OpenAPI schemas, drift check (pass/fail/restore), and name-truncation behavior with a 53-char release name.
- Known Helm behavior, documented in the README: CRDs in `crds/` are never upgraded or deleted by Helm; upgrades shipping CRD changes require `kubectl apply --server-side -f helm-operator/crds/`. Uninstall keeps CRDs, and `LoraAdapter` finalizers may need manual removal if the operator dies first.
- Chart version 0.1.0 (unreleased); the workflow only uses the preinstalled helm on GitHub-hosted runners plus `pyyaml`/`jsonschema`.
