### PR TITLE
[Router] Make backend request timeouts configurable via environment variables

### DIFF
--- a/src/tests/test_request_timeouts.py
+++ b/src/tests/test_request_timeouts.py
@@ -1,0 +1,29 @@
+from vllm_router.services.request_service.request import (
+    _resolve_timeout_seconds,
+)
+
+
+class TestResolveTimeoutSeconds:
+    def test_env_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("ROUTER_DECODE_TIMEOUT_SECONDS", raising=False)
+        assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 600
+
+    def test_env_unset_none_default(self, monkeypatch):
+        monkeypatch.delenv("ROUTER_PROXY_TIMEOUT_SECONDS", raising=False)
+        assert _resolve_timeout_seconds("ROUTER_PROXY_TIMEOUT_SECONDS", None) is None
+
+    def test_env_value_used(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", "900")
+        assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 900
+
+    def test_env_float_value(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_PREFILL_TIMEOUT_SECONDS", "42.5")
+        assert _resolve_timeout_seconds("ROUTER_PREFILL_TIMEOUT_SECONDS", 300) == 42.5
+
+    def test_empty_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", "  ")
+        assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 600
+
+    def test_non_numeric_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", "abc")
+        assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 600

--- a/src/tests/test_request_timeouts.py
+++ b/src/tests/test_request_timeouts.py
@@ -27,3 +27,16 @@ class TestResolveTimeoutSeconds:
     def test_non_numeric_env_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", "abc")
         assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 600
+
+    def test_negative_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", "-10")
+        assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 600
+
+    def test_non_finite_env_falls_back_to_default(self, monkeypatch):
+        for raw in ("nan", "inf", "-inf"):
+            monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", raw)
+            assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 600
+
+    def test_zero_is_valid(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_DECODE_TIMEOUT_SECONDS", "0")
+        assert _resolve_timeout_seconds("ROUTER_DECODE_TIMEOUT_SECONDS", 600) == 0

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import math
 import os
 import time
 import uuid
@@ -114,10 +115,17 @@ def _resolve_timeout_seconds(env_var: str, default: Optional[float]) -> Optional
     if raw is None or raw.strip() == "":
         return default
     try:
-        return float(raw)
+        val = float(raw)
     except ValueError:
         logger.warning(f"Ignoring non-numeric {env_var}={raw!r}, using {default}")
         return default
+    if val < 0 or not math.isfinite(val):
+        logger.warning(
+            f"Ignoring invalid {env_var}={raw!r} (negative or non-finite), "
+            f"using {default}"
+        )
+        return default
+    return val
 
 
 def _resolve_client_timeout(

--- a/src/vllm_router/services/request_service/request.py
+++ b/src/vllm_router/services/request_service/request.py
@@ -101,6 +101,32 @@ _HEADERS_TO_STRIP_FROM_RESPONSE = {
 }
 
 
+def _resolve_timeout_seconds(env_var: str, default: Optional[float]) -> Optional[float]:
+    """Resolve a backend request timeout: ``env_var`` > ``default``.
+
+    Follows the ``LOADAWARE_BETA`` env fallback pattern: the value is read
+    on every request so it can be adjusted on a running deployment without
+    changing the router's command line. Empty or non-numeric values fall
+    back to the default. A value of ``None`` means the aiohttp total
+    timeout is uncapped.
+    """
+    raw = os.environ.get(env_var)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(f"Ignoring non-numeric {env_var}={raw!r}, using {default}")
+        return default
+
+
+def _resolve_client_timeout(
+    env_var: str, default: Optional[float]
+) -> aiohttp.ClientTimeout:
+    """Build an aiohttp request timeout from ``env_var``, falling back to ``default``."""
+    return aiohttp.ClientTimeout(total=_resolve_timeout_seconds(env_var, default))
+
+
 def _is_json_media_type(content_type: str) -> bool:
     media_type = content_type.partition(";")[0].strip().lower()
     return media_type == "application/json" or media_type.endswith("+json")
@@ -315,7 +341,7 @@ async def process_request(
             url=backend_url + endpoint,
             headers=headers,
             data=body,
-            timeout=aiohttp.ClientTimeout(total=None),
+            timeout=_resolve_client_timeout("ROUTER_PROXY_TIMEOUT_SECONDS", None),
         ) as backend_response:
             http_status_code = backend_response.status
             # Set response status on span if tracing
@@ -831,7 +857,7 @@ async def route_orchestrated_disaggregated_request(
                 "Content-Type": "application/json",
                 "X-Request-Id": request_id,
             },
-            timeout=aiohttp.ClientTimeout(total=300),
+            timeout=_resolve_client_timeout("ROUTER_PREFILL_TIMEOUT_SECONDS", 300),
         ) as prefill_resp:
             if prefill_resp.status != 200:
                 error_text = await prefill_resp.text()
@@ -877,7 +903,7 @@ async def route_orchestrated_disaggregated_request(
                 "Content-Type": "application/json",
                 "X-Request-Id": request_id,
             },
-            timeout=aiohttp.ClientTimeout(total=600),
+            timeout=_resolve_client_timeout("ROUTER_DECODE_TIMEOUT_SECONDS", 600),
         )
         try:
             if decode_resp.status != 200:
@@ -1337,7 +1363,9 @@ async def proxy_multipart_request(
                 f"{chosen_url}{endpoint}",
                 data=form_data,
                 headers=headers,
-                timeout=aiohttp.ClientTimeout(total=300),
+                timeout=_resolve_client_timeout(
+                    "ROUTER_MULTIPART_TIMEOUT_SECONDS", 300
+                ),
             )
         except Exception:
             request_stats_monitor.on_request_complete(


### PR DESCRIPTION
## Description

Backend request timeouts in the router's request service were hard-coded:
- proxy/streaming requests: no total timeout
- disaggregated prefill: 300s
- disaggregated decode: 600s
- multipart (e.g. audio) requests: 300s

This PR makes them configurable via environment variables, following the existing `LOADAWARE_BETA` env fallback pattern so values can be adjusted on a running deployment without changing the router's command line:

- `ROUTER_PROXY_TIMEOUT_SECONDS` (default: unset / no timeout)
- `ROUTER_PREFILL_TIMEOUT_SECONDS` (default: 300)
- `ROUTER_DECODE_TIMEOUT_SECONDS` (default: 600)
- `ROUTER_MULTIPART_TIMEOUT_SECONDS` (default: 300)

Empty or non-numeric values are ignored with a warning and fall back to the defaults.

## Testing

- Added `src/tests/test_request_timeouts.py` covering default fallback, env override, float values, and empty/non-numeric env values.
- ```bash
  cd src && python -m pytest tests/test_request_timeouts.py -v
  ```

`[Bugfix]` / `[Router]`